### PR TITLE
test: expand UnitTemplate persistence coverage

### DIFF
--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -20,23 +20,18 @@
 
 ## Active queue
 
-### CLEANUP-016 — Add lesson smoke/E2E prerequisite
-- **Status:** `done` — awaiting stacked PR review.
-- **Result:** Six Playwright tests cover guest lesson render, warmup-to-vocabulary navigation, quick-review-to-practice navigation, and section persistence on Desktop Chromium and Mobile Chrome against a production server.
-
 ### CLEANUP-004B — Extract UnitTemplate stateless presentation helpers
 - **Status:** `done` — awaiting stacked PR review.
-- **Result:** Extracted `LessonProgress` and `SessionBreakCard`, added focused component tests, reduced `UnitTemplate` from 1,182 to 1,069 lines, and passed full CI plus six production-server smoke tests.
+- **Result:** Extracted `LessonProgress` and `SessionBreakCard`, reduced `UnitTemplate` to 1,069 lines, and passed full CI plus production-server smoke coverage.
 
 ### CLEANUP-017 — Expand lesson progress persistence coverage
-- **Status:** `ready`
-- **Goal:** Add focused tests for malformed saved JSON, invalid section numbers, per-unit storage-key isolation, and final-section cleanup without changing production behavior.
-- **Done when:** New persistence tests, existing UnitTemplate/component tests, six production-server lesson smoke tests, typecheck, lint, full unit tests, content-standard tests, and production build pass.
+- **Status:** `done` — awaiting stacked PR review.
+- **Result:** Added seven persistence-focused cases for malformed JSON, non-restorable sections, per-unit key isolation, and final-section cleanup without changing production behavior.
 
 ### CLEANUP-004C — Extract UnitTemplate progress persistence
-- **Status:** `blocked`
-- **Blocked by:** CLEANUP-017 persistence-focused test matrix.
-- **Goal:** Move lesson-progress localStorage behavior into a dedicated hook without changing storage keys or section semantics.
+- **Status:** `ready`
+- **Goal:** Move lesson progress restore/save/remove behavior into a dedicated hook without changing `lesson-progress-<unitId>` keys or section semantics.
+- **Done when:** The 15 targeted tests, six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build pass with a focused reversible diff.
 
 ### CLEANUP-015 — Review unit action transaction boundaries
 - **Status:** `blocked`

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -6,10 +6,10 @@
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-004B — Extract UnitTemplate stateless presentation helpers |
+| Task | CLEANUP-017 — Expand lesson progress persistence coverage |
 | Status | done — awaiting stacked PR review |
-| Branch | `agent/unit-template-stateless-presentation` |
-| Goal | Move only the lesson progress and mid-lesson break presentation blocks out of `UnitTemplate` without moving orchestration state or changing behavior |
+| Branch | `agent/unit-template-persistence-tests` |
+| Goal | Lock malformed, non-restorable, per-unit, and final-section localStorage behavior before extracting lesson progress persistence into a hook |
 
 ## Completed in earlier cleanup batches
 
@@ -22,32 +22,23 @@
 - Added focused UnitTemplate orchestration tests.
 - Extracted lesson-domain types and exact section constants while preserving existing imports.
 - Added six production-server lesson smoke tests across desktop and mobile.
+- Extracted `LessonProgress` and `SessionBreakCard` without moving orchestration state.
 
-## Completed in CLEANUP-004B
+## Completed in CLEANUP-017
 
-Added dedicated presentation components:
+Expanded `src/components/learn/UnitTemplate.test.tsx` with seven persistence-focused cases covering:
 
-- `src/components/learn/lesson-ui/LessonProgress.tsx`
-- `src/components/learn/lesson-ui/SessionBreakCard.tsx`
-- `src/components/learn/lesson-ui/lesson-presentation.test.tsx`
+- malformed saved JSON stays non-fatal and leaves the lesson at Warmup
+- non-restorable saved sections `0`, `1`, `10`, and `11` are ignored
+- reads and writes use the current unit's `lesson-progress-<unitId>` key only
+- reaching the final Quiz removes only the current unit's progress key
+- unrelated unit progress remains untouched throughout navigation and cleanup
 
-`UnitTemplate.tsx` now delegates:
-
-- the exact ten-step non-linear progress display to `LessonProgress`
-- the Practice-to-Dialogue break card to `SessionBreakCard`
-
-Preserved exactly:
-
-- progressbar labels and percentages
-- completed/current/upcoming step styling
-- session-break copy, motion props, dashboard link, and continue callback
-- section order, navigation, localStorage, scoring, XP, completion, database actions, FSRS, auth, routes, lesson content, and UI behavior
-
-The focused `UnitTemplate` diff is `+4/-117`. The component decreased from 1,182 to 1,069 lines. Sticky-header interactions, completion overlay, `XpCounter`, video shadowing, orchestration state, and behavior-sensitive functions remain local.
+No production source, localStorage key, section order, navigation, scoring, XP, completion, database action, FSRS behavior, auth, route, lesson content, package, or UI copy changed.
 
 ## Validation completed
 
-A clean committed checkout ran:
+A clean GitHub Actions checkout ran:
 
 ```bash
 npm ci --ignore-scripts --legacy-peer-deps
@@ -55,7 +46,7 @@ npx playwright install --with-deps chromium
 npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
 npm run inventory -- --write
 npx tsc --noEmit
-npx eslint <focused files>
+npx eslint <focused test and lesson files>
 npm run lint
 npm run test
 npm run test:content-standard
@@ -63,22 +54,15 @@ npm run build
 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
 ```
 
-Results:
+Expected final results:
 
-- 8 targeted tests passed: 4 orchestration, 2 exact constants, and 2 presentation-helper tests
-- 6 production-server lesson smoke tests passed on Desktop Chromium and Mobile Chrome
-- source files scanned: 344 → 347
-- known entry points: 121 → 122
-- unreachable candidates remained 0
-- `UnitTemplate.tsx`: 1,182 → 1,069 lines
-- TypeScript passed
-- focused and full ESLint passed
-- full unit tests passed
-- lesson content-standard tests passed
-- production build passed
+- 15 targeted tests: 11 UnitTemplate behavior/persistence, 2 exact constants, and 2 presentation-helper tests
+- 6 production-server lesson smoke tests on Desktop Chromium and Mobile Chrome
+- source inventory remains 347 files, 122 entry points, and 0 unreachable candidates
+- TypeScript, focused/full ESLint, full unit tests, content-standard tests, and production build pass
 
-The temporary validation workflow is removed after the final successful documentation run.
+The temporary validation workflow is removed after the final successful clean-state run.
 
 ## Next action
 
-CLEANUP-017 — add a persistence-focused UnitTemplate test matrix for malformed saved JSON, invalid section numbers, per-unit key isolation, and final-section cleanup before moving localStorage behavior into a hook.
+CLEANUP-004C — extract lesson progress restore/save/remove behavior into a dedicated hook while preserving the exact storage key and section semantics now covered by tests.

--- a/reports/codebase-cleanup-inventory.md
+++ b/reports/codebase-cleanup-inventory.md
@@ -197,6 +197,29 @@ Validation results:
 
 No sticky-header interaction, completion overlay, `XpCounter`, video shadowing, orchestration state, persistence, scoring, completion transaction, server action, or section-rendering branch moved.
 
+### UnitTemplate progress persistence test matrix
+
+Expanded `src/components/learn/UnitTemplate.test.tsx` with seven focused cases that lock the existing browser persistence boundary:
+
+- malformed JSON is ignored without crashing or leaving Warmup
+- saved sections `0`, `1`, `10`, and `11` are not restored
+- progress reads and writes are isolated by `lesson-progress-<unitId>`
+- entering the final Quiz removes the current unit key only
+- progress belonging to another unit remains unchanged
+
+Validation results:
+
+- 15 targeted tests passed: 11 UnitTemplate behavior/persistence tests, 2 exact constants tests, and 2 presentation-helper tests
+- 6 production-server Playwright smoke tests passed on Desktop Chromium and Mobile Chrome
+- source inventory remained 347 files, 122 entry points, and 0 unreachable candidates
+- TypeScript passed
+- focused and full ESLint passed
+- full unit tests passed
+- lesson content-standard tests passed
+- production build passed
+
+This batch changes tests and cleanup documentation only. `UnitTemplate.tsx`, its localStorage effects, section order, routes, scoring, XP, completion, server actions, database behavior, FSRS, auth, lesson content, packages, and UI remain unchanged.
+
 Temporary GitHub Actions workflows used for full-checkout verification are removed after their successful run so they do not consume future Actions minutes.
 
 ## Current inventory summary
@@ -229,8 +252,8 @@ Safe refactor order:
 2. Extract lesson types and section constants — complete.
 3. Add production-server lesson smoke/E2E coverage — complete.
 4. Extract first stateless presentation helpers — complete.
-5. Expand persistence-specific coverage.
-6. Extract local-storage hooks only after the persistence test matrix passes.
+5. Expand persistence-specific coverage — complete.
+6. Extract local-storage hooks with the persistence test matrix as a required gate.
 7. Extract completion logic after server-action and achievement coverage.
 8. Replace related state groups with a reducer only after each state transition is covered.
 
@@ -255,4 +278,4 @@ A source file can be deleted only when all applicable checks pass:
 
 ## Next cleanup work
 
-CLEANUP-017 — expand focused lesson-progress persistence coverage for malformed JSON, invalid section numbers, per-unit key isolation, and final-section cleanup. Do not move localStorage behavior into a hook until this test matrix and the six production-server lesson smoke tests pass.
+CLEANUP-004C — extract lesson progress restore/save/remove behavior into a dedicated hook. Preserve the exact `lesson-progress-<unitId>` key, section semantics, and per-unit cleanup behavior covered by the 15 targeted tests and six production-server smoke tests.

--- a/src/components/learn/UnitTemplate.test.tsx
+++ b/src/components/learn/UnitTemplate.test.tsx
@@ -345,4 +345,69 @@ describe("UnitTemplate behavior foundation", () => {
     expect(container.textContent).toContain("Xuất sắc! 🏆");
     expect(container.querySelector('a[href="/learn/next-unit"]')).not.toBeNull();
   });
+
+it("ignores malformed saved progress without leaving the warmup", async () => {
+  const key = "lesson-progress-unit-test";
+  localStorage.setItem(key, "{broken-json");
+
+  await renderUnit();
+
+  expect(container.querySelector('[data-testid="section-warmup"]')).not.toBeNull();
+  expect(container.querySelector('[role="progressbar"]')).toHaveAttribute(
+    "aria-label",
+    "Tiến độ bài học: bước 1 / 10",
+  );
+  expect(localStorage.getItem(key)).toBe("{broken-json");
+});
+
+it.each([0, 1, 10, 11])(
+  "ignores non-restorable saved section %s",
+  async (savedSection) => {
+    const key = "lesson-progress-unit-test";
+    localStorage.setItem(key, JSON.stringify({ section: savedSection }));
+
+    await renderUnit();
+
+    expect(container.querySelector('[data-testid="section-warmup"]')).not.toBeNull();
+    expect(container.querySelector('[role="progressbar"]')).toHaveAttribute(
+      "aria-label",
+      "Tiến độ bài học: bước 1 / 10",
+    );
+    expect(JSON.parse(localStorage.getItem(key) ?? "null")).toEqual({
+      section: savedSection,
+    });
+  },
+);
+
+it("isolates progress reads and writes by unit id", async () => {
+  const currentKey = "lesson-progress-unit-test";
+  const otherKey = "lesson-progress-unit-other";
+  localStorage.setItem(otherKey, JSON.stringify({ section: 9 }));
+
+  await renderUnit();
+
+  expect(container.querySelector('[data-testid="section-warmup"]')).not.toBeNull();
+  await click(container.querySelector('[data-testid="section-warmup"]') as HTMLButtonElement);
+
+  expect(container.querySelector('[data-testid="section-vocab"]')).not.toBeNull();
+  expect(JSON.parse(localStorage.getItem(currentKey) ?? "null")).toEqual({ section: 2 });
+  expect(JSON.parse(localStorage.getItem(otherKey) ?? "null")).toEqual({ section: 9 });
+});
+
+it("removes only the current unit progress key on the final section", async () => {
+  const currentKey = "lesson-progress-unit-test";
+  const otherKey = "lesson-progress-unit-other";
+  localStorage.setItem(currentKey, JSON.stringify({ section: 7 }));
+  localStorage.setItem(otherKey, JSON.stringify({ section: 4 }));
+
+  await renderUnit();
+
+  expect(container.querySelector('[data-testid="section-speaking"]')).not.toBeNull();
+  await click(container.querySelector('[data-testid="section-speaking"]') as HTMLButtonElement);
+
+  expect(container.querySelector('[data-testid="section-quiz"]')).not.toBeNull();
+  expect(localStorage.getItem(currentKey)).toBeNull();
+  expect(JSON.parse(localStorage.getItem(otherKey) ?? "null")).toEqual({ section: 4 });
+});
+
 });


### PR DESCRIPTION
## What changed

Expanded `src/components/learn/UnitTemplate.test.tsx` with seven persistence-focused cases before moving lesson progress localStorage behavior into a hook.

The new coverage verifies:

- malformed saved JSON is non-fatal and leaves the lesson at Warmup
- saved sections `0`, `1`, `10`, and `11` are not restored
- progress reads and writes use only the current `lesson-progress-<unitId>` key
- entering the final Quiz removes only the current unit progress key
- progress belonging to another unit remains untouched

Updated the cleanup plan, backlog, and inventory to mark CLEANUP-017 complete and open CLEANUP-004C.

## Safety

This batch changes tests and cleanup documentation only. It does not modify:

- `UnitTemplate.tsx`
- localStorage effects or keys
- section order or navigation
- scoring, XP, completion, server actions, database behavior, or FSRS
- auth, routes, lesson content, UI, package files, or lockfile

## Validation

A full GitHub Actions checkout ran twice, including a final read-only run on the committed state:

```bash
npm ci --ignore-scripts --legacy-peer-deps
npx playwright install --with-deps chromium
npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
npm run inventory -- --write
npx tsc --noEmit
npx eslint <focused test and lesson files>
npm run lint
npm run test
npm run test:content-standard
npm run build
PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
```

Results:

- 15 targeted tests passed: 11 UnitTemplate behavior/persistence tests, 2 exact constants tests, and 2 presentation-helper tests
- 6 production-server lesson smoke tests passed on Desktop Chromium and Mobile Chrome
- source inventory remained 347 files, 122 entry points, and 0 unreachable candidates
- TypeScript passed
- focused and full ESLint passed
- full unit tests passed
- lesson content-standard tests passed
- production build passed

The temporary workflow was removed after the successful read-only run.

## Final diff

Relative to `agent/unit-template-stateless-presentation`, only these files change:

- `src/components/learn/UnitTemplate.test.tsx`
- `AGENT_PLAN.md`
- `AGENT_BACKLOG.md`
- `reports/codebase-cleanup-inventory.md`

## Stacked base

This PR targets `agent/unit-template-stateless-presentation` and depends on PR #14 → PR #13 → PR #12 → PR #11 → PR #10 → PR #9 → PR #8 → PR #7 → PR #6 → PR #5 → PR #4 → PR #3 → PR #2 → PR #1.