### PR TITLE
Remove invalid gitlab-ci-local gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # testing
 /coverage
 
+# generated gitlab-ci-local cache and build worktrees
+/.gitlab-ci-local/
+
 # next.js
 /.next/
 /.next-dev/


### PR DESCRIPTION
## Mục tiêu

Loại bỏ gitlink lỗi tại `.gitlab-ci-local/builds/.docker` đang khiến GitHub Actions cảnh báo trong bước cleanup của `actions/checkout`.

## Nguyên nhân gốc

`.gitlab-ci-local/` là thư mục cache/worktree được sinh tự động bởi `gitlab-ci-local`. Một thư mục con `.docker` đã bị commit dưới dạng gitlink mode `160000`, nhưng repository không có `.gitmodules` tương ứng. Vì vậy mọi lệnh `git submodule foreach` đều báo:

```text
fatal: No url found for submodule path '.gitlab-ci-local/builds/.docker' in .gitmodules
```

## Thay đổi

- Xóa gitlink `.gitlab-ci-local/builds/.docker` khỏi Git tree.
- Thêm `/.gitlab-ci-local/` vào `.gitignore` để cache và build worktree không bị commit lại.

## Xác minh

Final head: `ee519558c6db22df5ac2259147611bc4c090120a`.

GitHub Actions Verify run `30706871231`:

- `npm ci` — pass.
- ESLint — pass.
- TypeScript — pass.
- **27 test files / 270 tests** — pass.
- Content standards **50/50** — pass.
- Post-checkout cleanup — pass.

Log checkout sau thay đổi vẫn chạy các lệnh `git submodule foreach --recursive`, nhưng không còn xuất hiện:

```text
fatal: No url found for submodule path '.gitlab-ci-local/builds/.docker' in .gitmodules
```

## Phạm vi

- Chỉ thay đổi `.gitignore` và xóa một gitlink lỗi.
- Không thay đổi application code, dependency hoặc runtime behavior.
- Không thay đổi GitLab CI configuration.
- Không tạo preview hoặc production deployment.