### PR TITLE
test: add lesson production smoke E2E

### DIFF
--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -21,18 +21,17 @@
 ## Active queue
 
 ### CLEANUP-016 — Add lesson smoke/E2E prerequisite
-- **Status:** `ready`
-- **Goal:** Verify a real lesson route on a production Next.js server before extracting stateless presentation helpers.
-- **Done when:** A focused Playwright or smoke flow confirms the lesson renders, section progress remains usable, quick-review reaches Quiz, and the test passes with production build output.
+- **Status:** `done` — awaiting stacked PR review.
+- **Result:** Six Playwright tests now cover guest lesson render, warmup-to-vocabulary navigation, quick-review-to-practice navigation, and section persistence on Desktop Chromium and Mobile Chrome against a production Next.js server.
 
 ### CLEANUP-004B — Extract UnitTemplate stateless helpers
-- **Status:** `blocked`
-- **Blocked by:** CLEANUP-016 lesson smoke/E2E coverage.
-- **Goal:** Extract small stateless presentation helpers in separate reviewable commits without moving orchestration state or behavior-sensitive logic.
+- **Status:** `ready`
+- **Goal:** Extract only small stateless presentation helpers in separate reviewable commits without moving orchestration state or behavior-sensitive logic.
+- **Done when:** Component tests, the six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build all pass.
 
 ### CLEANUP-004C — Extract UnitTemplate progress persistence
 - **Status:** `blocked`
-- **Blocked by:** Additional persistence-focused tests beyond the current restore/clear coverage.
+- **Blocked by:** Additional persistence-focused tests beyond the current restore/clear and smoke coverage.
 - **Goal:** Move lesson-progress localStorage behavior into a dedicated hook without changing storage keys or section semantics.
 
 ### CLEANUP-015 — Review unit action transaction boundaries

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -6,10 +6,10 @@
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-004A — Extract UnitTemplate lesson types and constants |
+| Task | CLEANUP-016 — Add lesson production smoke/E2E prerequisite |
 | Status | done — awaiting stacked PR review |
-| Branch | `agent/unit-template-types-and-constants` |
-| Goal | Move lesson-domain interfaces and section constants out of `UnitTemplate` without changing runtime behavior or breaking existing imports |
+| Branch | `agent/lesson-production-smoke-e2e` |
+| Goal | Lock real guest lesson rendering and section navigation on a production Next.js server before extracting stateless helpers |
 
 ## Completed in earlier cleanup batches
 
@@ -20,60 +20,56 @@
 - Reconciled protected-route E2E coverage with intentional guest self-study behavior.
 - Removed proven dependency waste and classified retained framework/tooling false positives.
 - Added four focused UnitTemplate orchestration tests.
+- Extracted lesson-domain types and exact section constants while preserving existing imports.
 
-## Completed in CLEANUP-004A
+## Completed in CLEANUP-016
 
-Added dedicated modules:
+Added durable Playwright coverage:
 
-- `src/components/learn/lesson-types.ts`
-- `src/components/learn/lesson-sections.ts`
-- `src/components/learn/lesson-sections.test.ts`
+- `e2e/lesson-smoke.spec.ts`
 
-Updated `src/components/learn/UnitTemplate.tsx` to:
+The suite runs against `next start` after a production build and verifies on both Desktop Chromium and Mobile Chrome:
 
-- import lesson-domain interfaces from `lesson-types.ts`
-- import section labels, order, total, and `SectionNumber` from `lesson-sections.ts`
-- re-export every previously public lesson type so existing imports remain compatible
-- keep `UnitTemplateProps` and completion-only state local
+1. A guest can load `/learn/unit-a0-1` with HTTP 200 and reach the warmup section without an auth redirect.
+2. `Bắt đầu học` opens the Vocabulary section and persists section 2 to `lesson-progress-unit-a0-1`.
+3. `Ôn nhanh` opens the Practice section and persists section 4 to the same storage key.
 
-Preserved exactly:
+The tests also verify the visible lesson progressbar for steps 1, 2, and 4 and fail on uncaught browser page errors during the initial render flow.
 
-- section order `[1, 2, 3, 4, 5, 10, 9, 6, 7, 8]`
-- all ten Vietnamese section labels
-- scoring, XP, completion, localStorage, audio, FSRS, lesson content, routing, and rendering behavior
-
-The focused `UnitTemplate` diff is `+47/-213`. The component decreased from 1,348 to 1,182 lines without moving orchestration or behavior-sensitive logic.
+No production source, lesson content, section order, localStorage key, scoring, XP, completion, database action, FSRS behavior, auth policy, route, package, or UI copy changed.
 
 ## Validation completed
 
-A clean committed checkout ran:
+A full GitHub Actions checkout ran:
 
 ```bash
 npm ci --ignore-scripts --legacy-peer-deps
-npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts
+npx playwright install --with-deps chromium
 npm run inventory -- --write
 npx tsc --noEmit
-npx eslint src/components/learn/UnitTemplate.tsx src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-types.ts src/components/learn/lesson-sections.ts src/components/learn/lesson-sections.test.ts
+npx eslint e2e/lesson-smoke.spec.ts
 npm run lint
 npm run test
 npm run test:content-standard
 npm run build
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
 ```
 
 Results:
 
-- 6 targeted tests passed: 4 orchestration tests plus 2 exact constants tests
-- source files scanned: 341 → 344
-- known entry points: 120 → 121
-- unreachable candidates remained 0
-- TypeScript passed across all existing `UnitTemplate` type consumers
+- 6 production-server lesson smoke tests passed in 8.8 seconds
+- 3 flows passed on Desktop Chromium
+- 3 flows passed on Mobile Chrome
+- Next.js 16.2.9 production server became ready in 209 ms
+- source inventory remained 344 files, 121 entry points, and 0 unreachable candidates
+- TypeScript passed
 - focused and full ESLint passed
 - full unit tests passed
 - lesson content-standard tests passed
 - production build passed
 
-The temporary validation workflow was removed after the final successful run.
+The temporary validation workflow was removed after the successful run.
 
 ## Next action
 
-CLEANUP-016 — run or strengthen a production-server lesson smoke/E2E flow before extracting stateless presentation helpers. The smoke coverage must verify a real lesson route renders, the section order remains usable, and quick-review reaches Quiz without changing production logic.
+CLEANUP-004B — extract only small stateless presentation helpers from `UnitTemplate` in a reversible batch. Keep orchestration state, persistence, scoring, completion, server actions, and section rendering branches in place, then rerun component tests, the six production-server lesson smoke tests, and full validation.

--- a/e2e/lesson-smoke.spec.ts
+++ b/e2e/lesson-smoke.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const UNIT_ROUTE = "/learn/unit-a0-1";
+const PROGRESS_KEY = "lesson-progress-unit-a0-1";
+
+async function readSavedSection(page: Page): Promise<number | null> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+
+    try {
+      const parsed = JSON.parse(raw) as { section?: unknown };
+      return typeof parsed.section === "number" ? parsed.section : null;
+    } catch {
+      return null;
+    }
+  }, PROGRESS_KEY);
+}
+
+test.describe("Lesson production smoke", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((key) => window.localStorage.removeItem(key), PROGRESS_KEY);
+  });
+
+  test("guest learner can render the A0 warmup without an auth redirect", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    const response = await page.goto(UNIT_ROUTE);
+
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe(UNIT_ROUTE);
+    await expect(page.getByTestId("lesson-section-warmup")).toBeVisible();
+    await expect(
+      page.getByRole("progressbar", { name: "Tiến độ bài học: bước 1 / 10" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /Ôn nhanh/i })).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("starting the lesson opens vocabulary and persists section 2", async ({ page }) => {
+    await page.goto(UNIT_ROUTE);
+
+    await page.getByRole("button", { name: "Bắt đầu học", exact: true }).click();
+
+    await expect(page.getByRole("heading", { name: "Từ vựng", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("progressbar", { name: "Tiến độ bài học: bước 2 / 10" }),
+    ).toBeVisible();
+    await expect.poll(() => readSavedSection(page)).toBe(2);
+  });
+
+  test("quick review opens practice and persists section 4", async ({ page }) => {
+    await page.goto(UNIT_ROUTE);
+
+    await page.getByRole("button", { name: /Ôn nhanh/i }).click();
+
+    await expect(page.getByRole("heading", { name: "Luyện tập", exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("progressbar", { name: "Tiến độ bài học: bước 4 / 10" }),
+    ).toBeVisible();
+    await expect.poll(() => readSavedSection(page)).toBe(4);
+  });
+});

--- a/reports/codebase-cleanup-inventory.md
+++ b/reports/codebase-cleanup-inventory.md
@@ -133,7 +133,34 @@ Validation results:
 - lesson content-standard tests passed
 - production build passed
 
-Temporary GitHub Actions workflows used for full-checkout verification are removed after their final successful run so they do not consume future Actions minutes.
+### Lesson production smoke/E2E prerequisite
+
+Added durable browser coverage:
+
+- `e2e/lesson-smoke.spec.ts`
+
+The suite runs against `next start` after a production build and verifies:
+
+- guest `/learn/unit-a0-1` returns HTTP 200 and renders the warmup without redirecting to login
+- lesson progress renders at step 1 of 10
+- `Bắt đầu học` opens Vocabulary, renders step 2 of 10, and persists section 2
+- `Ôn nhanh` opens Practice, renders step 4 of 10, and persists section 4
+- the same three flows pass on Desktop Chromium and Mobile Chrome
+
+Validation results:
+
+- 6 Playwright tests passed in 8.8 seconds
+- Next.js 16.2.9 production server became ready in 209 ms
+- source inventory remained 344 files, 121 entry points, and 0 unreachable candidates because the new file is under `e2e/`
+- TypeScript passed
+- focused and full ESLint passed
+- full unit tests passed
+- lesson content-standard tests passed
+- production build passed
+
+No production source, lesson content, section order, localStorage key, scoring, XP, completion, database action, FSRS behavior, auth policy, route, package, or UI copy changed.
+
+Temporary GitHub Actions workflows used for full-checkout verification are removed after their successful run so they do not consume future Actions minutes.
 
 ## Current inventory summary
 
@@ -163,7 +190,7 @@ Safe refactor order:
 
 1. Focused lesson behavior coverage — complete.
 2. Extract lesson types and section constants — complete.
-3. Add production-server lesson smoke/E2E coverage.
+3. Add production-server lesson smoke/E2E coverage — complete.
 4. Extract stateless helper components.
 5. Extract local-storage hooks after persistence-specific coverage.
 6. Extract completion logic after server-action and achievement coverage.
@@ -190,4 +217,4 @@ A source file can be deleted only when all applicable checks pass:
 
 ## Next cleanup work
 
-CLEANUP-016 — run or strengthen a focused lesson smoke/E2E flow against a production Next.js server. Do not extract stateless helpers until a real lesson route, section navigation, and quick-review-to-Quiz flow are covered.
+CLEANUP-004B — extract only small stateless presentation helpers from `UnitTemplate` in a reversible batch. Keep orchestration state, persistence, scoring, completion, server actions, and section rendering branches in place. Rerun component tests, the six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build.


### PR DESCRIPTION
## What changed

Added durable Playwright smoke coverage for the guest lesson route:

- `e2e/lesson-smoke.spec.ts`

The suite runs against a built Next.js production server and covers three core flows on both configured browser projects:

1. `/learn/unit-a0-1` returns HTTP 200, stays out of `/login`, renders warmup, and shows lesson step 1 of 10.
2. `Bắt đầu học` opens Vocabulary, shows step 2 of 10, and persists section 2 to `lesson-progress-unit-a0-1`.
3. `Ôn nhanh` opens Practice, shows step 4 of 10, and persists section 4 to the same storage key.

The initial render flow also fails on uncaught browser page errors.

Updated the cleanup plan, backlog, and inventory to mark CLEANUP-016 complete and unblock CLEANUP-004B.

## Safety

This batch adds test coverage only. It does not modify `UnitTemplate`, lesson sections, lesson content, section order, localStorage keys, completion logic, database actions, auth policy, scoring, XP, FSRS, routes, UI copy, package files, or production configuration.

## Validation

A full GitHub Actions checkout ran:

```bash
npm ci --ignore-scripts --legacy-peer-deps
npx playwright install --with-deps chromium
npm run inventory -- --write
npx tsc --noEmit
npx eslint e2e/lesson-smoke.spec.ts
npm run lint
npm run test
npm run test:content-standard
npm run build
PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
```

Results:

- 6 Playwright tests passed in 8.8 seconds
- 3 flows passed on Desktop Chromium
- 3 flows passed on Mobile Chrome
- Next.js 16.2.9 production server became ready in 209 ms
- source inventory remained 344 files, 121 entry points, and 0 unreachable candidates
- TypeScript passed
- focused and full ESLint passed
- full unit tests passed
- lesson content-standard tests passed
- production build passed

The temporary validation workflow was removed after the successful run.

## Diff scope

Relative to `agent/unit-template-types-and-constants`:

- one durable E2E test file added
- three cleanup/planning documents updated
- no production source or package changes

## Stacked base

This PR targets `agent/unit-template-types-and-constants` and depends on PR #12 → PR #11 → PR #10 → PR #9 → PR #8 → PR #7 → PR #6 → PR #5 → PR #4 → PR #3 → PR #2 → PR #1.