### PR TITLE
refactor: extract UnitTemplate stateless presentation helpers

### DIFF
--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -22,16 +22,20 @@
 
 ### CLEANUP-016 — Add lesson smoke/E2E prerequisite
 - **Status:** `done` — awaiting stacked PR review.
-- **Result:** Six Playwright tests now cover guest lesson render, warmup-to-vocabulary navigation, quick-review-to-practice navigation, and section persistence on Desktop Chromium and Mobile Chrome against a production Next.js server.
+- **Result:** Six Playwright tests cover guest lesson render, warmup-to-vocabulary navigation, quick-review-to-practice navigation, and section persistence on Desktop Chromium and Mobile Chrome against a production server.
 
-### CLEANUP-004B — Extract UnitTemplate stateless helpers
+### CLEANUP-004B — Extract UnitTemplate stateless presentation helpers
+- **Status:** `done` — awaiting stacked PR review.
+- **Result:** Extracted `LessonProgress` and `SessionBreakCard`, added focused component tests, reduced `UnitTemplate` from 1,182 to 1,069 lines, and passed full CI plus six production-server smoke tests.
+
+### CLEANUP-017 — Expand lesson progress persistence coverage
 - **Status:** `ready`
-- **Goal:** Extract only small stateless presentation helpers in separate reviewable commits without moving orchestration state or behavior-sensitive logic.
-- **Done when:** Component tests, the six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build all pass.
+- **Goal:** Add focused tests for malformed saved JSON, invalid section numbers, per-unit storage-key isolation, and final-section cleanup without changing production behavior.
+- **Done when:** New persistence tests, existing UnitTemplate/component tests, six production-server lesson smoke tests, typecheck, lint, full unit tests, content-standard tests, and production build pass.
 
 ### CLEANUP-004C — Extract UnitTemplate progress persistence
 - **Status:** `blocked`
-- **Blocked by:** Additional persistence-focused tests beyond the current restore/clear and smoke coverage.
+- **Blocked by:** CLEANUP-017 persistence-focused test matrix.
 - **Goal:** Move lesson-progress localStorage behavior into a dedicated hook without changing storage keys or section semantics.
 
 ### CLEANUP-015 — Review unit action transaction boundaries

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -6,10 +6,10 @@
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-016 — Add lesson production smoke/E2E prerequisite |
+| Task | CLEANUP-004B — Extract UnitTemplate stateless presentation helpers |
 | Status | done — awaiting stacked PR review |
-| Branch | `agent/lesson-production-smoke-e2e` |
-| Goal | Lock real guest lesson rendering and section navigation on a production Next.js server before extracting stateless helpers |
+| Branch | `agent/unit-template-stateless-presentation` |
+| Goal | Move only the lesson progress and mid-lesson break presentation blocks out of `UnitTemplate` without moving orchestration state or changing behavior |
 
 ## Completed in earlier cleanup batches
 
@@ -19,35 +19,43 @@
 - Added Supabase session regression coverage while removing the obsolete middleware helper.
 - Reconciled protected-route E2E coverage with intentional guest self-study behavior.
 - Removed proven dependency waste and classified retained framework/tooling false positives.
-- Added four focused UnitTemplate orchestration tests.
+- Added focused UnitTemplate orchestration tests.
 - Extracted lesson-domain types and exact section constants while preserving existing imports.
+- Added six production-server lesson smoke tests across desktop and mobile.
 
-## Completed in CLEANUP-016
+## Completed in CLEANUP-004B
 
-Added durable Playwright coverage:
+Added dedicated presentation components:
 
-- `e2e/lesson-smoke.spec.ts`
+- `src/components/learn/lesson-ui/LessonProgress.tsx`
+- `src/components/learn/lesson-ui/SessionBreakCard.tsx`
+- `src/components/learn/lesson-ui/lesson-presentation.test.tsx`
 
-The suite runs against `next start` after a production build and verifies on both Desktop Chromium and Mobile Chrome:
+`UnitTemplate.tsx` now delegates:
 
-1. A guest can load `/learn/unit-a0-1` with HTTP 200 and reach the warmup section without an auth redirect.
-2. `Bắt đầu học` opens the Vocabulary section and persists section 2 to `lesson-progress-unit-a0-1`.
-3. `Ôn nhanh` opens the Practice section and persists section 4 to the same storage key.
+- the exact ten-step non-linear progress display to `LessonProgress`
+- the Practice-to-Dialogue break card to `SessionBreakCard`
 
-The tests also verify the visible lesson progressbar for steps 1, 2, and 4 and fail on uncaught browser page errors during the initial render flow.
+Preserved exactly:
 
-No production source, lesson content, section order, localStorage key, scoring, XP, completion, database action, FSRS behavior, auth policy, route, package, or UI copy changed.
+- progressbar labels and percentages
+- completed/current/upcoming step styling
+- session-break copy, motion props, dashboard link, and continue callback
+- section order, navigation, localStorage, scoring, XP, completion, database actions, FSRS, auth, routes, lesson content, and UI behavior
+
+The focused `UnitTemplate` diff is `+4/-117`. The component decreased from 1,182 to 1,069 lines. Sticky-header interactions, completion overlay, `XpCounter`, video shadowing, orchestration state, and behavior-sensitive functions remain local.
 
 ## Validation completed
 
-A full GitHub Actions checkout ran:
+A clean committed checkout ran:
 
 ```bash
 npm ci --ignore-scripts --legacy-peer-deps
 npx playwright install --with-deps chromium
+npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
 npm run inventory -- --write
 npx tsc --noEmit
-npx eslint e2e/lesson-smoke.spec.ts
+npx eslint <focused files>
 npm run lint
 npm run test
 npm run test:content-standard
@@ -57,19 +65,20 @@ PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.s
 
 Results:
 
-- 6 production-server lesson smoke tests passed in 8.8 seconds
-- 3 flows passed on Desktop Chromium
-- 3 flows passed on Mobile Chrome
-- Next.js 16.2.9 production server became ready in 209 ms
-- source inventory remained 344 files, 121 entry points, and 0 unreachable candidates
+- 8 targeted tests passed: 4 orchestration, 2 exact constants, and 2 presentation-helper tests
+- 6 production-server lesson smoke tests passed on Desktop Chromium and Mobile Chrome
+- source files scanned: 344 → 347
+- known entry points: 121 → 122
+- unreachable candidates remained 0
+- `UnitTemplate.tsx`: 1,182 → 1,069 lines
 - TypeScript passed
 - focused and full ESLint passed
 - full unit tests passed
 - lesson content-standard tests passed
 - production build passed
 
-The temporary validation workflow was removed after the successful run.
+The temporary validation workflow is removed after the final successful documentation run.
 
 ## Next action
 
-CLEANUP-004B — extract only small stateless presentation helpers from `UnitTemplate` in a reversible batch. Keep orchestration state, persistence, scoring, completion, server actions, and section rendering branches in place, then rerun component tests, the six production-server lesson smoke tests, and full validation.
+CLEANUP-017 — add a persistence-focused UnitTemplate test matrix for malformed saved JSON, invalid section numbers, per-unit key isolation, and final-section cleanup before moving localStorage behavior into a hook.

--- a/reports/codebase-cleanup-inventory.md
+++ b/reports/codebase-cleanup-inventory.md
@@ -160,12 +160,49 @@ Validation results:
 
 No production source, lesson content, section order, localStorage key, scoring, XP, completion, database action, FSRS behavior, auth policy, route, package, or UI copy changed.
 
+### UnitTemplate stateless presentation extraction
+
+Added:
+
+- `src/components/learn/lesson-ui/LessonProgress.tsx`
+- `src/components/learn/lesson-ui/SessionBreakCard.tsx`
+- `src/components/learn/lesson-ui/lesson-presentation.test.tsx`
+
+`UnitTemplate.tsx` now delegates the exact ten-step progress display and the mid-lesson session-break card to dedicated components. Both helpers are presentation-only: they receive derived position or callbacks through props and own no lesson orchestration state.
+
+Preserved exactly:
+
+- non-linear section order and progressbar labels
+- progress percentages and completed/current/upcoming visual states
+- session-break copy, motion props, dashboard link, and continue callback
+- section navigation, localStorage behavior, scoring, XP, completion, database actions, FSRS, auth, routes, lesson content, and UI behavior
+
+Focused diff and size results:
+
+- `UnitTemplate.tsx` diff: `+4/-117`
+- `UnitTemplate.tsx` size: 1,182 → 1,069 lines
+- source files scanned: 344 → 347
+- known entry points: 121 → 122
+- unreachable candidates remained 0
+
+Validation results:
+
+- 8 targeted tests passed: 4 orchestration, 2 exact constants, and 2 presentation-helper tests
+- 6 production-server Playwright smoke tests passed on Desktop Chromium and Mobile Chrome
+- TypeScript passed
+- focused and full ESLint passed
+- full unit tests passed
+- lesson content-standard tests passed
+- production build passed
+
+No sticky-header interaction, completion overlay, `XpCounter`, video shadowing, orchestration state, persistence, scoring, completion transaction, server action, or section-rendering branch moved.
+
 Temporary GitHub Actions workflows used for full-checkout verification are removed after their successful run so they do not consume future Actions minutes.
 
 ## Current inventory summary
 
-- Source files scanned: 344
-- Known entry points: 121
+- Source files scanned: 347
+- Known entry points: 122
 - Unreachable candidates: 0
 - Files with at least 500 lines: 32
 - Conservative dependency warnings: 6 runtime/tooling and 1 type package
@@ -184,17 +221,18 @@ This does not mean the repository has no architecture debt. Large active compone
 
 Classification: **active, oversized, high-priority refactor — never delete**
 
-Current generated size: 1,182 lines. It still owns orchestration state, browser persistence, audio, server-action coordination, scoring, completion logic, and celebration UI.
+Current generated size: 1,069 lines. It still owns orchestration state, browser persistence, audio, server-action coordination, scoring, completion logic, celebration UI, and the remaining stateful helper components.
 
 Safe refactor order:
 
 1. Focused lesson behavior coverage — complete.
 2. Extract lesson types and section constants — complete.
 3. Add production-server lesson smoke/E2E coverage — complete.
-4. Extract stateless helper components.
-5. Extract local-storage hooks after persistence-specific coverage.
-6. Extract completion logic after server-action and achievement coverage.
-7. Replace related state groups with a reducer only after each state transition is covered.
+4. Extract first stateless presentation helpers — complete.
+5. Expand persistence-specific coverage.
+6. Extract local-storage hooks only after the persistence test matrix passes.
+7. Extract completion logic after server-action and achievement coverage.
+8. Replace related state groups with a reducer only after each state transition is covered.
 
 ### `src/app/actions/unit.ts`
 
@@ -217,4 +255,4 @@ A source file can be deleted only when all applicable checks pass:
 
 ## Next cleanup work
 
-CLEANUP-004B — extract only small stateless presentation helpers from `UnitTemplate` in a reversible batch. Keep orchestration state, persistence, scoring, completion, server actions, and section rendering branches in place. Rerun component tests, the six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build.
+CLEANUP-017 — expand focused lesson-progress persistence coverage for malformed JSON, invalid section numbers, per-unit key isolation, and final-section cleanup. Do not move localStorage behavior into a hook until this test matrix and the six production-server lesson smoke tests pass.

--- a/src/components/learn/UnitTemplate.tsx
+++ b/src/components/learn/UnitTemplate.tsx
@@ -22,6 +22,8 @@ import SpeakingSection from "./sections/SpeakingSection";
 import QuizSection from "./sections/QuizSection";
 import TranslateSection from "./sections/TranslateSection";
 import FluencySection from "./sections/FluencySection";
+import LessonProgress from "./lesson-ui/LessonProgress";
+import SessionBreakCard from "./lesson-ui/SessionBreakCard";
 import {
   SECTION_LABELS,
   SECTION_ORDER,
@@ -636,8 +638,6 @@ export default function UnitTemplate({ unit, nextRoute = "/dashboard" }: UnitTem
   };
 
   const sectionOrderIdx = SECTION_ORDER.indexOf(section as SectionNumber);
-  const progress = Math.round((sectionOrderIdx / (TOTAL_SECTIONS - 1)) * 100);
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-zinc-950 via-zinc-900 to-emerald-950/20">
       {/* Sticky Header */}
@@ -707,63 +707,7 @@ export default function UnitTemplate({ unit, nextRoute = "/dashboard" }: UnitTem
             </div>
           </div>
 
-          {/* Step dots progress */}
-          <div
-            className="flex items-center gap-0 mt-2"
-            role="progressbar"
-            aria-valuenow={progress}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={`Tiến độ bài học: bước ${sectionOrderIdx + 1} / ${TOTAL_SECTIONS}`}
-          >
-            {SECTION_ORDER.map((secNum, i) => {
-              const isSecCompleted = i < sectionOrderIdx;
-              const isSecCurrent = i === sectionOrderIdx;
-              return (
-                <div key={secNum} className="flex items-center flex-1 min-w-0">
-                  <div
-                    className={`relative flex items-center justify-center rounded-full shrink-0 transition-all duration-300 ${
-                      isSecCurrent
-                        ? "w-7 h-7 bg-emerald-500 ring-2 ring-emerald-400/50 ring-offset-1 ring-offset-zinc-950 shadow-lg shadow-emerald-900/60"
-                        : isSecCompleted
-                        ? "w-5 h-5 bg-emerald-800"
-                        : "w-5 h-5 bg-zinc-800"
-                    }`}
-                  >
-                    {isSecCompleted ? (
-                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                        <path
-                          d="M2 5l2 2 4-4"
-                          stroke="#34d399"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                    ) : (
-                      <span
-                        className={`font-bold tabular-nums leading-none select-none ${
-                          isSecCurrent ? "text-white text-[11px]" : "text-zinc-600 text-[9px]"
-                        }`}
-                      >
-                        {i + 1}
-                      </span>
-                    )}
-                    {isSecCurrent && (
-                      <span className="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping" />
-                    )}
-                  </div>
-                  {i < SECTION_ORDER.length - 1 && (
-                    <div
-                      className={`h-px flex-1 mx-0.5 transition-all duration-500 ${
-                        i < sectionOrderIdx ? "bg-emerald-700" : "bg-zinc-800"
-                      }`}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
+          <LessonProgress sectionOrderIdx={sectionOrderIdx} />
         </div>
       </div>
 
@@ -771,64 +715,7 @@ export default function UnitTemplate({ unit, nextRoute = "/dashboard" }: UnitTem
       <div className="max-w-3xl mx-auto px-4 py-4 sm:py-8 pb-24">
         <AnimatePresence mode="wait">
 
-          {/* ── Session Break Card (between Practice and Dialogue) ── */}
-          {sessionBreak && (
-            <motion.div
-              key="session-break"
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0 }}
-              className="rounded-3xl border border-emerald-500/20 bg-gradient-to-b from-emerald-500/8 to-teal-500/5 p-6 sm:p-8 space-y-6 text-center"
-            >
-              {/* Congrats badge */}
-              <div className="flex size-16 mx-auto items-center justify-center rounded-2xl bg-emerald-500/10 text-3xl">
-                ☕
-              </div>
-              <div>
-                <p className="text-xs font-black text-emerald-500 uppercase tracking-widest mb-1">Phần 1 hoàn thành!</p>
-                <h3 className="text-lg sm:text-xl font-black text-zinc-900 dark:text-zinc-50 leading-tight">
-                  Bạn đã học xong ~15 phút đầu tiên
-                </h3>
-                <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1.5 max-w-sm mx-auto">
-                  Nghỉ ngơi hoặc tiếp tục ngay Phần 2 — Hội thoại, Shadowing, Luyện nói và Hoàn thành.
-                </p>
-              </div>
-
-              {/* Part 1 recap */}
-              <div className="flex flex-wrap justify-center gap-2">
-                {["✅ Khởi động", "✅ Từ vựng", "✅ Ngữ pháp", "✅ Luyện tập"].map((s) => (
-                  <span key={s} className="text-xs font-bold px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400">
-                    {s}
-                  </span>
-                ))}
-              </div>
-              {/* Part 2 preview */}
-              <div className="flex flex-wrap justify-center gap-2">
-                {["⏳ Hội thoại", "⏳ Phản xạ", "⏳ Dịch câu", "⏳ Shadowing", "⏳ Luyện nói", "⏳ Quiz"].map((s) => (
-                  <span key={s} className="text-xs font-bold px-3 py-1.5 rounded-full bg-zinc-100 dark:bg-zinc-800/60 border border-zinc-200/60 dark:border-zinc-700/40 text-zinc-500">
-                    {s}
-                  </span>
-                ))}
-              </div>
-
-              {/* CTAs */}
-              <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                <button
-                  onClick={goNext}
-                  className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-6 py-3 rounded-2xl bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white font-black text-sm shadow-lg shadow-emerald-900/20 transition-all"
-                >
-                  Tiếp tục Phần 2 →
-                </button>
-                <a
-                  href="/dashboard"
-                  className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-6 py-3 rounded-2xl border border-zinc-200/60 dark:border-zinc-700/60 text-zinc-600 dark:text-zinc-400 font-bold text-sm hover:border-zinc-300 dark:hover:border-zinc-600 transition-all"
-                >
-                  💾 Lưu và nghỉ ngơi
-                </a>
-              </div>
-              <p className="text-[11px] text-zinc-400">Tiến độ tự động được lưu — quay lại lúc nào cũng được</p>
-            </motion.div>
-          )}
+          {sessionBreak && <SessionBreakCard onContinue={goNext} />}
 
           {section === 1 && !sessionBreak && (
             <WarmupSection

--- a/src/components/learn/lesson-ui/LessonProgress.tsx
+++ b/src/components/learn/lesson-ui/LessonProgress.tsx
@@ -1,0 +1,71 @@
+import { SECTION_ORDER, TOTAL_SECTIONS } from "../lesson-sections";
+
+interface LessonProgressProps {
+  sectionOrderIdx: number;
+}
+
+export default function LessonProgress({ sectionOrderIdx }: LessonProgressProps) {
+  const progress = Math.round((sectionOrderIdx / (TOTAL_SECTIONS - 1)) * 100);
+
+  return (
+    <div
+      className="flex items-center gap-0 mt-2"
+      role="progressbar"
+      aria-valuenow={progress}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={`Tiến độ bài học: bước ${sectionOrderIdx + 1} / ${TOTAL_SECTIONS}`}
+    >
+      {SECTION_ORDER.map((secNum, index) => {
+        const isSectionCompleted = index < sectionOrderIdx;
+        const isSectionCurrent = index === sectionOrderIdx;
+
+        return (
+          <div key={secNum} className="flex items-center flex-1 min-w-0">
+            <div
+              className={`relative flex items-center justify-center rounded-full shrink-0 transition-all duration-300 ${
+                isSectionCurrent
+                  ? "w-7 h-7 bg-emerald-500 ring-2 ring-emerald-400/50 ring-offset-1 ring-offset-zinc-950 shadow-lg shadow-emerald-900/60"
+                  : isSectionCompleted
+                    ? "w-5 h-5 bg-emerald-800"
+                    : "w-5 h-5 bg-zinc-800"
+              }`}
+            >
+              {isSectionCompleted ? (
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                  <path
+                    d="M2 5l2 2 4-4"
+                    stroke="#34d399"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              ) : (
+                <span
+                  className={`font-bold tabular-nums leading-none select-none ${
+                    isSectionCurrent
+                      ? "text-white text-[11px]"
+                      : "text-zinc-600 text-[9px]"
+                  }`}
+                >
+                  {index + 1}
+                </span>
+              )}
+              {isSectionCurrent && (
+                <span className="absolute inset-0 rounded-full bg-emerald-400/20 animate-ping" />
+              )}
+            </div>
+            {index < SECTION_ORDER.length - 1 && (
+              <div
+                className={`h-px flex-1 mx-0.5 transition-all duration-500 ${
+                  index < sectionOrderIdx ? "bg-emerald-700" : "bg-zinc-800"
+                }`}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/learn/lesson-ui/SessionBreakCard.tsx
+++ b/src/components/learn/lesson-ui/SessionBreakCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface SessionBreakCardProps {
+  onContinue: () => void;
+}
+
+const COMPLETED_SECTIONS = [
+  "✅ Khởi động",
+  "✅ Từ vựng",
+  "✅ Ngữ pháp",
+  "✅ Luyện tập",
+];
+
+const UPCOMING_SECTIONS = [
+  "⏳ Hội thoại",
+  "⏳ Phản xạ",
+  "⏳ Dịch câu",
+  "⏳ Shadowing",
+  "⏳ Luyện nói",
+  "⏳ Quiz",
+];
+
+export default function SessionBreakCard({ onContinue }: SessionBreakCardProps) {
+  return (
+    <motion.div
+      key="session-break"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0 }}
+      className="rounded-3xl border border-emerald-500/20 bg-gradient-to-b from-emerald-500/8 to-teal-500/5 p-6 sm:p-8 space-y-6 text-center"
+    >
+      <div className="flex size-16 mx-auto items-center justify-center rounded-2xl bg-emerald-500/10 text-3xl">
+        ☕
+      </div>
+      <div>
+        <p className="text-xs font-black text-emerald-500 uppercase tracking-widest mb-1">
+          Phần 1 hoàn thành!
+        </p>
+        <h3 className="text-lg sm:text-xl font-black text-zinc-900 dark:text-zinc-50 leading-tight">
+          Bạn đã học xong ~15 phút đầu tiên
+        </h3>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1.5 max-w-sm mx-auto">
+          Nghỉ ngơi hoặc tiếp tục ngay Phần 2 — Hội thoại, Shadowing, Luyện nói và Hoàn thành.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {COMPLETED_SECTIONS.map((section) => (
+          <span
+            key={section}
+            className="text-xs font-bold px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400"
+          >
+            {section}
+          </span>
+        ))}
+      </div>
+      <div className="flex flex-wrap justify-center gap-2">
+        {UPCOMING_SECTIONS.map((section) => (
+          <span
+            key={section}
+            className="text-xs font-bold px-3 py-1.5 rounded-full bg-zinc-100 dark:bg-zinc-800/60 border border-zinc-200/60 dark:border-zinc-700/40 text-zinc-500"
+          >
+            {section}
+          </span>
+        ))}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 justify-center">
+        <button
+          onClick={onContinue}
+          className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-6 py-3 rounded-2xl bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white font-black text-sm shadow-lg shadow-emerald-900/20 transition-all"
+        >
+          Tiếp tục Phần 2 →
+        </button>
+        <a
+          href="/dashboard"
+          className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-6 py-3 rounded-2xl border border-zinc-200/60 dark:border-zinc-700/60 text-zinc-600 dark:text-zinc-400 font-bold text-sm hover:border-zinc-300 dark:hover:border-zinc-600 transition-all"
+        >
+          💾 Lưu và nghỉ ngơi
+        </a>
+      </div>
+      <p className="text-[11px] text-zinc-400">
+        Tiến độ tự động được lưu — quay lại lúc nào cũng được
+      </p>
+    </motion.div>
+  );
+}

--- a/src/components/learn/lesson-ui/lesson-presentation.test.tsx
+++ b/src/components/learn/lesson-ui/lesson-presentation.test.tsx
@@ -1,0 +1,70 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import LessonProgress from "./LessonProgress";
+import SessionBreakCard from "./SessionBreakCard";
+
+vi.mock("framer-motion", async () => {
+  const React = await import("react");
+  const MotionDiv = ({ initial, animate, exit, transition, ...props }: Record<string, unknown>) => {
+    void initial;
+    void animate;
+    void exit;
+    void transition;
+    return React.createElement("div", props);
+  };
+
+  return { motion: { div: MotionDiv } };
+});
+
+describe("lesson presentation helpers", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(ui: ReactNode) {
+    await act(async () => root.render(ui));
+  }
+
+  it("renders the exact non-linear lesson progress position", async () => {
+    await render(<LessonProgress sectionOrderIdx={3} />);
+
+    const progress = container.querySelector('[role="progressbar"]');
+    expect(progress?.getAttribute("aria-label")).toBe(
+      "Tiến độ bài học: bước 4 / 10",
+    );
+    expect(progress?.getAttribute("aria-valuenow")).toBe("33");
+    expect(progress?.querySelectorAll("svg")).toHaveLength(3);
+  });
+
+  it("preserves the session break copy, rest link, and continue callback", async () => {
+    const onContinue = vi.fn();
+    await render(<SessionBreakCard onContinue={onContinue} />);
+
+    expect(container.textContent).toContain("Phần 1 hoàn thành!");
+    expect(container.textContent).toContain("Tiếp tục Phần 2 →");
+    expect(container.querySelector('a[href="/dashboard"]')?.textContent).toContain(
+      "Lưu và nghỉ ngơi",
+    );
+
+    const continueButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Tiếp tục Phần 2"),
+    );
+    expect(continueButton).toBeDefined();
+
+    await act(async () => {
+      continueButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed

Extracted two presentation-only blocks from `src/components/learn/UnitTemplate.tsx`:

- lesson step progress → `src/components/learn/lesson-ui/LessonProgress.tsx`
- Practice-to-Dialogue break card → `src/components/learn/lesson-ui/SessionBreakCard.tsx`

Added focused coverage:

- `src/components/learn/lesson-ui/lesson-presentation.test.tsx`

`UnitTemplate` now passes only the derived section index to `LessonProgress` and the existing `goNext` callback to `SessionBreakCard`.

## Preserved behavior

The extraction keeps exactly:

- non-linear section order `[1, 2, 3, 4, 5, 10, 9, 6, 7, 8]`
- progressbar labels, values, step dots, and completed/current/upcoming styling
- all session-break copy, motion props, dashboard link, and continue callback
- section navigation and rendering branches
- localStorage keys and persistence behavior
- scoring, XP, completion, server actions, database behavior, FSRS, audio, auth, routes, curriculum, and UI behavior

Sticky-header interactions, the completion overlay, `XpCounter`, video shadowing, orchestration state, and behavior-sensitive functions remain inside `UnitTemplate`.

## Focused diff

Relative to `agent/lesson-production-smoke-e2e`:

- `UnitTemplate.tsx`: `+4/-117`
- component size: 1,182 → 1,069 lines
- two presentation components added
- one focused test file added
- three cleanup/planning documents updated
- no package or lockfile change

## Validation

A clean committed checkout ran:

```bash
npm ci --ignore-scripts --legacy-peer-deps
npx playwright install --with-deps chromium
npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
npm run inventory -- --write
npx tsc --noEmit
npx eslint <focused files>
npm run lint
npm run test
npm run test:content-standard
npm run build
PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
```

Results:

- 8 targeted tests passed: 4 UnitTemplate orchestration tests, 2 exact section-constant tests, and 2 presentation-helper tests
- 6 production-server lesson smoke tests passed on Desktop Chromium and Mobile Chrome
- source files scanned: 344 → 347
- known entry points: 121 → 122
- unreachable candidates remained 0
- TypeScript passed
- focused and full ESLint passed
- full unit tests passed
- lesson content-standard tests passed
- production build passed

The final documentation commit was validated by the same read-only gate. The temporary workflow was removed afterward.

## Diff scope

Final diff contains only:

- `src/components/learn/UnitTemplate.tsx`
- `src/components/learn/lesson-ui/LessonProgress.tsx`
- `src/components/learn/lesson-ui/SessionBreakCard.tsx`
- `src/components/learn/lesson-ui/lesson-presentation.test.tsx`
- `AGENT_PLAN.md`
- `AGENT_BACKLOG.md`
- `reports/codebase-cleanup-inventory.md`

## Stacked base

This PR targets `agent/lesson-production-smoke-e2e` and depends on PR #13 → PR #12 → PR #11 → PR #10 → PR #9 → PR #8 → PR #7 → PR #6 → PR #5 → PR #4 → PR #3 → PR #2 → PR #1.