### PR TITLE
fix: harden Supabase database security

### DIFF
--- a/supabase/migrations/20260722055805_harden_database_foundation.sql
+++ b/supabase/migrations/20260722055805_harden_database_foundation.sql
@@ -1,0 +1,237 @@
+-- Harden Supabase RPCs, function search paths, and exposed privileges.
+-- Keeps current app signatures stable while moving trust checks into Postgres.
+
+create schema if not exists private;
+revoke all on schema private from public;
+grant usage on schema private to authenticated, service_role;
+
+-- Restore columns required by the current completeUnit() server action.
+alter table public.user_lesson_progress
+  add column if not exists xp_earned integer not null default 0;
+alter table public.user_lesson_progress
+  add column if not exists created_at timestamptz not null default now();
+create unique index if not exists user_lesson_progress_user_id_unit_id_key
+  on public.user_lesson_progress (user_id, unit_id);
+
+-- Remove an unnecessary permissive INSERT policy. service_role bypasses RLS.
+drop policy if exists "Service role can insert notifications"
+  on public.notification_logs;
+revoke insert on table public.notification_logs from anon, authenticated;
+
+-- Internal project memories must not be exposed to browser roles.
+revoke all on table public.project_memories from anon, authenticated;
+
+-- Move pgvector out of the exposed public schema.
+do $migration$
+begin
+  if exists (
+    select 1
+    from pg_extension e
+    join pg_namespace n on n.oid = e.extnamespace
+    where e.extname = 'vector' and n.nspname = 'public'
+  ) then
+    execute 'alter extension vector set schema extensions';
+  end if;
+end
+$migration$;
+
+create or replace function public.match_memories(
+  query_embedding extensions.vector,
+  match_threshold double precision default 0.70,
+  match_count integer default 8,
+  filter_project text default null,
+  filter_category text default null
+)
+returns table (
+  id bigint,
+  content text,
+  category text,
+  metadata jsonb,
+  project text,
+  created_at timestamptz,
+  similarity double precision
+)
+language sql
+stable
+security invoker
+set search_path = ''
+as $function$
+  select
+    pm.id,
+    pm.content,
+    pm.category,
+    pm.metadata,
+    pm.project,
+    pm.created_at,
+    (1 - (pm.embedding operator(extensions.<=>) query_embedding))::double precision as similarity
+  from public.project_memories as pm
+  where
+    (1 - (pm.embedding operator(extensions.<=>) query_embedding)) > greatest(0.0, least(match_threshold, 1.0))
+    and (filter_project is null or pm.project = filter_project)
+    and (filter_category is null or pm.category = filter_category)
+  order by pm.embedding operator(extensions.<=>) query_embedding
+  limit greatest(1, least(match_count, 50));
+$function$;
+
+revoke all on function public.match_memories(extensions.vector, double precision, integer, text, text)
+  from public, anon, authenticated;
+grant execute on function public.match_memories(extensions.vector, double precision, integer, text, text)
+  to service_role;
+
+-- Safe trigger helpers and pure helpers: immutable search path.
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  new.updated_at := pg_catalog.now();
+  return new;
+end;
+$function$;
+
+create or replace function public.update_ufp_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  new.updated_at := pg_catalog.now();
+  return new;
+end;
+$function$;
+
+create or replace function public.update_unit_content_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  new.updated_at := pg_catalog.now();
+  return new;
+end;
+$function$;
+
+create or replace function public.prune_old_notifications()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  delete from public.notification_logs
+  where user_id = new.user_id
+    and id not in (
+      select nl.id
+      from public.notification_logs as nl
+      where nl.user_id = new.user_id
+      order by nl.created_at desc
+      limit 200
+    );
+  return new;
+end;
+$function$;
+
+create or replace function public.units_required_for_level(level text)
+returns integer
+language sql
+immutable
+security invoker
+set search_path = ''
+as $function$
+  select case level
+    when 'A1' then 4
+    when 'A2' then 6
+    when 'B1' then 8
+    when 'B2' then 10
+    else 999
+  end;
+$function$;
+
+create or replace function public.next_cefr_level(level text)
+returns text
+language sql
+immutable
+security invoker
+set search_path = ''
+as $function$
+  select case level
+    when 'A1' then 'A2'
+    when 'A2' then 'B1'
+    when 'B1' then 'B2'
+    when 'B2' then 'C1'
+    else level
+  end;
+$function$;
+
+create or replace function public.check_cefr_progression()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_current_level text;
+  v_completed_count integer;
+  v_required integer;
+  v_next_level text;
+begin
+  select up.current_level
+    into v_current_level
+  from public.user_progress as up
+  where up.user_id = new.user_id;
+
+  if v_current_level is null or v_current_level = 'C1' then
+    return new;
+  end if;
+
+  select count(distinct ulp.unit_id)::integer
+    into v_completed_count
+  from public.user_lesson_progress as ulp
+  where ulp.user_id = new.user_id;
+
+  v_required := public.units_required_for_level(v_current_level);
+
+  if v_completed_count >= v_required then
+    v_next_level := public.next_cefr_level(v_current_level);
+    update public.user_progress
+    set current_level = v_next_level
+    where user_id = new.user_id
+      and current_level = v_current_level;
+  end if;
+
+  return new;
+end;
+$function$;
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  insert into public.users (id, email, display_name, avatar_url)
+  values (
+    new.id,
+    new.email,
+    coalesce(new.raw_user_meta_data ->> 'display_name', new.raw_user_meta_data ->> 'full_name'),
+    new.raw_user_meta_data ->> 'avatar_url'
+  )
+  on conflict (id) do nothing;
+
+  insert into public.user_progress (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+
+  return new;
+end;
+$function$;
+
+revoke all on function public.handle_new_user()
+  from public, anon, authenticated, service_role;
+grant execute on function public.handle_new_user()
+  to supabase_auth_admin;

--- a/supabase/migrations/20260722055900_harden_progress_rpcs.sql
+++ b/supabase/migrations/20260722055900_harden_progress_rpcs.sql
@@ -1,0 +1,243 @@
+-- Self-scoped XP award. Dates are derived server-side, not trusted from callers.
+create or replace function public.award_user_xp(
+  p_user_id uuid,
+  p_xp_amount integer,
+  p_today date,
+  p_yesterday date
+)
+returns table (
+  total_xp integer,
+  streak integer,
+  last_active_date date
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+  v_today date := (pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date;
+  v_yesterday date := ((pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date - 1);
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  if p_xp_amount < 0 or p_xp_amount > 1900 then
+    raise exception 'xp amount is outside the allowed range' using errcode = '22023';
+  end if;
+
+  return query
+  insert into public.user_progress (
+    user_id,
+    total_xp,
+    streak,
+    last_active_date,
+    daily_xp_goal
+  )
+  values (
+    p_user_id,
+    p_xp_amount,
+    1,
+    v_today,
+    50
+  )
+  on conflict (user_id) do update set
+    total_xp = public.user_progress.total_xp + greatest(p_xp_amount, 0),
+    streak = case
+      when public.user_progress.last_active_date = v_today then public.user_progress.streak
+      when public.user_progress.last_active_date = v_yesterday then public.user_progress.streak + 1
+      when public.user_progress.last_active_date is null then 1
+      else 1
+    end,
+    last_active_date = v_today,
+    best_streak = greatest(
+      public.user_progress.best_streak,
+      case
+        when public.user_progress.last_active_date = v_today then public.user_progress.streak
+        when public.user_progress.last_active_date = v_yesterday then public.user_progress.streak + 1
+        else 1
+      end
+    ),
+    updated_at = pg_catalog.now()
+  returning
+    public.user_progress.total_xp,
+    public.user_progress.streak,
+    public.user_progress.last_active_date;
+end;
+$function$;
+
+revoke all on function public.award_user_xp(uuid, integer, date, date)
+  from public, anon, authenticated, service_role;
+grant execute on function public.award_user_xp(uuid, integer, date, date)
+  to authenticated, service_role;
+
+-- Atomic unit completion. The database validates unit reward data itself.
+create or replace function public.complete_unit_transaction(
+  p_user_id uuid,
+  p_unit_id text,
+  p_xp_earned integer,
+  p_stars integer,
+  p_today text
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+  v_base_xp integer;
+  v_expected_xp integer;
+  v_progress_id uuid;
+  v_new_xp integer;
+  v_new_streak integer;
+  v_current_level text;
+  v_new_level text;
+  v_streak_last_active date;
+  v_today date := (pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date;
+  v_yesterday date := ((pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date - 1);
+  v_completed_count integer;
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  if p_stars not between 1 and 3 then
+    raise exception 'invalid star count' using errcode = '22023';
+  end if;
+
+  v_base_xp := case
+    when p_unit_id in (
+      'unit-a0-1','unit-a0-2','unit-a0-3','unit-a0-4',
+      'unit-a0-5','unit-a0-6','unit-a0-7'
+    ) then 60
+    when p_unit_id in (
+      'unit-a0-8','unit-1','unit-2','unit-3','unit-4','unit-5','unit-6',
+      'unit-8','unit-9','unit-10','unit-11'
+    ) then 80
+    when p_unit_id = 'unit-7' then 85
+    when p_unit_id = 'unit-12' then 120
+    else null
+  end;
+
+  if v_base_xp is null then
+    raise exception 'unit is not configured for completion' using errcode = '22023';
+  end if;
+
+  v_expected_xp := case p_stars
+    when 3 then v_base_xp
+    when 2 then round(v_base_xp * 0.85)::integer
+    when 1 then round(v_base_xp * 0.70)::integer
+  end;
+
+  if p_xp_earned is distinct from v_expected_xp then
+    raise exception 'invalid XP reward for unit and star count' using errcode = '22023';
+  end if;
+
+  insert into public.user_lesson_progress (
+    user_id,
+    unit_id,
+    xp_earned,
+    completed_at,
+    created_at
+  )
+  values (
+    p_user_id,
+    p_unit_id,
+    v_expected_xp,
+    pg_catalog.now(),
+    pg_catalog.now()
+  )
+  on conflict (user_id, unit_id) do nothing
+  returning id into v_progress_id;
+
+  if v_progress_id is null then
+    return pg_catalog.jsonb_build_object(
+      'success', true,
+      'already_completed', true
+    );
+  end if;
+
+  select count(distinct ulp.unit_id)::integer
+    into v_completed_count
+  from public.user_lesson_progress as ulp
+  where ulp.user_id = p_user_id;
+
+  v_new_level := case
+    when v_completed_count >= 40 then 'B2'
+    when v_completed_count >= 26 then 'B1'
+    when v_completed_count >= 20 then 'A2'
+    when v_completed_count >= 8 then 'A1'
+    else 'A0'
+  end;
+
+  select up.streak, up.total_xp, up.last_active_date, up.current_level
+    into v_new_streak, v_new_xp, v_streak_last_active, v_current_level
+  from public.user_progress as up
+  where up.user_id = p_user_id
+  for update;
+
+  if not found then
+    -- Bootstrap only the default row. XP is added exactly once in the UPDATE below.
+    insert into public.user_progress (user_id)
+    values (p_user_id)
+    on conflict (user_id) do nothing;
+
+    select up.streak, up.total_xp, up.last_active_date, up.current_level
+      into v_new_streak, v_new_xp, v_streak_last_active, v_current_level
+    from public.user_progress as up
+    where up.user_id = p_user_id
+    for update;
+  end if;
+
+  if v_streak_last_active = v_today then
+    v_new_streak := v_new_streak;
+  elsif v_streak_last_active = v_yesterday then
+    v_new_streak := v_new_streak + 1;
+  else
+    v_new_streak := 1;
+  end if;
+
+  if (
+    case v_new_level
+      when 'C1' then 6 when 'B2' then 5 when 'B1' then 4
+      when 'A2' then 3 when 'A1' then 2 when 'A0' then 1 else 0
+    end
+  ) <= (
+    case coalesce(v_current_level, 'A0')
+      when 'C1' then 6 when 'B2' then 5 when 'B1' then 4
+      when 'A2' then 3 when 'A1' then 2 when 'A0' then 1 else 0
+    end
+  ) then
+    v_new_level := coalesce(v_current_level, 'A0');
+  end if;
+
+  update public.user_progress
+  set total_xp = total_xp + v_expected_xp,
+      streak = v_new_streak,
+      best_streak = greatest(best_streak, v_new_streak),
+      last_active_date = v_today,
+      current_level = v_new_level,
+      updated_at = pg_catalog.now()
+  where user_id = p_user_id
+  returning total_xp into v_new_xp;
+
+  return pg_catalog.jsonb_build_object(
+    'success', true,
+    'xp_earned', v_expected_xp,
+    'new_streak', v_new_streak,
+    'new_total_xp', v_new_xp,
+    'current_level', v_new_level,
+    'completed_count', v_completed_count,
+    'leveled_up', (v_new_level is distinct from coalesce(v_current_level, 'A0'))
+  );
+end;
+$function$;
+
+revoke all on function public.complete_unit_transaction(uuid, text, integer, integer, text)
+  from public, anon, authenticated, service_role;
+grant execute on function public.complete_unit_transaction(uuid, text, integer, integer, text)
+  to authenticated, service_role;

--- a/supabase/migrations/20260722055958_harden_gamification_rpcs.sql
+++ b/supabase/migrations/20260722055958_harden_gamification_rpcs.sql
@@ -1,0 +1,259 @@
+-- League assignment remains privileged internally but is exposed through a self-scoped invoker wrapper.
+create or replace function private.assign_league_for_user_internal(p_user_id uuid)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_week date := pg_catalog.date_trunc('week', pg_catalog.now())::date;
+  v_tier public.league_tier;
+  v_league_id uuid;
+  v_xp integer;
+begin
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_user_id::text || ':' || v_week::text, 0)
+  );
+
+  select lm.league_id
+    into v_league_id
+  from public.league_memberships as lm
+  join public.leagues as l on l.id = lm.league_id
+  where lm.user_id = p_user_id
+    and l.week_start = v_week
+  limit 1;
+
+  if v_league_id is not null then
+    return v_league_id;
+  end if;
+
+  select coalesce(up.total_xp, 0)
+    into v_xp
+  from public.user_progress as up
+  where up.user_id = p_user_id;
+
+  v_xp := coalesce(v_xp, 0);
+  v_tier := case
+    when v_xp >= 10000 then 'diamond'::public.league_tier
+    when v_xp >= 4000 then 'emerald'::public.league_tier
+    when v_xp >= 1500 then 'gold'::public.league_tier
+    when v_xp >= 400 then 'silver'::public.league_tier
+    else 'bronze'::public.league_tier
+  end;
+
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(v_week::text || ':' || v_tier::text, 0)
+  );
+
+  select l.id
+    into v_league_id
+  from public.leagues as l
+  left join public.league_memberships as lm on lm.league_id = l.id
+  where l.week_start = v_week
+    and l.tier = v_tier
+  group by l.id
+  having count(lm.user_id) < 30
+  order by count(lm.user_id) desc
+  limit 1;
+
+  if v_league_id is null then
+    insert into public.leagues (week_start, tier)
+    values (v_week, v_tier)
+    returning id into v_league_id;
+  end if;
+
+  insert into public.league_memberships (user_id, league_id, xp_this_week)
+  values (p_user_id, v_league_id, 0)
+  on conflict do nothing;
+
+  return v_league_id;
+end;
+$function$;
+
+revoke all on function private.assign_league_for_user_internal(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function private.assign_league_for_user_internal(uuid)
+  to authenticated, service_role;
+
+create or replace function public.assign_league_for_user(p_user_id uuid)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  return private.assign_league_for_user_internal(p_user_id);
+end;
+$function$;
+
+revoke all on function public.assign_league_for_user(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function public.assign_league_for_user(uuid)
+  to authenticated, service_role;
+
+create or replace function public.bump_league_xp(p_user_id uuid, p_xp_delta integer)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+  v_week date := pg_catalog.date_trunc('week', pg_catalog.now())::date;
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  if p_xp_delta < 0 or p_xp_delta > 500 then
+    raise exception 'invalid league XP delta' using errcode = '22023';
+  end if;
+
+  update public.league_memberships as lm
+  set xp_this_week = lm.xp_this_week + p_xp_delta
+  from public.leagues as l
+  where lm.league_id = l.id
+    and lm.user_id = p_user_id
+    and l.week_start = v_week;
+end;
+$function$;
+
+revoke all on function public.bump_league_xp(uuid, integer)
+  from public, anon, authenticated, service_role;
+grant execute on function public.bump_league_xp(uuid, integer)
+  to authenticated, service_role;
+
+-- Streak freeze grants are recorded once per milestone to prevent repeated claims.
+create table if not exists private.streak_freeze_grants (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  milestone integer not null check (milestone in (7, 14, 30)),
+  granted_at timestamptz not null default now(),
+  primary key (user_id, milestone)
+);
+revoke all on table private.streak_freeze_grants from public, anon, authenticated;
+grant select, insert on table private.streak_freeze_grants to service_role;
+
+create or replace function private.grant_streak_freeze_internal(
+  p_user_id uuid,
+  p_count integer
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_streak integer;
+  v_granted integer;
+begin
+  if p_count <> 1 then
+    raise exception 'freeze grant count must be 1' using errcode = '22023';
+  end if;
+
+  select up.streak
+    into v_streak
+  from public.user_progress as up
+  where up.user_id = p_user_id
+  for update;
+
+  if v_streak not in (7, 14, 30) then
+    return;
+  end if;
+
+  insert into private.streak_freeze_grants (user_id, milestone)
+  values (p_user_id, v_streak)
+  on conflict do nothing
+  returning milestone into v_granted;
+
+  if v_granted is not null then
+    update public.user_progress
+    set streak_freeze_count = least(streak_freeze_count + 1, 5),
+        updated_at = pg_catalog.now()
+    where user_id = p_user_id;
+  end if;
+end;
+$function$;
+
+revoke all on function private.grant_streak_freeze_internal(uuid, integer)
+  from public, anon, authenticated, service_role;
+grant execute on function private.grant_streak_freeze_internal(uuid, integer)
+  to authenticated, service_role;
+
+create or replace function public.grant_streak_freeze(
+  p_user_id uuid,
+  p_count integer default 1
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  perform private.grant_streak_freeze_internal(p_user_id, p_count);
+end;
+$function$;
+
+revoke all on function public.grant_streak_freeze(uuid, integer)
+  from public, anon, authenticated, service_role;
+grant execute on function public.grant_streak_freeze(uuid, integer)
+  to authenticated, service_role;
+
+create or replace function public.use_streak_freeze(p_user_id uuid)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_uid uuid := (select auth.uid());
+  v_freeze_count integer;
+  v_streak integer;
+begin
+  if current_user not in ('postgres', 'service_role')
+     and (v_uid is null or p_user_id is distinct from v_uid) then
+    raise exception 'not authorized' using errcode = '42501';
+  end if;
+
+  update public.user_progress
+  set streak_freeze_count = streak_freeze_count - 1,
+      last_active_date = (pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date,
+      updated_at = pg_catalog.now()
+  where user_id = p_user_id
+    and streak_freeze_count > 0
+  returning streak_freeze_count, streak
+    into v_freeze_count, v_streak;
+
+  if not found then
+    return pg_catalog.jsonb_build_object(
+      'success', false,
+      'error', 'No streak freezes available'
+    );
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'success', true,
+    'freezes_remaining', v_freeze_count,
+    'streak', v_streak
+  );
+end;
+$function$;
+
+revoke all on function public.use_streak_freeze(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function public.use_streak_freeze(uuid)
+  to authenticated, service_role;

--- a/supabase/migrations/20260722060258_fix_league_rls_recursion.sql
+++ b/supabase/migrations/20260722060258_fix_league_rls_recursion.sql
@@ -1,0 +1,36 @@
+create or replace function private.current_user_league_ids()
+returns setof uuid
+language sql
+stable
+security definer
+set search_path = ''
+as $function$
+  select lm.league_id
+  from public.league_memberships as lm
+  where lm.user_id = (select auth.uid());
+$function$;
+
+revoke all on function private.current_user_league_ids()
+  from public, anon, authenticated, service_role;
+grant execute on function private.current_user_league_ids()
+  to authenticated, service_role;
+
+drop policy if exists "league_memberships: read own league"
+  on public.league_memberships;
+create policy "league_memberships: read own league"
+  on public.league_memberships
+  for select
+  to authenticated
+  using (
+    league_id in (select private.current_user_league_ids())
+  );
+
+drop policy if exists "leagues: members can read own league"
+  on public.leagues;
+create policy "leagues: members can read own league"
+  on public.leagues
+  for select
+  to authenticated
+  using (
+    id in (select private.current_user_league_ids())
+  );


### PR DESCRIPTION
## What changed

- move pgvector out of the exposed `public` schema
- lock `project_memories` and `match_memories` to service-role access
- remove the overly permissive notification insert policy
- add fixed empty `search_path` configuration to database functions
- prevent authenticated users from invoking RPCs for another user ID
- validate unit XP and star rewards inside PostgreSQL
- restore the `xp_earned` and `created_at` lesson-progress columns required by the current app
- fix the league assignment query to use `total_xp`
- prevent duplicate streak-freeze milestone claims
- replace the recursive league RLS policy with a private helper

## Production status

These four migrations have already been applied successfully to the connected AtoEnglish Supabase production project. The files in this PR synchronize Git history with Supabase migration history.

## Validation

- Supabase Security Advisor now reports only the project-level leaked-password-protection setting
- authorized unit completion succeeded inside a rolled-back authenticated transaction
- cross-user unit completion, league assignment, and streak-freeze calls were rejected
- league assignment and league XP update succeeded inside a rolled-back authenticated transaction
- verification confirmed no test lesson-progress or league-membership rows persisted
