### PR TITLE
refactor: extract UnitTemplate progress persistence hook

### DIFF
--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -20,20 +20,20 @@
 
 ## Active queue
 
-### CLEANUP-004B — Extract UnitTemplate stateless presentation helpers
-- **Status:** `done` — awaiting stacked PR review.
-- **Result:** Extracted `LessonProgress` and `SessionBreakCard`, reduced `UnitTemplate` to 1,069 lines, and passed full CI plus production-server smoke coverage.
-
 ### CLEANUP-017 — Expand lesson progress persistence coverage
 - **Status:** `done` — awaiting stacked PR review.
-- **Result:** Added seven persistence-focused cases for malformed JSON, non-restorable sections, per-unit key isolation, and final-section cleanup without changing production behavior.
+- **Result:** Added seven persistence-focused cases for malformed JSON, non-restorable sections, per-unit key isolation, and final-section cleanup.
 
 ### CLEANUP-004C — Extract UnitTemplate progress persistence
+- **Status:** `done` — awaiting stacked PR review.
+- **Result:** Moved restore/save/remove behavior into `useLessonProgress` while preserving the exact storage key and section semantics covered by the 15 targeted tests.
+
+### CLEANUP-018 — Expand UnitTemplate completion-flow coverage
 - **Status:** `ready`
-- **Goal:** Move lesson progress restore/save/remove behavior into a dedicated hook without changing `lesson-progress-<unitId>` keys or section semantics.
-- **Done when:** The 15 targeted tests, six production-server lesson smoke tests, typecheck, focused/full lint, full unit tests, content-standard tests, and production build pass with a focused reversible diff.
+- **Goal:** Add focused tests around completion success/failure, star and XP derivation, guest fallback, achievement/streak coordination, and next-route behavior before moving completion logic.
+- **Done when:** New completion tests, existing lesson tests, six production-server smoke tests, typecheck, lint, full unit tests, content-standard tests, and production build pass without production behavior changes.
 
 ### CLEANUP-015 — Review unit action transaction boundaries
 - **Status:** `blocked`
-- **Blocked by:** Focused tests for completion, XP, achievements, vocabulary seeding, streaks, and cache revalidation.
+- **Blocked by:** CLEANUP-018 completion-flow coverage and focused server-action transaction tests.
 - **Goal:** Classify responsibilities in `src/app/actions/unit.ts` before any structural split.

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -6,39 +6,48 @@
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-017 — Expand lesson progress persistence coverage |
+| Task | CLEANUP-004C — Extract UnitTemplate progress persistence |
 | Status | done — awaiting stacked PR review |
-| Branch | `agent/unit-template-persistence-tests` |
-| Goal | Lock malformed, non-restorable, per-unit, and final-section localStorage behavior before extracting lesson progress persistence into a hook |
+| Branch | `agent/unit-template-progress-persistence-hook` |
+| Goal | Move lesson progress restore/save/remove behavior into a dedicated hook without changing storage keys or section semantics |
 
 ## Completed in earlier cleanup batches
 
-- Stopped automatic maintenance-task generation, commits, and direct pushes.
-- Added reproducible source and dependency inventory plus durable cleanup evidence.
 - Reduced conservative unreachable source candidates from 17 to 0.
-- Added Supabase session regression coverage while removing the obsolete middleware helper.
-- Reconciled protected-route E2E coverage with intentional guest self-study behavior.
-- Removed proven dependency waste and classified retained framework/tooling false positives.
-- Added focused UnitTemplate orchestration tests.
-- Extracted lesson-domain types and exact section constants while preserving existing imports.
+- Added Supabase session regression coverage and reconciled protected-route E2E.
+- Removed proven dependency waste and classified retained framework/tooling dependencies.
+- Added focused UnitTemplate orchestration and persistence tests.
+- Extracted lesson-domain types, section constants, and presentation-only helpers.
 - Added six production-server lesson smoke tests across desktop and mobile.
-- Extracted `LessonProgress` and `SessionBreakCard` without moving orchestration state.
 
-## Completed in CLEANUP-017
+## Completed in CLEANUP-004C
 
-Expanded `src/components/learn/UnitTemplate.test.tsx` with seven persistence-focused cases covering:
+Added:
 
-- malformed saved JSON stays non-fatal and leaves the lesson at Warmup
-- non-restorable saved sections `0`, `1`, `10`, and `11` are ignored
-- reads and writes use the current unit's `lesson-progress-<unitId>` key only
-- reaching the final Quiz removes only the current unit's progress key
-- unrelated unit progress remains untouched throughout navigation and cleanup
+- `src/components/learn/hooks/useLessonProgress.ts`
 
-No production source, localStorage key, section order, navigation, scoring, XP, completion, database action, FSRS behavior, auth, route, lesson content, package, or UI copy changed.
+`UnitTemplate.tsx` now delegates browser lesson-progress persistence to `useLessonProgress` while keeping section state and all orchestration in the component.
+
+Preserved exactly:
+
+- storage key `lesson-progress-<unitId>`
+- malformed JSON remains non-fatal
+- saved sections restore only when `savedSection > 1 && savedSection < 10`
+- section `10` remains intentionally non-restorable
+- the first section writes nothing
+- intermediate sections write `{ section }` JSON
+- entering the final Quiz removes only the current unit key
+- progress belonging to other units remains untouched
+
+The warmup-card, completion-status, and guest-completion effect remains inside `UnitTemplate`. No scoring, XP, completion transaction, database action, FSRS, auth, route, lesson content, package, or UI behavior changed.
+
+Focused size result:
+
+- `UnitTemplate.tsx`: 1,069 → 1054 lines
 
 ## Validation completed
 
-A clean GitHub Actions checkout ran:
+A clean committed checkout ran:
 
 ```bash
 npm ci --ignore-scripts --legacy-peer-deps
@@ -46,7 +55,7 @@ npx playwright install --with-deps chromium
 npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
 npm run inventory -- --write
 npx tsc --noEmit
-npx eslint <focused test and lesson files>
+npx eslint <focused hook and lesson files>
 npm run lint
 npm run test
 npm run test:content-standard
@@ -56,13 +65,13 @@ PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.s
 
 Expected final results:
 
-- 15 targeted tests: 11 UnitTemplate behavior/persistence, 2 exact constants, and 2 presentation-helper tests
-- 6 production-server lesson smoke tests on Desktop Chromium and Mobile Chrome
-- source inventory remains 347 files, 122 entry points, and 0 unreachable candidates
+- 15 targeted tests pass
+- 6 production-server lesson smoke tests pass on Desktop Chromium and Mobile Chrome
+- source inventory becomes 348 files, 122 entry points, and 0 unreachable candidates
 - TypeScript, focused/full ESLint, full unit tests, content-standard tests, and production build pass
 
 The temporary validation workflow is removed after the final successful clean-state run.
 
 ## Next action
 
-CLEANUP-004C — extract lesson progress restore/save/remove behavior into a dedicated hook while preserving the exact storage key and section semantics now covered by tests.
+CLEANUP-018 — add focused completion-flow regression coverage before moving completion, XP, achievement, or server-action coordination out of `UnitTemplate`.

--- a/reports/codebase-cleanup-inventory.md
+++ b/reports/codebase-cleanup-inventory.md
@@ -220,11 +220,48 @@ Validation results:
 
 This batch changes tests and cleanup documentation only. `UnitTemplate.tsx`, its localStorage effects, section order, routes, scoring, XP, completion, server actions, database behavior, FSRS, auth, lesson content, packages, and UI remain unchanged.
 
+### UnitTemplate progress persistence hook extraction
+
+Added:
+
+- `src/components/learn/hooks/useLessonProgress.ts`
+
+The hook owns only the existing browser persistence boundary: reading `lesson-progress-<unitId>`, restoring eligible sections, writing intermediate progress, and removing the current unit key on the final Quiz. `UnitTemplate` continues to own section state and all lesson orchestration.
+
+Preserved exactly:
+
+- malformed saved JSON is ignored
+- saved sections restore only when greater than 1 and less than 10
+- section 10 remains non-restorable
+- the first section does not write progress
+- intermediate sections persist `{ section }`
+- final-section cleanup removes only the active unit key
+- unrelated unit progress remains untouched
+
+Focused results:
+
+- `UnitTemplate.tsx`: 1,069 → 1054 lines
+- source files scanned: 347 → 348
+- known entry points remained 122
+- unreachable candidates remained 0
+
+Validation results:
+
+- 15 targeted lesson tests passed
+- 6 production-server Playwright smoke tests passed on Desktop Chromium and Mobile Chrome
+- TypeScript passed
+- focused and full ESLint passed
+- full unit tests passed
+- lesson content-standard tests passed
+- production build passed
+
+No localStorage key, section order, navigation, scoring, XP, completion transaction, server action, database behavior, FSRS, auth, route, lesson content, package, or UI behavior changed.
+
 Temporary GitHub Actions workflows used for full-checkout verification are removed after their successful run so they do not consume future Actions minutes.
 
 ## Current inventory summary
 
-- Source files scanned: 347
+- Source files scanned: 348
 - Known entry points: 122
 - Unreachable candidates: 0
 - Files with at least 500 lines: 32
@@ -244,7 +281,7 @@ This does not mean the repository has no architecture debt. Large active compone
 
 Classification: **active, oversized, high-priority refactor — never delete**
 
-Current generated size: 1,069 lines. It still owns orchestration state, browser persistence, audio, server-action coordination, scoring, completion logic, celebration UI, and the remaining stateful helper components.
+Current generated size: 1054 lines. It still owns orchestration state, audio, server-action coordination, scoring, completion logic, celebration UI, and the remaining stateful helper components.
 
 Safe refactor order:
 
@@ -253,7 +290,7 @@ Safe refactor order:
 3. Add production-server lesson smoke/E2E coverage — complete.
 4. Extract first stateless presentation helpers — complete.
 5. Expand persistence-specific coverage — complete.
-6. Extract local-storage hooks with the persistence test matrix as a required gate.
+6. Extract local-storage hooks with the persistence test matrix as a required gate — complete.
 7. Extract completion logic after server-action and achievement coverage.
 8. Replace related state groups with a reducer only after each state transition is covered.
 
@@ -278,4 +315,4 @@ A source file can be deleted only when all applicable checks pass:
 
 ## Next cleanup work
 
-CLEANUP-004C — extract lesson progress restore/save/remove behavior into a dedicated hook. Preserve the exact `lesson-progress-<unitId>` key, section semantics, and per-unit cleanup behavior covered by the 15 targeted tests and six production-server smoke tests.
+CLEANUP-018 — add focused completion-flow regression coverage before moving completion, XP, achievement, streak, or server-action coordination out of `UnitTemplate`.

--- a/src/components/learn/UnitTemplate.tsx
+++ b/src/components/learn/UnitTemplate.tsx
@@ -24,6 +24,7 @@ import TranslateSection from "./sections/TranslateSection";
 import FluencySection from "./sections/FluencySection";
 import LessonProgress from "./lesson-ui/LessonProgress";
 import SessionBreakCard from "./lesson-ui/SessionBreakCard";
+import useLessonProgress from "./hooks/useLessonProgress";
 import {
   SECTION_LABELS,
   SECTION_ORDER,
@@ -268,14 +269,6 @@ export default function UnitTemplate({ unit, nextRoute = "/dashboard" }: UnitTem
         setIsCompleted(true);
       }
     } catch {}
-    try {
-      const saved = localStorage.getItem(`lesson-progress-${normalizedUnit.unitId}`);
-      if (saved) {
-        const { section: savedSection } = JSON.parse(saved) as { section: number };
-         
-        if (savedSection > 1 && savedSection < TOTAL_SECTIONS) setSection(savedSection);
-      }
-    } catch { /* ignore */ }
   }, [normalizedUnit.unitId]);
 
   useEffect(() => {
@@ -284,18 +277,11 @@ export default function UnitTemplate({ unit, nextRoute = "/dashboard" }: UnitTem
     };
   }, []);
 
-  // Save progress
-  useEffect(() => {
-    const orderIdx = SECTION_ORDER.indexOf(section as SectionNumber);
-    const isFirstSection = orderIdx === 0;
-    const isLastSection = orderIdx === SECTION_ORDER.length - 1;
-
-    if (isLastSection) {
-      localStorage.removeItem(`lesson-progress-${normalizedUnit.unitId}`);
-    } else if (!isFirstSection && orderIdx > 0) {
-      localStorage.setItem(`lesson-progress-${normalizedUnit.unitId}`, JSON.stringify({ section }));
-    }
-  }, [section, normalizedUnit.unitId]);
+useLessonProgress({
+  unitId: normalizedUnit.unitId,
+  section,
+  setSection,
+});
 
   // Settings
   const userSettings = (() => {

--- a/src/components/learn/hooks/useLessonProgress.ts
+++ b/src/components/learn/hooks/useLessonProgress.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+
+import { SECTION_ORDER, TOTAL_SECTIONS, type SectionNumber } from "../lesson-sections";
+
+interface UseLessonProgressOptions {
+  unitId: string;
+  section: number;
+  setSection: Dispatch<SetStateAction<number>>;
+}
+
+const getProgressKey = (unitId: string) => `lesson-progress-${unitId}`;
+
+export default function useLessonProgress({
+  unitId,
+  section,
+  setSection,
+}: UseLessonProgressOptions) {
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(getProgressKey(unitId));
+      if (saved) {
+        const { section: savedSection } = JSON.parse(saved) as { section: number };
+
+        if (savedSection > 1 && savedSection < TOTAL_SECTIONS) setSection(savedSection);
+      }
+    } catch {
+      // Preserve the existing non-fatal behavior for malformed browser storage.
+    }
+  }, [setSection, unitId]);
+
+  useEffect(() => {
+    const orderIdx = SECTION_ORDER.indexOf(section as SectionNumber);
+    const isFirstSection = orderIdx === 0;
+    const isLastSection = orderIdx === SECTION_ORDER.length - 1;
+    const progressKey = getProgressKey(unitId);
+
+    if (isLastSection) {
+      localStorage.removeItem(progressKey);
+    } else if (!isFirstSection && orderIdx > 0) {
+      localStorage.setItem(progressKey, JSON.stringify({ section }));
+    }
+  }, [section, unitId]);
+}


### PR DESCRIPTION
## What changed

Extracted the existing lesson-progress browser persistence boundary from `src/components/learn/UnitTemplate.tsx` into:

- `src/components/learn/hooks/useLessonProgress.ts`

`UnitTemplate` now passes the current `unitId`, `section`, and stable `setSection` setter to the hook. It continues to own section state, lesson orchestration, warmup/completion loading, guest completion, navigation, scoring, XP, server actions, and rendering.

## Preserved semantics

The hook keeps the previous behavior exactly:

- storage key remains `lesson-progress-<unitId>`
- malformed JSON is ignored without crashing
- saved progress restores only when `savedSection > 1 && savedSection < 10`
- section `10` remains intentionally non-restorable
- the first section writes nothing
- intermediate sections persist `{ section }` JSON
- entering the final Quiz removes only the active unit key
- progress belonging to another unit remains untouched

No localStorage key, section order, navigation, scoring, XP, completion transaction, server action, database behavior, FSRS, auth, route, lesson content, package, lockfile, or UI behavior changed.

## Focused diff

Relative to `agent/unit-template-persistence-tests`:

- `src/components/learn/UnitTemplate.tsx`: `+6/-20`
- `src/components/learn/hooks/useLessonProgress.ts`: new 45-line hook
- `UnitTemplate.tsx`: 1,069 → 1,054 lines
- three cleanup/planning documents updated
- no test file changed

## Validation

A full GitHub Actions checkout ran on the extraction and again as a final read-only run on the committed state:

```bash
npm ci --ignore-scripts --legacy-peer-deps
npx playwright install --with-deps chromium
npx vitest run src/components/learn/UnitTemplate.test.tsx src/components/learn/lesson-sections.test.ts src/components/learn/lesson-ui/lesson-presentation.test.tsx
npm run inventory -- --write
npx tsc --noEmit
npx eslint <focused hook and lesson files>
npm run lint
npm run test
npm run test:content-standard
npm run build
PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/lesson-smoke.spec.ts
```

Results:

- 15 targeted lesson behavior/persistence tests passed
- 6 production-server lesson smoke tests passed on Desktop Chromium and Mobile Chrome
- source inventory: 348 files, 122 entry points, 0 unreachable candidates
- TypeScript passed
- focused and full ESLint passed
- full unit tests passed
- lesson content-standard tests passed
- production build passed

The temporary workflow was removed after the successful final run.

## Final diff

Only these files change:

- `src/components/learn/UnitTemplate.tsx`
- `src/components/learn/hooks/useLessonProgress.ts`
- `AGENT_PLAN.md`
- `AGENT_BACKLOG.md`
- `reports/codebase-cleanup-inventory.md`

## Stacked base

This PR targets `agent/unit-template-persistence-tests` and depends on PR #15 → PR #14 → PR #13 → PR #12 → PR #11 → PR #10 → PR #9 → PR #8 → PR #7 → PR #6 → PR #5 → PR #4 → PR #3 → PR #2 → PR #1.