### PR TITLE
docs: make AtoEnglish product direction agent-readable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,18 +3,80 @@
 > Vietnamese-first English learning web app.
 > Stack: Next.js 16, React 19, TypeScript, Tailwind CSS v4, Supabase, Vitest, Playwright, Vercel.
 
+This file is the default operating contract for coding agents working in this repository.
+
+## Mission
+
+AtoEnglish is the product. Coding agents are implementation workers. CycleWarden, GitHub, tests, and automation exist to help the owner develop AtoEnglish without losing product direction or repository control.
+
+The current product goal is deliberately narrow:
+
+> Help Vietnamese adults who know some English but freeze when speaking at work complete a 28-day, 10–15 minute-per-day journey and demonstrate a practical speaking improvement.
+
+Do not optimize for feature count, architectural novelty, autonomous operation, or broad A0–B2 coverage.
+
+## Mandatory reading order
+
+Before proposing or changing non-trivial code, read:
+
+1. `docs/product/PRODUCT_TRUTH.md`
+2. `docs/product/CURRENT_PRIORITY.md`
+3. `docs/product/DO_NOT_BUILD.md`
+4. `docs/curriculum/28-day-speaking-journey-contract.md` for curriculum or lesson work
+5. `CONTENT_STYLE.md` for learner-facing content
+6. the relevant implementation, tests, migrations, issues, and recent pull requests
+
+When these sources disagree, stop and report the conflict. Do not silently choose the broader or more ambitious interpretation.
+
 ## Working model
 
-1. Read this file before non-trivial work.
-2. Work on a branch; do not push autonomous changes directly to `main`.
-3. Use one branch per cleanup campaign and one logical concern per commit.
-4. Do not create commits whose only purpose is recording that checks passed.
-5. Do not generate placeholder maintenance tasks to keep an agent busy.
-6. Keep `AGENT_PLAN.md` limited to the current task.
-7. Keep `AGENT_BACKLOG.md` limited to open tasks.
-8. Git history and pull requests are the record of completed work; do not duplicate full history in Markdown logs.
-9. Runtime logs under `logs/agent/` must not be committed.
-10. When uncertain whether a file is used, classify it for manual verification instead of deleting it.
+1. Work on a dedicated branch; never push autonomous changes directly to `main`.
+2. Use one pull request for one bounded product or technical outcome.
+3. Do not create commits whose only purpose is recording successful checks.
+4. Do not generate placeholder maintenance work to keep an agent busy.
+5. Keep `AGENT_PLAN.md` limited to the current task and `AGENT_BACKLOG.md` limited to open work.
+6. Git history and pull requests are the record of completed work; do not duplicate full history in Markdown logs.
+7. Runtime logs under `logs/agent/` must not be committed.
+8. Stop and document ambiguity instead of guessing.
+9. Treat the approved scope as a permission boundary, not a suggestion.
+10. Never merge or deploy automatically. The owner makes the final authorization decision.
+
+## Product-first rules
+
+1. **Product priority beats technical interest.** Cleanup, abstraction, or infrastructure work is not justified unless it directly unblocks `docs/product/CURRENT_PRIORITY.md`.
+2. **Make the smallest coherent change.** Preserve working behavior outside the approved scope.
+3. **Do not mix systems.** Curriculum, authentication, database, analytics, XP, FSRS, payments, and architecture work require separate pull requests unless one cannot function without the other and the coupling is documented.
+4. **Separate technical evidence from learner evidence.** Passing checks proves repository consistency, not learning effectiveness or market demand.
+5. **Do not invent requirements.** Use visible assumptions or request a decision.
+6. **Stop when scope expands.** Open a follow-up issue instead of silently widening the current change.
+7. **Never expose secrets or perform unapproved production writes.** Never edit `.env.local` or commit credentials.
+
+## Task contract
+
+Every implementation task must state:
+
+- problem;
+- intended learner, user, or developer outcome;
+- current evidence;
+- allowed files or directories;
+- explicitly forbidden scope;
+- acceptance criteria;
+- required technical checks;
+- required product checks;
+- manual review questions;
+- rollback or recovery plan.
+
+Small fixes may keep this contract in the issue or pull-request description. Larger work should use a focused spec document.
+
+## Workflow depth
+
+Use the lightest safe process:
+
+- **Small:** isolated copy, metadata, or narrowly characterized bug — inspect, patch, targeted checks, pull request.
+- **Medium:** lesson or bounded feature — task contract, approved scope, implementation, technical and product checks, pull request.
+- **High risk:** auth, database, privacy, production, or broad architecture — explicit decision, risk review, migration or rollback plan, independent verification, pull request.
+
+Do not force every task through a large research lifecycle.
 
 ## Commands
 
@@ -32,6 +94,8 @@ npm run inventory
 ```
 
 Use `npm run build` as the final compilation check, not after every small edit.
+
+Do not claim a check passed unless it actually ran against the final committed state.
 
 ## Architecture
 
@@ -52,28 +116,34 @@ src/
 └── proxy.ts                     # Next.js route protection and rate limiting
 ```
 
-New product-specific code should normally live under `src/features/<feature>/`. Shared visual primitives belong under `src/components/ui/`. Avoid new catch-all folders such as `misc`, `helpers`, `old`, `backup`, or `temp`.
+New product-specific code should normally live under `src/features/<feature>/`. Shared visual primitives belong under `src/components/ui/`. Avoid catch-all folders such as `misc`, `helpers`, `old`, `backup`, or `temp`.
+
+Preserve the modular monolith unless a measured product blocker requires architectural change.
 
 ## Protected areas
 
-Ask before changing:
+Do not change these areas unless the task explicitly requires them:
 
-- Database schema, migrations, or RLS policies.
-- Authentication and onboarding behavior.
-- `src/proxy.ts` route-protection behavior.
-- FSRS scheduling parameters.
-- Lesson section order or pedagogical flow.
-- Dependencies with meaningful bundle, runtime, or infrastructure impact.
-
-Never edit secrets or `.env.local`.
+- database schema, migrations, functions, or RLS policies;
+- authentication, onboarding, and route protection;
+- `src/proxy.ts` behavior;
+- analytics event taxonomy or privacy boundary;
+- FSRS scheduling parameters;
+- XP, stars, streaks, leagues, and achievements;
+- payment or production deployment configuration;
+- lesson section order or pedagogical flow;
+- `src/components/learn/UnitTemplate.tsx` architecture;
+- unrelated curriculum units;
+- dependencies with meaningful bundle, runtime, or infrastructure impact;
+- raw audio, transcripts, names, employers, or learner free text in analytics.
 
 ## TypeScript and Next.js
 
 - Do not use `any` or `as any`.
 - In Next.js 16 server code, await asynchronous framework APIs such as `cookies()`, `headers()`, `params`, and the server Supabase client.
 - Use the correct Supabase client for the execution context:
-  - Server components, route handlers, and actions: server client.
-  - Client components: browser client.
+  - server components, route handlers, and actions: server client;
+  - client components: browser client;
   - `proxy.ts`: middleware client.
 - Prefer parallel independent database queries with `Promise.all`.
 - Do not use `dynamic(..., { ssr: false })` inside server components.
@@ -84,49 +154,71 @@ Never edit secrets or `.env.local`.
 - Derive the authenticated user with `supabase.auth.getUser()`; never trust a client-supplied user ID.
 - Validate external input with Zod.
 - Apply rate limiting to write actions where required by existing project patterns.
+- Make schema changes only through migrations.
 - After a migration, regenerate `src/types/supabase.ts` with `npm run db:types`.
 - Known table names include `user_progress` and `user_lesson_progress`; do not invent replacement names.
 
-## Curriculum
+## Curriculum and lesson work
 
 Before editing unit content, read:
 
-- `CONTENT_STYLE.md`
-- `src/lib/lessons/lesson-blueprint.ts`
-- `src/lib/lessons/learning-flow.ts`
-- `src/lib/lessons/content-standard.ts`
-- the current golden unit example
+- `docs/curriculum/28-day-speaking-journey-contract.md`;
+- `CONTENT_STYLE.md`;
+- `src/lib/lessons/lesson-blueprint.ts`;
+- `src/lib/lessons/learning-flow.ts`;
+- `src/lib/lessons/content-standard.ts`;
+- the current relevant unit and its tests.
+
+A lesson change must demonstrate more than valid TypeScript and required field counts. Confirm:
+
+- one measurable daily can-do outcome;
+- a required spoken output;
+- a credible 10–15 minute scope;
+- retrieval rather than only recognition or repetition;
+- lower prompt support by the final task;
+- a changed or meaningful speaking situation;
+- no language expansion beyond the daily task;
+- a completion path containing speaking evidence or the approved fallback;
+- alignment with the 28-day journey and later assessment.
 
 Do not change lesson order as part of content cleanup.
+
+Curriculum changes require, at minimum:
+
+```bash
+npm run test:content-standard
+bash scripts/audit-lesson-content.sh
+npx tsc --noEmit
+npm run lint
+npm run test
+npm run build
+```
+
+Also run targeted unit tests and relevant production lesson smoke checks.
 
 ## Cleanup rules
 
 Cleanup must be staged:
 
-1. Establish a passing baseline.
-2. Run `npm run inventory` and review its candidates.
-3. Classify each candidate as `safe_to_delete`, `likely_unused`, or `manual_verification`.
-4. Delete only verified items.
-5. Refactor large components through small behavior-preserving extractions.
-6. Run relevant checks after every batch.
-7. Review the diff before committing.
+1. establish a passing baseline;
+2. run `npm run inventory` and review its candidates;
+3. classify each candidate as `safe_to_delete`, `likely_unused`, or `manual_verification`;
+4. delete only verified items;
+5. refactor large components through small behavior-preserving extractions;
+6. run relevant checks after every batch;
+7. review the diff before committing.
 
-Do not combine cleanup with feature development.
+Do not combine cleanup with feature development. Do not refactor merely to reduce line count.
 
 ## Before a pull request
 
-```bash
-npm run inventory
-npx tsc --noEmit
-npm run lint
-npm run test
-```
+Run the checks appropriate to the changed surface and confirm:
 
-Run additional content, integration, E2E, or build checks when the touched area requires them.
+- no unrelated files changed;
+- no production `console.log` or `console.error` was introduced;
+- no generated or runtime artifact was committed;
+- no secrets or production data were exposed;
+- documentation describes the current repository rather than an old implementation;
+- the pull-request body explains what changed, why it serves the current priority, checks executed, remaining risks, and what the owner should manually review.
 
-Confirm:
-
-- No unrelated files changed.
-- No production `console.log` or `console.error` was introduced.
-- No generated or runtime artifact was committed.
-- Documentation describes the current repository rather than an old implementation.
+The ordered development direction is maintained in `docs/product/CURRENT_PRIORITY.md`. Agents must not choose a different roadmap item merely because it is easier or more technically interesting.

--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -1,28 +1,55 @@
 # Agent Backlog — Active Tasks Only
 
+> Use `docs/product/CURRENT_PRIORITY.md` for ordering and `docs/product/DO_NOT_BUILD.md` for deferred scope.
+
 ## Rules
 
 1. Use a dedicated branch and reviewed pull request.
-2. Never merge automatically.
-3. Add characterization tests before moving behavior-sensitive logic.
-4. Do not change product behavior merely to reduce line count.
-5. Stop and document ambiguous behavior instead of guessing.
+2. Never merge or deploy automatically.
+3. Keep one bounded outcome per pull request.
+4. Every task must name the current AtoEnglish blocker it resolves.
+5. Do not add cleanup, abstraction, infrastructure, or agent capability without a current product need.
+6. Stop and document ambiguous behavior instead of guessing.
+7. Completed work belongs in Git history and pull requests, not the active backlog.
 
 ## Active queue
 
-### CLEANUP-018 — UnitTemplate completion-flow characterization
+### PRODUCT-001 — Product truth and agent constitution
+
 - **Status:** `in_progress`
-- **Scope:** Tests and documentation only.
-- **Coverage:** Star/XP derivation, authenticated success and failure, guest fallback, nextRoute, streak/achievement coordination, completion-status loading, duplicate prevention where currently enforced, and active-unit progress cleanup.
+- **Outcome:** Repository-owned product truth, active priority, do-not-build boundary, and agent operating contract.
+- **Scope:** Documentation only.
+- **Blocked by:** Nothing.
 
-### CLEANUP-019 — `/login` metadata/title investigation
-- **Status:** `ready`
-- **Scope:** Independent bug investigation; do not mix with lesson refactoring.
+### TOOLING-001 — Focused verification entry point
 
-### CLEANUP-004D — Extract pure completion calculations
+- **Status:** `ready_after_product_001`
+- **Outcome:** One command or manifest that selects and reports existing checks for a focused AtoEnglish change.
+- **Initial consumer:** The Gold Day 1 curriculum pull request.
+- **Required behavior:** Report executed, passed, failed, and unavailable checks; distinguish technical checks from manual product review.
+- **Forbidden scope:** Product behavior, new CI platform, generic orchestration framework, remote sandbox, auto-merge, auto-deploy.
+
+### CURRICULUM-001 — Gold Day 1 lesson
+
 - **Status:** `blocked`
-- **Blocked by:** CLEANUP-018 review and merge.
+- **Blocked by:** PRODUCT-001 and TOOLING-001.
+- **Outcome:** A 10–15 minute Day 1 lesson for greeting, name, Vietnamese-name spelling, one lightweight repeat request, and one final spoken output.
+- **Expected scope:** `src/lib/data/units/unitA01.ts`, direct targeted tests, and the smallest relevant lesson smoke assertion.
+- **Forbidden scope:** Role, company, responsibility, all five questions, full repair training, auth, database, analytics infrastructure, XP, FSRS, unrelated units, and major `UnitTemplate` refactor.
 
-### CLEANUP-015 — Review unit action transaction boundaries
-- **Status:** `blocked`
-- **Blocked by:** Completion characterization and focused server-action transaction tests.
+### PILOT-OPS-001 — Recruit and operate the first learner pilot
+
+- **Status:** `planned`
+- **Starts when:** The first-week journey and baseline flow are usable enough for real learners.
+- **Outcome:** Obtain learner, learning, support-cost, and payment evidence.
+- **Default approach:** Manual operations before new infrastructure.
+
+## Interrupt policy
+
+Only these may interrupt the queue:
+
+- a production defect blocking the pilot journey;
+- a security, privacy, or data-integrity defect;
+- a repeated development blocker observed in at least two real AtoEnglish tasks.
+
+An interrupt still requires explicit scope, acceptance criteria, verification, and a separate pull request.

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -1,30 +1,45 @@
 # Agent Plan — Current Work Only
 
-> Historical cleanup is recorded in merged pull requests and `reports/codebase-cleanup-inventory.md`.
+> Product direction is defined in `docs/product/PRODUCT_TRUTH.md`. Ordered work is defined in `docs/product/CURRENT_PRIORITY.md`.
 
 ## Current task
 
 | Field | Value |
 |---|---|
-| Task | CLEANUP-018 — Characterize UnitTemplate completion flow |
-| Status | in progress — test-only pull request |
-| Goal | Lock current completion, star, XP, guest, streak, achievement, and navigation behavior before any extraction |
-
-## Merged baseline
-
-- Cleanup PRs #1–#16 are merged into `main`.
-- Conservative unreachable candidates are 0.
-- `UnitTemplate` types, section constants, presentation helpers, and progress persistence are already extracted.
-- Production-server lesson smoke coverage exists on desktop and mobile.
+| Task | PRODUCT-001 — Encode AtoEnglish product truth and agent development rules |
+| Status | in progress — documentation-only pull request |
+| Goal | Make the current 28-day pilot direction discoverable and prevent agents from selecting stale cleanup or premature feature work |
 
 ## Scope
 
-This phase changes tests and cleanup documentation only. It must not move completion logic or change XP, star, guest, streak, achievement, storage, server-action, database, auth, FSRS, route, or curriculum behavior.
+This task may change only repository guidance and planning documents:
 
-## Separate known issue
+- `AGENTS.md`
+- `AGENT_PLAN.md`
+- `AGENT_BACKLOG.md`
+- `docs/product/**`
 
-The direct `/login` E2E title assertion can observe an empty document title while the route still returns HTTP 200. Track and fix that independently; it is not part of lesson completion refactoring.
+It must not change product runtime, lesson data, tests, dependencies, database, authentication, analytics, XP, FSRS, payment, or deployment behavior.
+
+## Acceptance
+
+- The target learner, 28-day promise, final speaking outcome, and evidence hierarchy are explicit.
+- Agents have one mandatory reading order and one task-contract format.
+- The active priority and deferred scope are explicit.
+- Historical cleanup tasks no longer appear as current work.
+- No runtime source or configuration changes are included.
+
+## Completed baseline
+
+The repository already contains:
+
+- aligned pilot promise;
+- baseline/final speaking assessment and rubric;
+- privacy-bounded pilot analytics;
+- Supabase security hardening;
+- a repository-owned 28-day speaking-journey contract;
+- an explicit Day 1 lesson boundary.
 
 ## Next action
 
-Review the CLEANUP-018 characterization PR. Phase 2 remains blocked until this PR is explicitly reviewed and merged.
+Review and merge this documentation reset. The next separate task is TOOLING-001: create one small verification entry point for a focused AtoEnglish curriculum slice without changing product behavior.

--- a/docs/product/CURRENT_PRIORITY.md
+++ b/docs/product/CURRENT_PRIORITY.md
@@ -1,0 +1,130 @@
+# AtoEnglish current priority
+
+**Updated:** 2026-07-24  
+**Owner:** Thunderkill016  
+**Primary roadmap:** GitHub issue #20
+
+## North star
+
+Prove that one Vietnamese adult beginner can follow a coherent 28-day, 10–15 minute-per-day journey and improve a practical work-speaking performance.
+
+Everything else is secondary until the repository can support and measure that journey.
+
+## Current phase
+
+**Phase: make AtoEnglish safe and legible for AI-assisted development, then implement the first gold lesson.**
+
+The repository already has enough application, authentication, assessment, analytics, database, and testing infrastructure for bounded curriculum work. The immediate risk is not missing platform capability. It is allowing agents to choose work that does not serve the pilot outcome.
+
+## Ordered queue
+
+### 1. Product and agent truth — in progress
+
+Establish repository-owned rules that every agent can read before proposing work:
+
+- `AGENTS.md`;
+- `docs/product/PRODUCT_TRUTH.md`;
+- this current-priority document;
+- `docs/product/DO_NOT_BUILD.md`;
+- current `AGENT_PLAN.md` and `AGENT_BACKLOG.md`.
+
+**Done when:** the repository has one discoverable product direction, stale cleanup plans no longer select work, and every future task must show how it serves the current priority.
+
+### 2. One verification entry point — next
+
+Create the smallest repository-owned verification wrapper or manifest that maps a changed surface to the checks already available.
+
+Initial goal:
+
+- preserve existing commands rather than inventing a new CI system;
+- support a focused curriculum slice first;
+- report which checks ran, passed, failed, or were unavailable;
+- distinguish technical checks from manual product review;
+- make the result usable by a coding agent and by the owner.
+
+This task must not change product behavior.
+
+### 3. Gold Day 1 lesson — after verification entry point
+
+Implement the preferred Day 1 design from `docs/curriculum/28-day-speaking-journey-contract.md`.
+
+Day 1 should cover only:
+
+- greeting;
+- name;
+- spelling a Vietnamese name;
+- one lightweight request to repeat;
+- one final spoken output using name and spelling.
+
+It must fit 10–15 minutes and must not absorb role, company, responsibility, all five questions, or full repair training.
+
+Expected scope:
+
+- `src/lib/data/units/unitA01.ts`;
+- direct targeted tests;
+- the smallest relevant lesson smoke assertion.
+
+Explicitly out of scope:
+
+- authentication;
+- database and RLS;
+- analytics infrastructure;
+- XP, streak, league, and FSRS rules;
+- major `UnitTemplate` refactor;
+- unrelated units.
+
+### 4. First-week journey — later
+
+After Day 1 is proven coherent, implement Days 2–7 as separate bounded outcomes and add checkpoint 1.
+
+Do not build all 28 days in one pull request.
+
+### 5. Pilot operations and learner evidence
+
+Recruit target learners, run baseline assessment, sell or manually administer the initial pilot, observe failure points, and build only repeated P0 blockers.
+
+## Decisions already completed
+
+- `/login` metadata defect was fixed.
+- The pilot promise was aligned across the main funnel.
+- Baseline and final speaking assessment plus rubric were defined.
+- Minimal privacy-bounded pilot analytics were added and recovered correctly.
+- Supabase security findings were hardened.
+- The 28-day journey contract and Day 1 boundary were defined.
+
+Do not reopen these decisions without new evidence.
+
+## Work selection rule
+
+A proposed task may enter the active queue only when it does at least one of the following:
+
+1. directly advances the ordered queue above;
+2. fixes a production defect blocking the pilot journey;
+3. fixes a security, privacy, or data-integrity defect;
+4. removes a repeated development blocker observed in at least two real AtoEnglish tasks.
+
+Every proposal must name the learner, product, or development blocker it resolves.
+
+## Time allocation
+
+Until the first pilot is ready:
+
+- 80–90% of effort should improve AtoEnglish and the pilot journey;
+- no more than 10–20% should improve CycleWarden or development tooling;
+- tooling work must be justified by a current AtoEnglish blocker.
+
+## Exit criteria for this phase
+
+This phase is complete when the owner can take one approved AtoEnglish task through:
+
+```text
+current priority
+→ bounded task contract
+→ approved scope
+→ coding agent implementation
+→ technical and product checks
+→ understandable review summary
+→ draft pull request
+```
+
+without writing an ad hoc manifest, losing product context, changing unrelated systems, or automatically merging or deploying.

--- a/docs/product/DO_NOT_BUILD.md
+++ b/docs/product/DO_NOT_BUILD.md
@@ -1,0 +1,118 @@
+# AtoEnglish do-not-build list
+
+**Updated:** 2026-07-24  
+**Applies until:** the focused 28-day pilot has learner, learning, and market evidence
+
+This document prevents technically attractive work from displacing the current product priority.
+
+Items below are not necessarily bad ideas. They are deferred because they do not currently provide the shortest path to validating the first learner outcome.
+
+## Product breadth
+
+Do not build yet:
+
+- a complete rebuild or expansion of the A0–B2/C1 curriculum;
+- broad interview English, travel English, or general conversation tracks;
+- a native mobile application;
+- a curriculum CMS or visual lesson editor;
+- social feeds, friend systems, clubs, or multiplayer learning;
+- more leagues, badges, achievements, streak mechanics, or XP breadth;
+- a custom payment platform;
+- complex subscriptions, entitlement systems, or pricing experiments before paid demand exists.
+
+## AI and speaking technology
+
+Do not build yet:
+
+- an open-ended AI conversation tutor;
+- unrestricted chatbot practice detached from the current lesson;
+- a proprietary speech-recognition model;
+- phoneme-level pronunciation scoring infrastructure;
+- native-accent imitation scoring;
+- autonomous curriculum generation or publication;
+- storing raw audio, transcripts, names, employers, or learner free text in analytics.
+
+Use controlled lesson tasks, existing browser capabilities, bounded feedback, immediate retry, and human assessment where they are sufficient.
+
+## Architecture and infrastructure
+
+Do not build yet:
+
+- a major rewrite of `UnitTemplate`;
+- a microservice migration;
+- a new generic workflow engine;
+- infrastructure solely for hypothetical scale;
+- a second database or event platform;
+- a new design system unrelated to pilot blockers;
+- broad dependency upgrades mixed with product work;
+- generalized abstractions without two real use cases;
+- remote sandbox infrastructure for ordinary trusted repository work;
+- automated merge or production deployment by an agent.
+
+Preserve the current modular monolith and extract only when a measured blocker requires it.
+
+## CycleWarden and developer tooling
+
+Do not expand CycleWarden with:
+
+- generic multi-agent orchestration;
+- additional coding-agent adapters before the primary Codex flow is useful on AtoEnglish;
+- enterprise RBAC, SSO, compliance mappings, or organization governance;
+- general web-research or product-research platforms;
+- release and deployment automation;
+- outcome-learning or self-improvement engines;
+- new journals, records, digests, or abstractions without a current AtoEnglish blocker;
+- work that cannot be demonstrated on a real AtoEnglish task.
+
+CycleWarden is an internal development supervisor for AtoEnglish in this phase, not a second product that competes for equal attention.
+
+## Premature measurement
+
+Do not treat these as primary proof of product value:
+
+- total registered accounts;
+- page views without speaking-task activation;
+- XP earned;
+- streak length;
+- lesson screens opened;
+- repository test counts;
+- CI success;
+- positive comments about visual design without completion or speaking evidence.
+
+The important evidence is activation, return, journey completion, speaking improvement, support cost, payment, renewal, and referral.
+
+## Scope mixing
+
+Do not combine a lesson outcome with changes to:
+
+- authentication or onboarding;
+- database schema or RLS;
+- analytics infrastructure;
+- XP, stars, streaks, leagues, achievements, or FSRS;
+- payment;
+- deployment;
+- broad architecture;
+- unrelated lessons.
+
+Create separate tasks with separate evidence.
+
+## Exception rule
+
+A deferred item may be reconsidered only when all of the following are documented:
+
+1. the exact current AtoEnglish blocker;
+2. evidence that the blocker occurred in a real learner or development flow;
+3. why an existing simpler solution is insufficient;
+4. the smallest reversible implementation;
+5. acceptance criteria and rollback plan;
+6. the systems explicitly left out of scope.
+
+Security, privacy, or data-integrity defects may bypass the normal product queue, but they still require bounded scope and verification.
+
+## Default response to new ideas
+
+When a new feature idea appears, ask:
+
+> Does this help a target learner start, complete, improve, pay for, or return to the current 28-day speaking journey?
+
+If the answer is not supported by current evidence, record the idea and continue the active priority instead of implementing it.

--- a/docs/product/PRODUCT_TRUTH.md
+++ b/docs/product/PRODUCT_TRUTH.md
@@ -1,0 +1,151 @@
+# AtoEnglish product truth
+
+**Status:** current product decision source  
+**Updated:** 2026-07-24  
+**Primary roadmap:** GitHub issue #20  
+**Journey contract:** `docs/curriculum/28-day-speaking-journey-contract.md`
+
+## What AtoEnglish is now
+
+AtoEnglish is a Vietnamese-first guided speaking product for adults who know some English but freeze when they need to speak at work.
+
+The first product is not the complete A0–B2 curriculum already present in the repository. It is one focused, measurable 28-day work-speaking pilot.
+
+## Target learner
+
+The initial learner is:
+
+- a Vietnamese adult beginner or false beginner;
+- able to recognize some common English but unable to retrieve it reliably while speaking;
+- likely to need English for a colleague, client, receptionist, interview, service, or workplace interaction;
+- willing to practice for 10–15 minutes per day;
+- better served by clear Vietnamese guidance and controlled speaking progression than by open-ended conversation.
+
+The current target segment is a product hypothesis. Interviews, paid pilot participation, completion, and learning evidence must validate it.
+
+## Product promise
+
+> In 28 days, practice 10–15 minutes per day to introduce yourself and your work, handle five predictable follow-up questions, and ask for repetition or slower speech.
+
+This promise must remain consistent across landing, onboarding, dashboard, lessons, assessment, and support communication.
+
+## Final learner outcome
+
+At the end of the pilot, the learner should be able to:
+
+1. greet and close a short workplace interaction;
+2. state and spell their name;
+3. state their role;
+4. state their company or workplace type;
+5. state one responsibility;
+6. answer five predictable questions about their work;
+7. independently ask for repetition or slower speech when needed;
+8. deliver a 30–45 second work introduction without a full-script prompt.
+
+This is a narrow product outcome, not a CEFR certification claim.
+
+## Learning model
+
+Every meaningful lesson should move through a controlled progression:
+
+```text
+real situation
+→ short comprehensible model
+→ notice useful chunks
+→ controlled retrieval
+→ supported speaking
+→ reduced prompts
+→ changed situation
+→ concise feedback
+→ immediate retry
+→ later spaced retrieval
+```
+
+Vocabulary, grammar, XP, streaks, and quizzes support this progression. They are not the final learner outcome.
+
+## Daily lesson contract
+
+A daily lesson should:
+
+- have one measurable can-do outcome;
+- fit a credible 10–15 minute session;
+- end in required spoken output;
+- use only the language needed for that task;
+- retrieve earlier chunks where relevant;
+- reduce support over time;
+- avoid showing the complete answer during the final performance;
+- give no more than one or two high-impact feedback points;
+- provide an immediate opportunity to speak again;
+- preserve an explicit fallback when browser speech capability is unavailable.
+
+## Product experience
+
+The intended learner journey is:
+
+```text
+clear promise
+→ start with minimal friction
+→ learn today's small speaking task
+→ perform the task
+→ receive understandable feedback
+→ retry
+→ see the next step
+→ return for spaced practice and the next daily outcome
+```
+
+The product must make the speaking task more important than browsing curriculum breadth or collecting points.
+
+## Evidence hierarchy
+
+Decisions should distinguish four evidence levels:
+
+1. **Repository evidence:** code, tests, docs, routes, data, and current behavior.
+2. **Usability evidence:** a learner can reach and complete the intended flow.
+3. **Learning evidence:** baseline-to-checkpoint or baseline-to-final speaking performance improves.
+4. **Market evidence:** target learners pay, complete, renew, or refer others.
+
+A technical check cannot substitute for learner or market evidence.
+
+## Existing foundation
+
+The repository already contains substantial infrastructure:
+
+- Next.js application and responsive lesson surfaces;
+- Supabase authentication, progress, migrations, and RLS;
+- 50 registered A0–B2 curriculum units;
+- vocabulary, grammar, dialogue, translation, shadowing, speaking, quiz, and review sections;
+- FSRS, XP, streak, league, progress, and guest flows;
+- baseline/final speaking assessment and rubric;
+- privacy-bounded pilot analytics;
+- Vitest, content-standard checks, production build, and Playwright smoke coverage.
+
+This foundation is available but not equivalent to a validated product. The current bottleneck is proving one coherent learner outcome.
+
+## Product boundaries
+
+Until the pilot is validated:
+
+- keep the existing 50 units available but do not treat breadth as proof of value;
+- build the 28-day journey in small, testable slices;
+- preserve the modular monolith;
+- use manual operations when they are cheaper and safer than building infrastructure;
+- collect only bounded analytics required to answer activation, completion, learning, and support questions;
+- do not store raw audio, transcripts, names, employers, or learner free text in analytics;
+- do not claim learner improvement until baseline and later performance evidence exists.
+
+## Success questions
+
+AtoEnglish must be able to answer with evidence:
+
+- who starts the first speaking task;
+- who completes it;
+- who returns after seven days;
+- who completes the 28-day journey;
+- whether speaking performance improves;
+- which lesson or UX failures block learners;
+- how much human support each learner requires;
+- whether the target learner will pay, renew, or refer another learner.
+
+## Product decision rule
+
+When choosing between building more breadth and improving the validated journey, choose the smallest change that increases the chance of obtaining trustworthy learner evidence.


### PR DESCRIPTION
## Goal

Make the current AtoEnglish product direction explicit and machine-readable before another coding task is selected.

AtoEnglish is the product. Coding agents and CycleWarden are development tools that must serve the focused 28-day work-speaking pilot rather than create a second competing roadmap.

References #20.

## What changed

- rewrote `AGENTS.md` as a product-first agent constitution while preserving the repository's Next.js, Supabase, security, curriculum, and cleanup rules
- added `docs/product/PRODUCT_TRUTH.md` with the target learner, 28-day promise, final speaking outcome, learning model, product boundaries, and evidence hierarchy
- added `docs/product/CURRENT_PRIORITY.md` with the ordered queue:
  1. product/agent truth
  2. focused verification entry point
  3. Gold Day 1 lesson
  4. first-week journey
  5. real pilot evidence
- added `docs/product/DO_NOT_BUILD.md` to defer broad curriculum expansion, open-ended AI tutoring, premature infrastructure, major architecture work, and non-blocking CycleWarden expansion
- replaced stale cleanup-era `AGENT_PLAN.md` and `AGENT_BACKLOG.md` with the current product-first work queue

## Why

The repository already has enough application, assessment, analytics, database, and testing infrastructure for bounded curriculum work. The larger risk is agents selecting technically interesting work that does not advance the validated learner outcome.

These documents create one discoverable source of truth and require future tasks to define their product outcome, allowed scope, forbidden scope, checks, manual review, and rollback.

## Impact

Documentation and planning only.

No change to:

- application runtime
- curriculum data
- authentication or route protection
- Supabase schema, migrations, functions, or RLS
- analytics
- XP, FSRS, streaks, leagues, or achievements
- dependencies, deployment, or production behavior

## Validation

- compared `agent/atoenglish-product-truth` directly against current `main`
- confirmed the diff contains exactly six documentation files
- confirmed the branch is based on current `main` and is not behind
- reviewed the new queue against issue #20 and `docs/curriculum/28-day-speaking-journey-contract.md`

Runtime checks were not run because this pull request changes no executable source, configuration, dependency, lesson data, or tests.

## Manual review

Please confirm:

- the target learner and 28-day promise are stated correctly
- the next separate task should be the focused verification entry point
- Gold Day 1 remains blocked until that verification slice exists
- the do-not-build list is appropriately strict for the first pilot
