### PR TITLE
Align dashboard word of the day topic

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import {
   getTodayMissionFlags,
 } from "@/app/actions/stats";
 import { buildDailyMissions } from "@/lib/dashboard/daily-missions";
+import { alignWordOfDayTopic } from "@/lib/dashboard/word-of-day";
 import {
   getAllUnitCompletionStatuses,
   getCurrentUnit,
@@ -18,7 +19,7 @@ import DashboardClient from "./components/DashboardClient";
 
 export const metadata: Metadata = {
   title: "Dashboard | AtoEnglish",
-  description: "Xem tiến độ học, streak, XP và tiếp tục bài học tiếng Anh của bạn. (Rollback best version + guest self-study)",
+  description: "Xem tiến độ học, streak, XP và tiếp tục bài học tiếng Anh của bạn.",
 };
 
 // P1-1 Fix: ISR 30s — fresh enough for daily dashboard use.
@@ -160,10 +161,10 @@ export default async function DashboardPage() {
   const vnDateStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Ho_Chi_Minh" });
   const [vyear, vmonth, vday] = vnDateStr.split("-").map(Number);
   const dayIndex = vyear * 10000 + vmonth * 100 + (vday ?? 0);
-  const wordOfDay = vocabPool.length > 0
+  const selectedWord = vocabPool.length > 0
     ? vocabPool[dayIndex % vocabPool.length]
     : null;
-
+  const wordOfDay = alignWordOfDayTopic(currentUnitData.unitId, selectedWord);
 
   const weeklyData = weeklyRes.success && weeklyRes.data ? weeklyRes.data : [];
 
@@ -196,5 +197,4 @@ export default async function DashboardPage() {
       recentSpeakingSessions={recentSpeakingSessions}
     />
   );
-
 }

--- a/src/lib/dashboard/word-of-day.test.ts
+++ b/src/lib/dashboard/word-of-day.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { alignWordOfDayTopic } from "@/lib/dashboard/word-of-day";
+import type { VocabularyItem } from "@/lib/constants/vocabulary";
+
+const legacyWord: VocabularyItem = {
+  word: "name",
+  phonetic: "/neɪm/",
+  meaning_vn: "tên",
+  example_en: "My name is Minh.",
+  topic: "Bảng Chữ Cái & Âm Cơ Bản",
+  level: "A0",
+};
+
+describe("alignWordOfDayTopic", () => {
+  it("uses the canonical pilot mission title", () => {
+    expect(alignWordOfDayTopic("unit-a0-1", legacyWord)).toMatchObject({
+      word: "name",
+      topic: "Gặp đồng nghiệp mới",
+    });
+  });
+
+  it("preserves the original topic for an unknown unit", () => {
+    expect(alignWordOfDayTopic("unit-missing", legacyWord)).toEqual(legacyWord);
+  });
+
+  it("returns null when no vocabulary item exists", () => {
+    expect(alignWordOfDayTopic("unit-a0-1", null)).toBeNull();
+  });
+});

--- a/src/lib/dashboard/word-of-day.ts
+++ b/src/lib/dashboard/word-of-day.ts
@@ -1,0 +1,23 @@
+import { UNITS } from "@/lib/constants/units";
+import type { VocabularyItem } from "@/lib/constants/vocabulary";
+
+const UNIT_TITLE_PREFIX = /^(?:Bài|Unit)\s+[^:]+:\s*/u;
+
+/**
+ * Replace legacy vocabulary topic labels with the canonical title of the unit
+ * currently shown across dashboard, roadmap and lesson surfaces.
+ */
+export function alignWordOfDayTopic(
+  unitId: string,
+  word: VocabularyItem | null | undefined,
+): VocabularyItem | null {
+  if (!word) return null;
+
+  const canonicalTitle = UNITS.find((unit) => unit.id === unitId)?.title;
+  if (!canonicalTitle) return word;
+
+  return {
+    ...word,
+    topic: canonicalTitle.replace(UNIT_TITLE_PREFIX, ""),
+  };
+}

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -8,6 +8,7 @@ export default defineProject({
     globals: true,
     include: [
       "scripts/lib/**/*.test.ts",
+      "src/lib/dashboard/word-of-day.test.ts",
       "src/__tests__/architecture-boundaries.test.ts",
       "src/__tests__/curriculum-quality.test.ts",
       "src/__tests__/learning-attempt-migration.test.ts",


### PR DESCRIPTION
## Mục tiêu

Hoàn tất Product Acceptance cho preview learning core bằng cách loại bỏ nhãn curriculum cũ còn sót trong thẻ “Từ hôm nay”.

## Nguyên nhân gốc

Dashboard đã dùng metadata canonical cho bài học, roadmap và daily mission, nhưng `wordOfDay.topic` vẫn được lấy trực tiếp từ `UNIT_VOCABULARY`, nơi các topic A0 pilot vẫn mang nhãn curriculum cũ.

## Thay đổi

- Thêm helper `alignWordOfDayTopic` để phủ topic bằng tên unit canonical.
- Giữ nguyên word, phonetic, nghĩa và câu ví dụ.
- Dọn chuỗi mô tả SEO nội bộ bị sót khỏi dashboard metadata.
- Thêm 3 regression tests cho pilot, unit không xác định và dữ liệu rỗng.

## Xác minh

Final head: `ce512f91e3d9dee516cc15a16724277925705af4`.

GitHub Actions Verify run `30708300183`:

- `npm ci` — pass.
- ESLint — pass.
- TypeScript — pass.
- **31 test files / 280 tests** — pass.
- Word-of-day regression — **3/3 pass**.
- Content standards — **50/50 pass**.

## Phạm vi

- Không thay đổi mission logic, từ vựng, database hoặc persistence.
- Không deploy production.
- Sau merge, branch `preview/learning-core` được cập nhật để xác minh lại route và runtime logs.