### PR TITLE
test: align protected-route E2E with guest self-study policy

### DIFF
--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -20,17 +20,12 @@
 
 ## Active queue
 
-### CLEANUP-013 — Reconcile protected-route E2E drift
+### CLEANUP-006 — Dependency classification
 - **Status:** `ready`
-- **Goal:** Align `e2e/protected-routes.spec.ts` with the intentional guest-route policy in `src/lib/supabase/session.ts` without changing production authentication behavior.
-- **Done when:** The source of truth is explicit, stale protected-route expectations are corrected, public/guest/protected coverage is preserved, and targeted E2E or equivalent route-policy validation passes.
+- **Goal:** Classify every suspected unused or misplaced package before changing `package.json` or the lockfile.
+- **Done when:** Each candidate is checked against imports, configuration, scripts, CLIs, generated tooling, clean install, typecheck, lint, unit tests, production build, and any area-specific validation.
 
 ### CLEANUP-004 — Split UnitTemplate safely
 - **Status:** `blocked`
 - **Blocked by:** Focused lesson behavior coverage plus relevant lesson smoke/E2E validation.
 - **Goal:** Extract types, constants, small components, storage hooks, and completion logic in separate reviewable batches.
-
-### CLEANUP-006 — Dependency classification
-- **Status:** `blocked`
-- **Blocked by:** Repository-wide config/script review and install/build verification for each package group.
-- **Goal:** Classify every suspected unused or misplaced package before changing `package.json` or the lockfile.

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -6,62 +6,59 @@
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-012B — Verify Supabase middleware helper |
+| Task | CLEANUP-013 — Reconcile protected-route E2E drift |
 | Status | done — awaiting stacked PR review |
-| Branch | `agent/cleanup-unused-supabase-middleware` |
-| Goal | Remove the obsolete helper while preserving the active proxy/session authentication boundary |
+| Branch | `agent/cleanup-protected-routes-e2e` |
+| Goal | Align route-policy E2E coverage with intentional guest self-study behavior without changing production authentication |
 
 ## Completed in earlier cleanup batches
 
 - Stopped automatic maintenance-task generation, commits, and direct pushes.
 - Added reproducible codebase inventory and durable cleanup evidence.
-- Removed foundation dead code, the disconnected notification center, legacy exercise components, the old landing outcomes section, unused shared UI, the legacy type barrel, and the retired lesson enrichment fallback.
+- Reduced conservative unreachable source candidates from 17 to 0.
+- Added focused Supabase session regression coverage while removing the obsolete middleware helper.
 
-## Completed in CLEANUP-012B
+## Completed in CLEANUP-013
 
-Removed after full-checkout and behavior-aware verification:
+Updated only:
 
-- `src/lib/supabase/middleware.ts`
+- `e2e/protected-routes.spec.ts`
 
-Added permanent regression coverage:
+Corrections:
 
-- `src/lib/supabase/session.test.ts`
-
-Evidence:
-
-- `createMiddlewareClient` and the old module path had no consumer.
-- `src/proxy.ts` is the only framework convention entry and imports `updateSession` from `src/lib/supabase/session.ts`.
-- `session.ts` owns cookie refresh, missing-environment fallback, public-route bypass, protected-route redirects, authenticated login redirects, and authenticated protected pass-through.
-- Focused tests cover all of those behaviors.
-- No protected-route list, redirect destination, cookie semantics, rate limit, environment variable, dependency, database, or Supabase schema changed.
+- Removed `/dashboard`, `/learn/*`, `/flashcards`, and `/speaking` from protected-route expectations because `session.ts` intentionally allows guest self-study there.
+- Added missing protected-route coverage for `/certificate` and `/checkpoint`.
+- Corrected the invalid A0 slug from `/learn/unit-a01` to `/learn/unit-a0-1`.
+- Added explicit guest-route assertions requiring HTTP 200 and no redirect to `/login`.
+- Strengthened protected redirects to verify `/login`, the original `next` path, and `mode=login`.
+- Kept `src/proxy.ts`, `src/lib/supabase/session.ts`, route policy, cookies, redirects, and production pages unchanged.
 
 ## Validation completed
 
-A full GitHub Actions checkout ran before and after deletion:
+A full GitHub Actions checkout ran against a production Next.js server:
 
 ```bash
 npm ci --ignore-scripts --legacy-peer-deps
-npm run inventory -- --write
-npx vitest run src/lib/supabase/session.test.ts
+npx playwright install --with-deps chromium
 npx tsc --noEmit
 npm run lint
 npm run test
 npm run build
+npm run start
+npx playwright test e2e/protected-routes.spec.ts --project=chromium
 ```
 
-Post-deletion results:
+Results:
 
-- source files scanned: 341 → 340
-- known entry points: 118 → 119
-- unreachable candidates: 1 → 0
-- targeted session tests passed
-- TypeScript passed
-- ESLint passed
-- full unit tests passed
-- production build passed
+- TypeScript passed.
+- ESLint passed.
+- Full unit tests passed.
+- Production build passed.
+- Production server startup passed.
+- All 26 targeted Chromium route, landing, and health-check E2E tests passed.
 
 The temporary validation workflow was removed after the final successful run.
 
 ## Next action
 
-CLEANUP-013 — reconcile `e2e/protected-routes.spec.ts` with the intentional guest-route policy in `session.ts`. Keep that behavior/test correction separate from this dead-code cleanup.
+CLEANUP-006 — classify suspected unused or misplaced dependencies in small, independently validated groups. Do not remove packages from import-only evidence.

--- a/e2e/protected-routes.spec.ts
+++ b/e2e/protected-routes.spec.ts
@@ -1,16 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Protected routes: redirect to /login when unauthenticated.
- * Source of truth: src/lib/supabase/session.ts → protectedRoutes array
- * Keep this list in sync whenever new routes are added to app/(main)/
+ * Authentication routing source of truth:
+ * src/lib/supabase/session.ts → protectedRoutes.
+ *
+ * Guest self-study routes are intentionally excluded from that array.
  */
 const PROTECTED_ROUTES = [
-  "/dashboard",
-  "/learn/unit-1",
-  "/learn/unit-a01",
-  "/flashcards",
-  "/speaking",
   "/progress",
   "/roadmap",
   "/writing",
@@ -21,13 +17,24 @@ const PROTECTED_ROUTES = [
   "/pronunciation",
   "/placement-test",
   "/invite",
+  "/certificate",
   "/settings",
+  "/checkpoint",
   "/quiz",
 ];
 
 /**
- * Public routes: accessible without authentication (return 200).
+ * Representative routes intentionally available to unauthenticated learners.
+ * `/learn` is prefix-based in session.ts, so test both A0 and A1 lesson slugs.
  */
+const GUEST_SELF_STUDY_ROUTES = [
+  "/dashboard",
+  "/learn/unit-a0-1",
+  "/learn/unit-1",
+  "/flashcards",
+  "/speaking",
+];
+
 const PUBLIC_ROUTES = [
   { path: "/", titleMatcher: /AtoEnglish/ },
   { path: "/login", titleMatcher: /AtoEnglish/ },
@@ -35,10 +42,25 @@ const PUBLIC_ROUTES = [
 
 test.describe("Protected Routes — Unauthenticated Redirects", () => {
   for (const route of PROTECTED_ROUTES) {
-    test(`${route} redirects to /login when not logged in`, async ({ page }) => {
+    test(`${route} redirects to /login with return context`, async ({ page }) => {
       await page.goto(route);
-      // Should land at /login (possibly with ?next= param)
-      await expect(page).toHaveURL(/\/login/, { timeout: 8000 });
+
+      const finalUrl = new URL(page.url());
+      expect(finalUrl.pathname).toBe("/login");
+      expect(finalUrl.searchParams.get("next")).toBe(route);
+      expect(finalUrl.searchParams.get("mode")).toBe("login");
+    });
+  }
+});
+
+test.describe("Guest Self-Study Routes — Accessible Without Auth", () => {
+  for (const route of GUEST_SELF_STUDY_ROUTES) {
+    test(`${route} remains accessible without login`, async ({ page }) => {
+      const response = await page.goto(route);
+      const finalUrl = new URL(page.url());
+
+      expect(finalUrl.pathname).not.toBe("/login");
+      expect(response?.status()).toBe(200);
     });
   }
 });
@@ -46,16 +68,14 @@ test.describe("Protected Routes — Unauthenticated Redirects", () => {
 test.describe("Public Routes — Accessible Without Auth", () => {
   for (const { path, titleMatcher } of PUBLIC_ROUTES) {
     test(`${path} loads without auth (200)`, async ({ page }) => {
-      const res = await page.goto(path);
-      // /login is the auth redirect destination — it's expected to be at /login
-      // Other public pages should not redirect to /login
+      const response = await page.goto(path);
+
       if (path !== "/login") {
-        expect(page.url()).not.toMatch(/\/login/);
+        expect(new URL(page.url()).pathname).not.toBe("/login");
       }
-      // Should have a valid AtoEnglish title
+
       await expect(page).toHaveTitle(titleMatcher, { timeout: 8000 });
-      // Status should be OK (200)
-      expect(res?.status()).toBe(200);
+      expect(response?.status()).toBe(200);
     });
   }
 });
@@ -75,8 +95,6 @@ test.describe("Landing Page — Key Elements", () => {
 
   test("has microstats trust bar", async ({ page }) => {
     await page.goto("/");
-    // HeroCTA is a client component — wait for hydration then check stat pills
-    // Text is split across two spans so check both separately
     await expect(page.getByText(/Miễn phí/i).first()).toBeVisible({ timeout: 10000 });
   });
 
@@ -89,10 +107,10 @@ test.describe("Landing Page — Key Elements", () => {
 
 test.describe("API Health Check", () => {
   test("/api/health returns valid JSON status", async ({ request }) => {
-    const res = await request.get("/api/health");
-    // Accept 200 (healthy) or 503 (degraded/no-DB in test env)
-    expect([200, 503]).toContain(res.status());
-    const body = await res.json();
+    const response = await request.get("/api/health");
+    expect([200, 503]).toContain(response.status());
+
+    const body = await response.json();
     expect(body).toHaveProperty("status");
     expect(["ok", "degraded", "error"]).toContain(body.status);
     expect(body).toHaveProperty("timestamp");


### PR DESCRIPTION
## What changed

Aligned `e2e/protected-routes.spec.ts` with the authentication policy implemented in `src/lib/supabase/session.ts`.

Corrections:

- removed intentional guest self-study routes from protected expectations:
  - `/dashboard`
  - `/learn/*`
  - `/flashcards`
  - `/speaking`
- added missing protected-route coverage:
  - `/certificate`
  - `/checkpoint`
- corrected the invalid A0 lesson slug from `/learn/unit-a01` to `/learn/unit-a0-1`
- added explicit guest-route checks requiring HTTP 200 and no `/login` redirect
- strengthened protected-route checks to verify `/login`, the original `next` path, and `mode=login`

## Production impact

Tests and cleanup documentation only.

No change to:

- `src/proxy.ts`
- `src/lib/supabase/session.ts`
- protected-route policy
- guest self-study behavior
- cookies or redirect destinations
- rate limiting
- production pages
- dependencies or lockfile

## Validation

A temporary GitHub Actions workflow ran against a built and started production Next.js server:

```bash
npm ci --ignore-scripts --legacy-peer-deps
npx playwright install --with-deps chromium
npx tsc --noEmit
npm run lint
npm run test
npm run build
npm run start
npx playwright test e2e/protected-routes.spec.ts --project=chromium
```

Results:

- TypeScript: passed
- ESLint: passed
- full unit tests: passed
- production build: passed
- production server startup: passed
- 26 targeted Chromium route, landing, and health-check E2E tests: passed

The final documentation-only run also passed. The temporary workflow was removed afterward.

## Diff scope

Relative to `agent/cleanup-unused-supabase-middleware`:

- 3 files changed
- only one test implementation changed
- no production source file changed

## Stacked base

This PR targets `agent/cleanup-unused-supabase-middleware` and depends on PR #8 → PR #7 → PR #6 → PR #5 → PR #4 → PR #3 → PR #2 → PR #1.