### PR TITLE
feat: add complete core plus free-source fallback lanes

### DIFF
--- a/docs/curriculum/FREE_AND_OPEN_VIDEO_SOURCES.md
+++ b/docs/curriculum/FREE_AND_OPEN_VIDEO_SOURCES.md
@@ -1,0 +1,176 @@
+# Free and open video source fallbacks
+
+Status: current source-discovery policy, 2026-08-02.
+
+## Product decision
+
+YouTube is not the only authentic-video source.
+
+When YouTube does not contain a suitable or usable example, Source Discovery continues through a ranked set of free, open, government, archival, or AtoEnglish-owned sources.
+
+```text
+usable YouTube source
+→ Wikimedia Commons
+→ DVIDS and other government media
+→ Library of Congress free-to-use collections
+→ NASA media when the communicative context fits
+→ Pexels or Pixabay for visual context with owned audio/dialogue
+→ AtoEnglish-owned capture for measured curriculum gaps
+```
+
+This order is a discovery heuristic, not an automatic rights decision.
+
+## Core selection rule
+
+A source is selected because it supplies a useful communicative event, not because it is free, famous, or visually attractive.
+
+For the first A0 slice, a useful source should provide one or more of:
+
+- a real greeting and response;
+- a speaker saying a name;
+- a genuine name question and answer;
+- a genuine origin question and answer;
+- a clarification or repetition repair sequence;
+- a short multi-turn exchange that can support transfer.
+
+Silent stock footage does not count as an authentic listening clip. It may provide a visual setting for dialogue or narration that AtoEnglish owns.
+
+## Source classes
+
+### Wikimedia Commons
+
+Use as a high-priority open-media discovery source.
+
+Commons accepts public-domain or freely licensed media that permits commercial reuse and derivatives, but each file has its own requirements. File-level license, author, attribution, source provenance, personality rights, and ShareAlike compatibility must be reviewed.
+
+Preferred item rights:
+
+- public domain;
+- CC0;
+- CC BY.
+
+CC BY-SA remains conditional because adaptations may need to be distributed under a compatible ShareAlike license.
+
+Official guidance:
+
+- <https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia>
+- <https://commons.wikimedia.org/wiki/Commons:Licensing>
+
+### DVIDS
+
+Use for real interviews, varied speakers, briefings, and unscripted government footage.
+
+Government-created visual information is often not eligible for U.S. copyright protection, but DVIDS warns that individual items may include third-party material. Privacy, publicity, military marks, commercial presentation, and non-endorsement also require review.
+
+DVIDS is useful for names and introductions but should not dominate the corpus because broadcast interviews contain little conversational repair.
+
+Official guidance:
+
+- <https://www.dvidshub.net/about/copyright>
+
+### Library of Congress
+
+Use free-to-use collections and item records as archival candidates.
+
+The Library identifies collections and sets that it believes are public domain, have no known copyright, or have been cleared, but users must consult collection and item rights statements. Some works remain restricted or affected by privacy, publicity, trademark, foreign copyright, or donor conditions.
+
+Historical footage also requires pedagogical review for audio quality, dated language, social norms, and practical relevance.
+
+Official guidance:
+
+- <https://www.loc.gov/free-to-use/>
+- <https://www.loc.gov/collections/national-screening-room/about-this-collection/rights-and-access/>
+
+### NASA media
+
+Use only when a NASA interview or mission context supplies a genuinely useful communication pattern.
+
+NASA media is generally available for factual educational or informational use under NASA's guidelines, but logos, identifiers, endorsement, depicted people, and third-party material need separate checks. Technical radio speech is not automatically suitable for A0 conversation.
+
+Official guidance:
+
+- <https://www.nasa.gov/nasa-brand-center/images-and-media/>
+
+### Pexels
+
+Use primarily for visual settings, AtoEnglish-owned narration, role-play backgrounds, and transfer prompts.
+
+Pexels permits free use and modification under its license, including commercial projects, but it restricts standalone redistribution and misleading or endorsement-related use. Recognizable people, brands, and other third-party rights still require review.
+
+A Pexels video is not accepted as an authentic listening source unless useful synchronized English dialogue and its reuse basis are manually verified.
+
+Official guidance:
+
+- <https://www.pexels.com/legal-pages/license/>
+
+### Pixabay
+
+Use primarily as another context and owned-dialogue fallback.
+
+The Pixabay license generally permits free use and adaptation subject to prohibited uses, including restrictions on standalone distribution and some uses involving trademarks, recognizable people, and misleading presentation.
+
+As with Pexels, visually suitable stock footage does not satisfy authentic-audio coverage by itself.
+
+Official guidance:
+
+- <https://pixabay.com/service/license-summary/>
+
+### Openverse
+
+Use only as a discovery index.
+
+Openverse indexes open and public-domain media from other repositories but says it does not verify the license or attribution of each work. Video search may also redirect to external sources. The original repository and item record must become the provenance source.
+
+Official guidance:
+
+- <https://openverse.org/about/>
+
+## Item-level acceptance gate
+
+No library-level description creates blanket permission.
+
+Every candidate must pass:
+
+1. exact item identity and original-source verification;
+2. license and intended-use compatibility;
+3. attribution requirements;
+4. third-party material review;
+5. privacy and publicity review;
+6. trademark and endorsement review;
+7. playback and audio review;
+8. transcript and speaker review;
+9. exact timestamp review;
+10. pedagogical fit and curriculum-role review.
+
+The item can then become one of:
+
+- `licensed_core_candidate`;
+- `youtube_companion_candidate`;
+- `visual_context_only`;
+- `discovery_only`;
+- `rejected`.
+
+## Gap-filling rule
+
+When an essential capability still lacks enough licensed authentic clips after external discovery:
+
+1. preserve the complete knowledge and activity design;
+2. identify the exact missing variant, speaker, or interaction;
+3. record a short unscripted or lightly prompted AtoEnglish-owned exchange;
+4. obtain participant consent and release;
+5. review transcript, timing, naturalness, and pedagogical fit;
+6. use external companion media later for additional variety.
+
+This prevents the curriculum from becoming either incomplete or dependent on low-quality stock footage.
+
+## Pilot hypotheses
+
+The following remain hypotheses to test, not standards:
+
+- this source order minimizes curation cost;
+- Wikimedia and government archives can supply enough varied A0 speakers;
+- stock libraries are more useful for context than listening input;
+- owned gap-filling capture will be required mainly for repair and multi-turn interaction;
+- learners benefit from mixing licensed core clips with optional companion media.
+
+The registry and order must be revised after measuring candidate yield, rejection reasons, authoring time, and learner transfer.

--- a/docs/curriculum/TWO_LANE_CONTENT_MODEL.md
+++ b/docs/curriculum/TWO_LANE_CONTENT_MODEL.md
@@ -1,0 +1,121 @@
+# AtoEnglish two-lane content model
+
+Status: owner-approved product decision, 2026-08-02.
+
+## Decision
+
+AtoEnglish uses two content lanes with different responsibilities and permission boundaries.
+
+```text
+Licensed Curriculum = complete learning and assessment core
+YouTube Companion   = optional authentic exposure and learner choice
+```
+
+The lanes may appear in one learner journey, but they are never interchangeable.
+
+## Non-negotiable completeness rule
+
+A communicative capability must be fully teachable and assessable without any YouTube Companion item.
+
+The licensed core must provide:
+
+1. communicative meaning and appropriate use;
+2. reusable formulaic chunks;
+3. the minimum grammar patterns needed to adapt those chunks;
+4. natural-speech features needed to recognize the language;
+5. interaction strategies such as turn-taking, clarification, confirmation, and repair;
+6. pragmatics, politeness, and register;
+7. common risks for Vietnamese learners;
+8. comprehension activities;
+9. productive retrieval;
+10. personal or multi-turn use;
+11. changed-context and unseen-input transfer;
+12. delayed evidence and review.
+
+A capability cannot be published when any required knowledge category is empty or when the licensed core fails its curriculum publication gates.
+
+## Lane 1: Licensed Curriculum
+
+Eligible sources are owned, public-domain, CC BY, or covered by permission that allows the exact intended uses.
+
+This lane may contain:
+
+- stored and reviewed transcripts;
+- timestamped Communication Clips;
+- Vietnamese translations;
+- source-language normalization;
+- gap-fill, reconstruction, shadowing, and active recall;
+- derived explanations and examples;
+- FSRS review items;
+- speaking tasks and transfer assessment.
+
+Its existing source, transcript, treatment, coverage, and publication gates remain unchanged.
+
+## Lane 2: YouTube Companion
+
+This lane uses the official YouTube player for optional authentic exposure when AtoEnglish does not hold transcript or derivative-use rights.
+
+It may contain:
+
+- the official watch and embed URLs;
+- creator and title metadata;
+- a reviewed start point or viewing window;
+- accent, topic, context, and capability tags;
+- general pre-watch, gist, observation, and personal-reaction prompts;
+- learner choice among a small prerequisite-safe set.
+
+It must not contain or perform:
+
+- downloaded or cached video/audio;
+- extracted or scraped captions;
+- ASR run on media obtained from YouTube;
+- stored transcript or line-by-line translation;
+- verbatim gap-fill or reconstruction derived from the video;
+- self-hosting or detached clips;
+- removal or concealment of YouTube branding and controls;
+- use as evidence that the licensed curriculum core is complete.
+
+A companion activity is deliberately generic: it can ask what the speaker is trying to do, what relationship or setting is visible, or how the learner would respond. It cannot require AtoEnglish to store the video's wording.
+
+## Learner journey
+
+A complete capability may be presented as:
+
+```text
+licensed anchor lesson
+→ licensed retrieval and speaking practice
+→ licensed interaction treatment
+→ optional YouTube Companion choices
+→ licensed cold-transfer assessment
+→ delayed review
+```
+
+The companion lane adds speaker, setting, accent, and topic variability. It does not carry required explanations, target answers, mastery evidence, or advancement gates.
+
+## Selection policy
+
+For a learner-facing companion item:
+
+- the video must remain embeddable through the official player;
+- title, creator, video ID, and URLs must be reviewed;
+- the capability must already exist in the licensed curriculum;
+- the learner must satisfy that capability's prerequisites;
+- the item must declare why it adds value: exposure, context, interest, speaker variability, or challenge;
+- no companion may unlock the next capability by itself.
+
+## Failure behavior
+
+If a companion video is removed, blocked, made private, or has embedding disabled:
+
+- retire the companion record;
+- preserve the licensed lesson and learner progression;
+- do not fail the capability or remove acquired evidence;
+- offer another optional companion when available.
+
+## Product consequence
+
+AtoEnglish can offer broad and interesting YouTube choice without making lesson completeness dependent on unlicensed transcripts.
+
+The promise to the learner is therefore:
+
+> The core teaches everything required to understand, retrieve, use, and retain the capability. YouTube Companion items provide additional real-world voices and situations.

--- a/docs/curriculum/TWO_LANE_CONTENT_MODEL.md
+++ b/docs/curriculum/TWO_LANE_CONTENT_MODEL.md
@@ -112,6 +112,37 @@ If a companion video is removed, blocked, made private, or has embedding disable
 - do not fail the capability or remove acquired evidence;
 - offer another optional companion when available.
 
+## Authority and interpretation
+
+This model combines external constraints with AtoEnglish product rules. They must not be confused.
+
+### Official platform constraints
+
+- YouTube IFrame Player API documents official embedded playback: <https://developers.google.com/youtube/iframe_api_reference>
+- YouTube captions API documents caption-list and download authorization boundaries: <https://developers.google.com/youtube/v3/docs/captions>
+- YouTube API Services policy governs use of player and API data: <https://developers.google.com/youtube/terms/developer-policies>
+
+These sources support using the official player and treating caption access as permission-sensitive. They do not by themselves define AtoEnglish's complete conservative companion policy.
+
+### Learning-framework alignment
+
+- CEFR action-oriented classroom guidance supports aligning capabilities, learning activities, and assessment around what learners can do: <https://www.coe.int/en/web/common-european-framework-reference-languages/cefr-in-the-classroom>
+
+CEFR does not prescribe the seven knowledge categories or the two-lane architecture. Those are AtoEnglish's product implementation of coherent teaching and assessment.
+
+### Internal product rules
+
+The following are explicit AtoEnglish rules, not international standards:
+
+- the licensed core must remain complete when every companion is removed;
+- companions contribute no mastery evidence;
+- every first-slice capability must cover all seven knowledge categories;
+- companion prompts remain transcript-free;
+- companion availability cannot block learner progression;
+- the exact number of companion choices will be tested during the pilot.
+
+These rules may change only through an explicit owner decision supported by source, learner, or operational evidence.
+
 ## Product consequence
 
 AtoEnglish can offer broad and interesting YouTube choice without making lesson completeness dependent on unlicensed transcripts.

--- a/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.test.ts
+++ b/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import { FIRST_A0_CAPABILITIES } from "@/features/curriculum-compiler/data/first-a0-capabilities";
 import { FIRST_A0_KNOWLEDGE_COVERAGE } from "@/features/curriculum-compiler/data/first-a0-knowledge-coverage";
+import type { CapabilityKnowledgeCoverage } from "@/features/curriculum-compiler/domain/content-lanes";
+
+const KNOWLEDGE_FIELDS: Array<keyof CapabilityKnowledgeCoverage> = [
+  "meaningAndUse",
+  "formulaicChunks",
+  "grammarPatterns",
+  "speechFeatures",
+  "interactionStrategies",
+  "pragmaticsAndRegister",
+  "vietnameseLearnerRisks",
+];
 
 describe("First A0 knowledge coverage", () => {
   it("covers every first-slice capability exactly once", () => {
@@ -14,9 +25,10 @@ describe("First A0 knowledge coverage", () => {
 
   it("contains reviewed instructional content in every required category", () => {
     for (const plan of FIRST_A0_KNOWLEDGE_COVERAGE) {
-      for (const values of Object.values(plan.knowledge)) {
+      for (const field of KNOWLEDGE_FIELDS) {
+        const values = plan.knowledge[field];
         expect(values.length).toBeGreaterThan(0);
-        expect(values.every((value) => value.trim().length > 0)).toBe(true);
+        expect(values.every((value: string) => value.trim().length > 0)).toBe(true);
       }
     }
   });

--- a/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.test.ts
+++ b/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { FIRST_A0_CAPABILITIES } from "@/features/curriculum-compiler/data/first-a0-capabilities";
+import { FIRST_A0_KNOWLEDGE_COVERAGE } from "@/features/curriculum-compiler/data/first-a0-knowledge-coverage";
+
+describe("First A0 knowledge coverage", () => {
+  it("covers every first-slice capability exactly once", () => {
+    const capabilityIds = FIRST_A0_CAPABILITIES.map((capability) => capability.id).sort();
+    const planIds = FIRST_A0_KNOWLEDGE_COVERAGE.map((plan) => plan.capabilityId).sort();
+
+    expect(planIds).toEqual(capabilityIds);
+    expect(new Set(planIds).size).toBe(planIds.length);
+  });
+
+  it("contains reviewed instructional content in every required category", () => {
+    for (const plan of FIRST_A0_KNOWLEDGE_COVERAGE) {
+      for (const values of Object.values(plan.knowledge)) {
+        expect(values.length).toBeGreaterThan(0);
+        expect(values.every((value) => value.trim().length > 0)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.ts
+++ b/src/features/curriculum-compiler/data/first-a0-knowledge-coverage.ts
@@ -1,0 +1,190 @@
+import type { CapabilityKnowledgeCoverage } from "@/features/curriculum-compiler/domain/content-lanes";
+
+export interface FirstA0KnowledgePlan {
+  capabilityId: string;
+  knowledge: CapabilityKnowledgeCoverage;
+}
+
+/**
+ * Required knowledge for the first five A0 capabilities.
+ *
+ * This is the instructional core. Authentic clips provide evidence and examples,
+ * but no source is allowed to silently define or narrow what the learner must know.
+ */
+export const FIRST_A0_KNOWLEDGE_COVERAGE: FirstA0KnowledgePlan[] = [
+  {
+    capabilityId: "a0.greet_someone",
+    knowledge: {
+      meaningAndUse: [
+        "Mở một tương tác ngắn và cho người đối diện biết mình sẵn sàng giao tiếp.",
+        "Nhận ra lời chào và đáp lại thay vì chỉ hiểu thụ động.",
+      ],
+      formulaicChunks: [
+        "Hi.",
+        "Hello.",
+        "Good morning.",
+        "Hi, nice to meet you.",
+      ],
+      grammarPatterns: [
+        "Greeting + name or introduction chunk.",
+        "Good + time-of-day noun for time-sensitive greetings.",
+      ],
+      speechFeatures: [
+        "Ngữ điệu thân thiện và trọng âm chính trên từ chào.",
+        "Nhận ra Hi và Hello ở tốc độ tự nhiên, kể cả khi rất ngắn.",
+      ],
+      interactionStrategies: [
+        "Đáp lại lời chào trong một lượt ngắn rồi cho phép hội thoại tiếp tục.",
+        "Kết hợp lời chào với tên khi cần mở đầu phần giới thiệu.",
+      ],
+      pragmaticsAndRegister: [
+        "Hi thường thân mật hơn Hello; Good morning phù hợp ngữ cảnh trung tính hoặc lịch sự.",
+        "Không cần kéo dài câu trả lời khi tình huống chỉ yêu cầu một lời chào ngắn.",
+      ],
+      vietnameseLearnerRisks: [
+        "Hiểu lời chào nhưng im lặng vì cố tạo một câu trả lời dài hoàn hảo.",
+        "Dùng Good morning không đúng thời điểm hoặc dùng Hello everyone khi chỉ nói với một người.",
+      ],
+    },
+  },
+  {
+    capabilityId: "a0.say_ones_name",
+    knowledge: {
+      meaningAndUse: [
+        "Cung cấp tên để người đối diện biết cách gọi mình trong phần mở đầu hội thoại.",
+        "Chọn cách giới thiệu ngắn phù hợp thay vì dịch từng từ từ tiếng Việt.",
+      ],
+      formulaicChunks: [
+        "I'm Minh.",
+        "My name's Minh.",
+        "You can call me Minh.",
+      ],
+      grammarPatterns: [
+        "I am / I'm + name.",
+        "My name is / My name's + name.",
+        "You can call me + preferred name.",
+      ],
+      speechFeatures: [
+        "Nhận ra và sử dụng contraction I'm và name's.",
+        "Nối mượt I'm với tên riêng nhưng vẫn phát âm tên đủ rõ.",
+      ],
+      interactionStrategies: [
+        "Chào trước, nói tên, rồi dừng để người kia có lượt phản hồi.",
+        "Lặp hoặc đánh vần tên khi người nghe chưa hiểu.",
+      ],
+      pragmaticsAndRegister: [
+        "Dùng tên gọi mong muốn trong giao tiếp; dùng đầy đủ họ tên khi bối cảnh chính thức yêu cầu.",
+        "You can call me hữu ích khi tên pháp lý và tên thường gọi khác nhau.",
+      ],
+      vietnameseLearnerRisks: [
+        "Nói I name Minh hoặc I am name Minh do thiếu mẫu cố định với động từ be.",
+        "Đọc chậm từng từ My name is thay vì truy xuất cả cụm như một đơn vị.",
+      ],
+    },
+  },
+  {
+    capabilityId: "a0.ask_others_name",
+    knowledge: {
+      meaningAndUse: [
+        "Yêu cầu người đối diện cho biết tên và chuẩn bị nghe một câu trả lời ngắn.",
+        "Dùng câu hỏi tên để tạo trao đổi hai chiều, không chỉ độc thoại giới thiệu bản thân.",
+      ],
+      formulaicChunks: [
+        "What's your name?",
+        "And you?",
+        "May I ask your name?",
+      ],
+      grammarPatterns: [
+        "What is / What's + possessive adjective + noun?",
+        "And + pronoun? as a short reciprocal question after giving personal information.",
+      ],
+      speechFeatures: [
+        "Nhận ra What's your ở dạng nối và giảm âm tự nhiên.",
+        "Dùng ngữ điệu câu hỏi rõ nhưng không kéo cao quá mức ở mọi từ.",
+      ],
+      interactionStrategies: [
+        "Giới thiệu tên mình trước rồi hỏi tên người khác khi điều đó làm câu hỏi tự nhiên hơn.",
+        "Nghe tên, xác nhận hoặc dùng lại tên trong phản hồi tiếp theo.",
+      ],
+      pragmaticsAndRegister: [
+        "What's your name? phù hợp nhiều tình huống nhưng có thể trực diện; May I ask your name? lịch sự hơn.",
+        "And you? chỉ rõ nghĩa khi ngữ cảnh trước đó đã thiết lập loại thông tin đang trao đổi.",
+      ],
+      vietnameseLearnerRisks: [
+        "Nói What your name? và bỏ động từ is.",
+        "Hỏi được tên nhưng không nghe hoặc không phản hồi vì chỉ tập trung nhớ câu hỏi.",
+      ],
+    },
+  },
+  {
+    capabilityId: "a0.say_where_from",
+    knowledge: {
+      meaningAndUse: [
+        "Nói quê quán hoặc nơi xuất thân khi được hỏi trong phần giới thiệu cơ bản.",
+        "Phân biệt nơi mình đến từ với nơi hiện đang sống khi bối cảnh cần rõ ràng.",
+      ],
+      formulaicChunks: [
+        "I'm from Vietnam.",
+        "I'm from Hanoi, Vietnam.",
+        "I come from Vietnam.",
+      ],
+      grammarPatterns: [
+        "I am / I'm + from + place.",
+        "I come + from + place.",
+        "Where are you from? as the common prompt that triggers this answer.",
+      ],
+      speechFeatures: [
+        "Nhận ra from ở dạng yếu trong I'm from và trọng âm rơi vào tên địa điểm.",
+        "Nối âm giữa I'm và from mà không bỏ mất động từ be.",
+      ],
+      interactionStrategies: [
+        "Trả lời bằng một địa điểm đủ cụ thể cho ngữ cảnh rồi có thể hỏi lại And you?.",
+        "Làm rõ city hoặc country khi người nghe chưa biết địa danh.",
+      ],
+      pragmaticsAndRegister: [
+        "I'm from thường nói về nguồn gốc; I live in nói về nơi ở hiện tại và không nên trộn hai ý.",
+        "Có thể thêm city, country để tránh mơ hồ trong hội thoại quốc tế.",
+      ],
+      vietnameseLearnerRisks: [
+        "Nói I from Vietnam và bỏ động từ am.",
+        "Nói I'm come from Vietnam do trộn hai cấu trúc đúng thành một cấu trúc sai.",
+      ],
+    },
+  },
+  {
+    capabilityId: "a0.request_repetition",
+    knowledge: {
+      meaningAndUse: [
+        "Giữ hội thoại tiếp tục khi không nghe rõ hoặc chưa hiểu thông tin vừa được nói.",
+        "Báo hiệu vấn đề nghe hiểu thay vì giả vờ đã hiểu.",
+      ],
+      formulaicChunks: [
+        "Could you say that again?",
+        "Could you repeat that?",
+        "Sorry, what was that?",
+        "I didn't catch that.",
+      ],
+      grammarPatterns: [
+        "Could you + base verb + object?",
+        "I did not / didn't + base verb + object.",
+        "What was + demonstrative pronoun? as a short repair question.",
+      ],
+      speechFeatures: [
+        "Nhận ra weak form của could và dạng nối trong could you.",
+        "Dùng trọng âm trên say, repeat, again hoặc catch để làm rõ mục đích repair.",
+      ],
+      interactionStrategies: [
+        "Báo hiệu vấn đề, yêu cầu nhắc lại, nghe lần hai và xác nhận thông tin.",
+        "Chuyển sang yêu cầu nói chậm hoặc xác nhận lựa chọn khi lặp lại vẫn chưa đủ.",
+      ],
+      pragmaticsAndRegister: [
+        "Sorry giúp giảm độ trực diện; Could you... phù hợp ngữ cảnh trung tính và lịch sự.",
+        "Again? có thể hiểu được nhưng quá ngắn trong nhiều tình huống dịch vụ hoặc công việc.",
+      ],
+      vietnameseLearnerRisks: [
+        "Im lặng hoặc trả lời đại khi không nghe rõ vì sợ làm gián đoạn hội thoại.",
+        "Học thuộc một câu duy nhất nhưng không nhận ra các biến thể tự nhiên từ người nói khác.",
+      ],
+    },
+  },
+];

--- a/src/features/curriculum-compiler/domain/content-lanes.test.ts
+++ b/src/features/curriculum-compiler/domain/content-lanes.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ClipRole,
+  ClipTreatment,
+  CommunicationClip,
+  CommunicativeCapability,
+  CurriculumPackage,
+  LearningActivity,
+  SourceAsset,
+  TranscriptSegment,
+} from "@/features/curriculum-compiler/domain/contracts";
+import {
+  canPublishCapabilityLearningBundle,
+  type CapabilityLearningBundle,
+  type CapabilityLearningSpecification,
+  type YouTubeCompanionAsset,
+  type YouTubeCompanionUsagePolicy,
+  validateCapabilityLearningBundle,
+  YOUTUBE_COMPANION_USAGE_POLICY,
+} from "@/features/curriculum-compiler/domain/content-lanes";
+
+const CAPABILITY: CommunicativeCapability = {
+  id: "a0.request_repetition",
+  level: "A0",
+  canDoVi: "Tôi có thể yêu cầu người khác nhắc lại khi không nghe rõ.",
+  canDoEn: "I can ask someone to repeat when I do not hear clearly.",
+  recommendedOrder: 1,
+  prerequisiteIds: [],
+  communicativeFunctions: ["requesting_repetition", "repairing_misunderstanding"],
+  evidencePolicy: {
+    requiresComprehension: true,
+    requiresProductiveRecall: true,
+    requiresInteractionalUse: true,
+    requiresDelayedTransfer: true,
+    minimumDistinctClips: 3,
+    minimumDistinctSpeakers: 3,
+  },
+};
+
+function createSource(index: number): SourceAsset {
+  return {
+    id: `source-${index}`,
+    provider: "youtube",
+    title: `Authorized repair conversation ${index}`,
+    creator: `Creator ${index}`,
+    sourceUrl: `https://www.youtube.com/watch?v=licensed-${index}`,
+    mediaUrl: `https://www.youtube.com/embed/licensed-${index}`,
+    mediaAccess: "youtube_embed",
+    durationMs: 20_000,
+    language: "en",
+    rights: {
+      basis: "written_permission",
+      status: "human_verified",
+      evidenceUrl: `https://example.com/rights/source-${index}`,
+      reviewedBy: "content-editor",
+      reviewedAt: "2026-08-02T07:30:00.000Z",
+      attribution: `Authorized repair conversation ${index} by Creator ${index}`,
+      requiresAttribution: true,
+      allowedUses: {
+        canEmbed: true,
+        canStoreTranscript: true,
+        canRunAsr: true,
+        canCreateDerivedLesson: true,
+        canSelfHostMedia: false,
+        canUseCommercially: true,
+      },
+    },
+    transcriptProvenance: "creator_provided",
+    transcriptSourceUrl: `https://example.com/transcripts/source-${index}`,
+    publicationStatus: "pilot",
+  };
+}
+
+function createSegment(index: number): TranscriptSegment {
+  return {
+    id: `segment-${index}`,
+    sourceAssetId: `source-${index}`,
+    speakerId: `speaker-${index}`,
+    startMs: 1_000,
+    endMs: 5_000,
+    sourceText: "Sorry, could you say that again?",
+    displayText: "Sorry, could you say that again?",
+    translationVi: "Xin lỗi, bạn có thể nói lại được không?",
+    transcriptStatus: "human_verified",
+    translationStatus: "human_verified",
+  };
+}
+
+function createClip(index: number): CommunicationClip {
+  return {
+    id: `clip-${index}`,
+    sourceAssetId: `source-${index}`,
+    segmentIds: [`segment-${index}`],
+    startMs: 1_000,
+    endMs: 5_000,
+    primaryCapabilityId: CAPABILITY.id,
+    secondaryCapabilityIds: [],
+    lexicalItems: ["say that again"],
+    grammarPatterns: ["Could you + verb"],
+    speechFeatures: ["linking", "weak_forms"],
+    context: {
+      relationship: "coworkers",
+      setting: "workplace",
+      formality: "neutral",
+      channel: "in_person",
+    },
+    reviewStatus: "human_verified",
+    publicationStatus: "pilot",
+  };
+}
+
+function createActivities(index: number, role: ClipRole): LearningActivity[] {
+  const evidenceSegmentIds = [`segment-${index}`];
+  const targetItems = ["Could you say that again?"];
+
+  return [
+    {
+      id: `activity-${index}-gist`,
+      layer: "comprehension",
+      kind: "gist_choice",
+      promptVi: "Người nói đang yêu cầu điều gì?",
+      evidenceSegmentIds,
+      targetItems,
+      requiresRetrieval: false,
+      requiresLearnerProduction: false,
+      exposesFullAnswer: false,
+      changedContext: false,
+      unseenInput: false,
+    },
+    {
+      id: `activity-${index}-recall`,
+      layer: "acquisition",
+      kind: "productive_recall",
+      promptVi: "Không nhìn mẫu, hãy yêu cầu người đối diện nói lại.",
+      evidenceSegmentIds,
+      targetItems,
+      requiresRetrieval: true,
+      requiresLearnerProduction: true,
+      exposesFullAnswer: false,
+      changedContext: false,
+      unseenInput: false,
+    },
+    {
+      id: `activity-${index}-transfer`,
+      layer: "transfer",
+      kind:
+        role === "interaction"
+          ? "multi_turn_interaction"
+          : role === "cold_transfer"
+            ? "unseen_speaker_response"
+            : "personal_response",
+      promptVi: "Phản hồi phù hợp trong tình huống mới.",
+      evidenceSegmentIds,
+      targetItems,
+      requiresRetrieval: true,
+      requiresLearnerProduction: true,
+      exposesFullAnswer: false,
+      changedContext: true,
+      unseenInput: role === "cold_transfer",
+    },
+  ];
+}
+
+function createTreatment(index: number, role: ClipRole): ClipTreatment {
+  return {
+    id: `treatment-${index}`,
+    clipId: `clip-${index}`,
+    level: "A0",
+    targetCapabilityId: CAPABILITY.id,
+    requiredCapabilityIds: [],
+    role,
+    learnerChoice: {
+      titleVi: `Yêu cầu nhắc lại ${index}`,
+      summaryVi: "Luyện phản ứng khi nghe không rõ với một người nói khác.",
+      difficulty: role === "cold_transfer" ? "stretch" : "core",
+      estimatedMinutes: 8,
+      accentTags: [`speaker-${index}`],
+      topicTags: ["repair", "workplace"],
+    },
+    activities: createActivities(index, role),
+    supportPolicy: {
+      initialCaption: role === "anchor" ? "bilingual" : "none",
+      finalAttemptCaption: "none",
+      allowSlowPlayback: true,
+      scaffoldOrder: [
+        "replay",
+        "context_hint",
+        "keyword_hint",
+        "english_caption",
+        "chunking",
+        "vietnamese_meaning",
+        "slow_playback",
+      ],
+    },
+    reviewStatus: "human_verified",
+    publicationStatus: "pilot",
+  };
+}
+
+function createCoreCurriculum(): CurriculumPackage {
+  const roles: ClipRole[] = ["anchor", "interaction", "cold_transfer"];
+  return {
+    id: "a0-repetition-core",
+    version: "1.0.0",
+    titleVi: "Lõi học yêu cầu nhắc lại",
+    capabilities: [structuredClone(CAPABILITY)],
+    sourceAssets: roles.map((_, index) => createSource(index + 1)),
+    transcriptSegments: roles.map((_, index) => createSegment(index + 1)),
+    clips: roles.map((_, index) => createClip(index + 1)),
+    treatments: roles.map((role, index) => createTreatment(index + 1, role)),
+    publicationStatus: "pilot",
+  };
+}
+
+function createSpecification(): CapabilityLearningSpecification {
+  return {
+    capabilityId: CAPABILITY.id,
+    knowledge: {
+      meaningAndUse: ["Dùng khi không nghe hoặc không hiểu rõ thông tin vừa được nói."],
+      formulaicChunks: [
+        "Could you say that again?",
+        "Sorry, what was that?",
+      ],
+      grammarPatterns: ["Could you + base verb + object?"],
+      speechFeatures: ["Weak form của could và nối âm trong could you."],
+      interactionStrategies: [
+        "Báo hiệu vấn đề, yêu cầu nhắc lại, nghe lại và xác nhận.",
+      ],
+      pragmaticsAndRegister: [
+        "Mở đầu bằng Sorry để giảm độ trực diện trong ngữ cảnh trung tính.",
+      ],
+      vietnameseLearnerRisks: [
+        "Không chỉ nói Again? trong bối cảnh cần lịch sự hoặc rõ mục đích.",
+      ],
+    },
+    coreTreatmentIds: ["treatment-1", "treatment-2", "treatment-3"],
+    companionAssetIds: ["companion-1"],
+  };
+}
+
+function createCompanion(): YouTubeCompanionAsset {
+  return {
+    id: "companion-1",
+    youtubeVideoId: "abc123DEF45",
+    title: "Natural conversation repair example",
+    creator: "Example Creator",
+    watchUrl: "https://www.youtube.com/watch?v=abc123DEF45",
+    embedUrl: "https://www.youtube-nocookie.com/embed/abc123DEF45",
+    capabilityIds: [CAPABILITY.id],
+    purpose: "speaker_variability",
+    accentTags: ["american-english"],
+    topicTags: ["repair", "daily-conversation"],
+    startSeconds: 20,
+    endSeconds: 70,
+    embedStatus: "embed_verified",
+    usagePolicy: structuredClone(YOUTUBE_COMPANION_USAGE_POLICY),
+    activities: [
+      {
+        id: "companion-activity-1",
+        kind: "communicative_intent_spotting",
+        promptVi: "Hãy xác định lúc nào một người gặp vấn đề nghe hiểu và họ xử lý ra sao.",
+        learningPurpose: "Nhận ra hành vi repair trong một giọng nói và bối cảnh mới.",
+        requiresTranscript: false,
+        storesSourceText: false,
+        contributesToMastery: false,
+      },
+    ],
+    publicationStatus: "pilot",
+  };
+}
+
+function createBundle(): CapabilityLearningBundle {
+  return {
+    id: "a0-repetition-bundle",
+    version: "1.0.0",
+    titleVi: "Yêu cầu người khác nhắc lại",
+    coreCurriculum: createCoreCurriculum(),
+    capabilitySpecifications: [createSpecification()],
+    youtubeCompanions: [createCompanion()],
+    publicationStatus: "pilot",
+  };
+}
+
+function codes(bundle: CapabilityLearningBundle) {
+  return validateCapabilityLearningBundle(bundle).map((issue) => issue.code);
+}
+
+describe("Two-lane content model", () => {
+  it("publishes a complete licensed core with an optional reviewed companion", () => {
+    expect(canPublishCapabilityLearningBundle(createBundle())).toBe(true);
+  });
+
+  it("publishes a complete licensed core even when no companion is available", () => {
+    const bundle = createBundle();
+    bundle.youtubeCompanions = [];
+    bundle.capabilitySpecifications[0].companionAssetIds = [];
+
+    expect(canPublishCapabilityLearningBundle(bundle)).toBe(true);
+  });
+
+  it("does not allow a companion to replace licensed core treatments", () => {
+    const bundle = createBundle();
+    bundle.coreCurriculum.treatments = [];
+    bundle.capabilitySpecifications[0].coreTreatmentIds = [];
+
+    expect(codes(bundle)).toContain("core_curriculum_invalid");
+    expect(codes(bundle)).toContain("missing_core_treatment");
+  });
+
+  it("requires every knowledge category to be complete", () => {
+    const bundle = createBundle();
+    bundle.capabilitySpecifications[0].knowledge.interactionStrategies = [];
+
+    expect(codes(bundle)).toContain("incomplete_knowledge_coverage");
+  });
+
+  it("rejects a companion policy that stores transcripts or derived media", () => {
+    const bundle = createBundle();
+    bundle.youtubeCompanions[0].usagePolicy = {
+      ...YOUTUBE_COMPANION_USAGE_POLICY,
+      canStoreTranscript: true,
+    } as unknown as YouTubeCompanionUsagePolicy;
+
+    expect(codes(bundle)).toContain("invalid_companion_policy");
+  });
+
+  it("requires an embed check before a companion is learner-facing", () => {
+    const bundle = createBundle();
+    bundle.youtubeCompanions[0].embedStatus = "unreviewed";
+
+    expect(codes(bundle)).toContain("companion_not_embed_verified");
+  });
+
+  it("keeps companion activities transcript-free and outside mastery", () => {
+    const bundle = createBundle();
+    bundle.youtubeCompanions[0].activities[0] = {
+      ...bundle.youtubeCompanions[0].activities[0],
+      contributesToMastery: true,
+    } as unknown as YouTubeCompanionAsset["activities"][number];
+
+    expect(codes(bundle)).toContain("invalid_companion_activity");
+  });
+});

--- a/src/features/curriculum-compiler/domain/content-lanes.ts
+++ b/src/features/curriculum-compiler/domain/content-lanes.ts
@@ -1,0 +1,542 @@
+import type {
+  CurriculumPackage,
+  PublicationStatus,
+} from "@/features/curriculum-compiler/domain/contracts";
+import { validateCurriculumPackage } from "@/features/curriculum-compiler/domain/validation";
+
+export type CompanionPurpose =
+  | "authentic_exposure"
+  | "speaker_variability"
+  | "context_variability"
+  | "learner_interest"
+  | "listening_challenge";
+
+export type CompanionActivityKind =
+  | "prewatch_prediction"
+  | "gist_reflection"
+  | "communicative_intent_spotting"
+  | "speaker_context_observation"
+  | "personal_reaction";
+
+export type CompanionEmbedStatus =
+  | "unreviewed"
+  | "embed_verified"
+  | "blocked"
+  | "retired";
+
+export interface YouTubeCompanionUsagePolicy {
+  canEmbed: true;
+  canStoreTranscript: false;
+  canRunAsr: false;
+  canCreateDerivedLesson: false;
+  canSelfHostMedia: false;
+  canDownloadMedia: false;
+  canDetachAudio: false;
+}
+
+export const YOUTUBE_COMPANION_USAGE_POLICY: YouTubeCompanionUsagePolicy = {
+  canEmbed: true,
+  canStoreTranscript: false,
+  canRunAsr: false,
+  canCreateDerivedLesson: false,
+  canSelfHostMedia: false,
+  canDownloadMedia: false,
+  canDetachAudio: false,
+};
+
+export interface CompanionActivity {
+  id: string;
+  kind: CompanionActivityKind;
+  promptVi: string;
+  learningPurpose: string;
+  /** Companion prompts cannot depend on a stored transcript or source wording. */
+  requiresTranscript: false;
+  storesSourceText: false;
+  contributesToMastery: false;
+}
+
+export interface YouTubeCompanionAsset {
+  id: string;
+  youtubeVideoId: string;
+  title: string;
+  creator: string;
+  watchUrl: string;
+  embedUrl: string;
+  capabilityIds: string[];
+  purpose: CompanionPurpose;
+  accentTags: string[];
+  topicTags: string[];
+  startSeconds?: number;
+  endSeconds?: number;
+  embedStatus: CompanionEmbedStatus;
+  usagePolicy: YouTubeCompanionUsagePolicy;
+  activities: CompanionActivity[];
+  publicationStatus: PublicationStatus;
+}
+
+export interface CapabilityKnowledgeCoverage {
+  meaningAndUse: string[];
+  formulaicChunks: string[];
+  grammarPatterns: string[];
+  speechFeatures: string[];
+  interactionStrategies: string[];
+  pragmaticsAndRegister: string[];
+  vietnameseLearnerRisks: string[];
+}
+
+export interface CapabilityLearningSpecification {
+  capabilityId: string;
+  knowledge: CapabilityKnowledgeCoverage;
+  /** Every licensed treatment for this capability must be listed here. */
+  coreTreatmentIds: string[];
+  /** Optional exposure only. These IDs can never satisfy core coverage. */
+  companionAssetIds: string[];
+}
+
+export interface CapabilityLearningBundle {
+  id: string;
+  version: string;
+  titleVi: string;
+  coreCurriculum: CurriculumPackage;
+  capabilitySpecifications: CapabilityLearningSpecification[];
+  youtubeCompanions: YouTubeCompanionAsset[];
+  publicationStatus: PublicationStatus;
+}
+
+export type LearningBundleValidationCode =
+  | "missing_bundle_identity"
+  | "core_curriculum_invalid"
+  | "core_status_mismatch"
+  | "duplicate_specification"
+  | "duplicate_companion_id"
+  | "missing_capability_specification"
+  | "unknown_capability"
+  | "incomplete_knowledge_coverage"
+  | "missing_core_treatment"
+  | "invalid_core_treatment_reference"
+  | "unknown_companion_reference"
+  | "companion_capability_mismatch"
+  | "invalid_youtube_url"
+  | "invalid_companion_window"
+  | "invalid_companion_policy"
+  | "invalid_companion_activity"
+  | "companion_not_embed_verified"
+  | "companion_status_mismatch";
+
+export interface LearningBundleValidationIssue {
+  code: LearningBundleValidationCode;
+  path: string;
+  message: string;
+}
+
+const KNOWLEDGE_FIELDS: Array<keyof CapabilityKnowledgeCoverage> = [
+  "meaningAndUse",
+  "formulaicChunks",
+  "grammarPatterns",
+  "speechFeatures",
+  "interactionStrategies",
+  "pragmaticsAndRegister",
+  "vietnameseLearnerRisks",
+];
+
+const POLICY_FIELDS: Array<keyof YouTubeCompanionUsagePolicy> = [
+  "canEmbed",
+  "canStoreTranscript",
+  "canRunAsr",
+  "canCreateDerivedLesson",
+  "canSelfHostMedia",
+  "canDownloadMedia",
+  "canDetachAudio",
+];
+
+function isLearnerFacing(status: PublicationStatus) {
+  return status === "pilot" || status === "approved";
+}
+
+function statusMeetsBundle(
+  bundleStatus: PublicationStatus,
+  itemStatus: PublicationStatus,
+) {
+  if (bundleStatus === "pilot") {
+    return itemStatus === "pilot" || itemStatus === "approved";
+  }
+  if (bundleStatus === "approved") return itemStatus === "approved";
+  return true;
+}
+
+function addIssue(
+  issues: LearningBundleValidationIssue[],
+  code: LearningBundleValidationCode,
+  path: string,
+  message: string,
+) {
+  issues.push({ code, path, message });
+}
+
+function duplicateStrings(values: readonly string[]) {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+function parseHttpsUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function isYouTubeWatchUrl(value: string, videoId: string) {
+  const url = parseHttpsUrl(value);
+  if (!url) return false;
+
+  const host = url.hostname.toLowerCase();
+  if (host === "youtu.be") return url.pathname.slice(1) === videoId;
+
+  if (
+    host === "youtube.com" ||
+    host === "www.youtube.com" ||
+    host === "m.youtube.com"
+  ) {
+    return url.pathname === "/watch" && url.searchParams.get("v") === videoId;
+  }
+
+  return false;
+}
+
+function isYouTubeEmbedUrl(value: string, videoId: string) {
+  const url = parseHttpsUrl(value);
+  if (!url) return false;
+
+  const host = url.hostname.toLowerCase();
+  const allowedHost =
+    host === "youtube.com" ||
+    host === "www.youtube.com" ||
+    host === "www.youtube-nocookie.com";
+
+  return allowedHost && url.pathname === `/embed/${videoId}`;
+}
+
+function validateCompanion(
+  companion: YouTubeCompanionAsset,
+  bundle: CapabilityLearningBundle,
+  capabilityIds: ReadonlySet<string>,
+  issues: LearningBundleValidationIssue[],
+) {
+  const path = `youtubeCompanions.${companion.id}`;
+
+  if (
+    !companion.id.trim() ||
+    !companion.youtubeVideoId.trim() ||
+    !companion.title.trim() ||
+    !companion.creator.trim() ||
+    companion.capabilityIds.length === 0 ||
+    companion.activities.length === 0
+  ) {
+    addIssue(
+      issues,
+      "invalid_companion_activity",
+      path,
+      "Companion identity, capability links, and activities are required.",
+    );
+  }
+
+  if (
+    !isYouTubeWatchUrl(companion.watchUrl, companion.youtubeVideoId) ||
+    !isYouTubeEmbedUrl(companion.embedUrl, companion.youtubeVideoId)
+  ) {
+    addIssue(
+      issues,
+      "invalid_youtube_url",
+      path,
+      "Companion URLs must use the declared video ID and official YouTube watch/embed forms.",
+    );
+  }
+
+  if (
+    companion.startSeconds !== undefined &&
+    (!Number.isFinite(companion.startSeconds) || companion.startSeconds < 0)
+  ) {
+    addIssue(
+      issues,
+      "invalid_companion_window",
+      `${path}.startSeconds`,
+      "Companion start time must be a non-negative number.",
+    );
+  }
+
+  if (
+    companion.endSeconds !== undefined &&
+    (!Number.isFinite(companion.endSeconds) ||
+      companion.endSeconds <= (companion.startSeconds ?? 0))
+  ) {
+    addIssue(
+      issues,
+      "invalid_companion_window",
+      `${path}.endSeconds`,
+      "Companion end time must be greater than its start time.",
+    );
+  }
+
+  for (const field of POLICY_FIELDS) {
+    if (companion.usagePolicy[field] !== YOUTUBE_COMPANION_USAGE_POLICY[field]) {
+      addIssue(
+        issues,
+        "invalid_companion_policy",
+        `${path}.usagePolicy.${field}`,
+        `YouTube Companion policy must keep ${field}=${String(YOUTUBE_COMPANION_USAGE_POLICY[field])}.`,
+      );
+    }
+  }
+
+  for (const capabilityId of companion.capabilityIds) {
+    if (!capabilityIds.has(capabilityId)) {
+      addIssue(
+        issues,
+        "unknown_capability",
+        `${path}.capabilityIds`,
+        `Unknown capability: ${capabilityId}`,
+      );
+    }
+  }
+
+  for (const activity of companion.activities) {
+    if (
+      !activity.id.trim() ||
+      !activity.promptVi.trim() ||
+      !activity.learningPurpose.trim() ||
+      activity.requiresTranscript !== false ||
+      activity.storesSourceText !== false ||
+      activity.contributesToMastery !== false
+    ) {
+      addIssue(
+        issues,
+        "invalid_companion_activity",
+        `${path}.activities.${activity.id}`,
+        "Companion activities must be transcript-free, store no source wording, and contribute no mastery evidence.",
+      );
+    }
+  }
+
+  if (isLearnerFacing(bundle.publicationStatus)) {
+    if (companion.embedStatus !== "embed_verified") {
+      addIssue(
+        issues,
+        "companion_not_embed_verified",
+        `${path}.embedStatus`,
+        "Learner-facing companion videos require a current embed check.",
+      );
+    }
+
+    if (!statusMeetsBundle(bundle.publicationStatus, companion.publicationStatus)) {
+      addIssue(
+        issues,
+        "companion_status_mismatch",
+        `${path}.publicationStatus`,
+        `Companion status ${companion.publicationStatus} cannot ship in a ${bundle.publicationStatus} bundle.`,
+      );
+    }
+  }
+}
+
+export function validateCapabilityLearningBundle(
+  bundle: CapabilityLearningBundle,
+): LearningBundleValidationIssue[] {
+  const issues: LearningBundleValidationIssue[] = [];
+
+  if (!bundle.id.trim() || !bundle.version.trim() || !bundle.titleVi.trim()) {
+    addIssue(
+      issues,
+      "missing_bundle_identity",
+      "bundle",
+      "Bundle ID, version, and Vietnamese title are required.",
+    );
+  }
+
+  for (const coreIssue of validateCurriculumPackage(bundle.coreCurriculum)) {
+    addIssue(
+      issues,
+      "core_curriculum_invalid",
+      `coreCurriculum.${coreIssue.path}`,
+      `${coreIssue.code}: ${coreIssue.message}`,
+    );
+  }
+
+  if (
+    isLearnerFacing(bundle.publicationStatus) &&
+    !statusMeetsBundle(
+      bundle.publicationStatus,
+      bundle.coreCurriculum.publicationStatus,
+    )
+  ) {
+    addIssue(
+      issues,
+      "core_status_mismatch",
+      "coreCurriculum.publicationStatus",
+      `Core curriculum status ${bundle.coreCurriculum.publicationStatus} cannot ship in a ${bundle.publicationStatus} bundle.`,
+    );
+  }
+
+  const capabilityById = new Map(
+    bundle.coreCurriculum.capabilities.map((capability) => [
+      capability.id,
+      capability,
+    ]),
+  );
+  const treatmentById = new Map(
+    bundle.coreCurriculum.treatments.map((treatment) => [
+      treatment.id,
+      treatment,
+    ]),
+  );
+  const companionById = new Map(
+    bundle.youtubeCompanions.map((companion) => [companion.id, companion]),
+  );
+  const specificationByCapability = new Map(
+    bundle.capabilitySpecifications.map((specification) => [
+      specification.capabilityId,
+      specification,
+    ]),
+  );
+
+  for (const duplicateId of duplicateStrings(
+    bundle.capabilitySpecifications.map(
+      (specification) => specification.capabilityId,
+    ),
+  )) {
+    addIssue(
+      issues,
+      "duplicate_specification",
+      "capabilitySpecifications",
+      `Duplicate capability specification: ${duplicateId}`,
+    );
+  }
+
+  for (const duplicateId of duplicateStrings(
+    bundle.youtubeCompanions.map((companion) => companion.id),
+  )) {
+    addIssue(
+      issues,
+      "duplicate_companion_id",
+      "youtubeCompanions",
+      `Duplicate companion ID: ${duplicateId}`,
+    );
+  }
+
+  for (const capability of bundle.coreCurriculum.capabilities) {
+    if (!specificationByCapability.has(capability.id)) {
+      addIssue(
+        issues,
+        "missing_capability_specification",
+        `capabilities.${capability.id}`,
+        "Every core capability requires a complete learning specification.",
+      );
+    }
+  }
+
+  for (const specification of bundle.capabilitySpecifications) {
+    const path = `capabilitySpecifications.${specification.capabilityId}`;
+    if (!capabilityById.has(specification.capabilityId)) {
+      addIssue(
+        issues,
+        "unknown_capability",
+        `${path}.capabilityId`,
+        `Unknown capability: ${specification.capabilityId}`,
+      );
+      continue;
+    }
+
+    for (const field of KNOWLEDGE_FIELDS) {
+      const values = specification.knowledge[field];
+      if (values.length === 0 || values.some((value) => !value.trim())) {
+        addIssue(
+          issues,
+          "incomplete_knowledge_coverage",
+          `${path}.knowledge.${field}`,
+          `Required knowledge category ${field} must contain reviewed content.`,
+        );
+      }
+    }
+
+    const expectedTreatmentIds = bundle.coreCurriculum.treatments
+      .filter(
+        (treatment) =>
+          treatment.targetCapabilityId === specification.capabilityId,
+      )
+      .map((treatment) => treatment.id);
+    const referencedTreatmentIds = new Set(specification.coreTreatmentIds);
+
+    if (specification.coreTreatmentIds.length === 0) {
+      addIssue(
+        issues,
+        "missing_core_treatment",
+        `${path}.coreTreatmentIds`,
+        "A companion-only capability is forbidden; licensed core treatments are required.",
+      );
+    }
+
+    for (const treatmentId of specification.coreTreatmentIds) {
+      const treatment = treatmentById.get(treatmentId);
+      if (
+        !treatment ||
+        treatment.targetCapabilityId !== specification.capabilityId
+      ) {
+        addIssue(
+          issues,
+          "invalid_core_treatment_reference",
+          `${path}.coreTreatmentIds`,
+          `Treatment ${treatmentId} is missing or targets another capability.`,
+        );
+      }
+    }
+
+    for (const expectedTreatmentId of expectedTreatmentIds) {
+      if (!referencedTreatmentIds.has(expectedTreatmentId)) {
+        addIssue(
+          issues,
+          "missing_core_treatment",
+          `${path}.coreTreatmentIds`,
+          `Licensed treatment ${expectedTreatmentId} is not represented in the capability specification.`,
+        );
+      }
+    }
+
+    for (const companionId of specification.companionAssetIds) {
+      const companion = companionById.get(companionId);
+      if (!companion) {
+        addIssue(
+          issues,
+          "unknown_companion_reference",
+          `${path}.companionAssetIds`,
+          `Unknown YouTube Companion: ${companionId}`,
+        );
+      } else if (!companion.capabilityIds.includes(specification.capabilityId)) {
+        addIssue(
+          issues,
+          "companion_capability_mismatch",
+          `${path}.companionAssetIds`,
+          `Companion ${companionId} does not declare capability ${specification.capabilityId}.`,
+        );
+      }
+    }
+  }
+
+  const capabilityIds = new Set(capabilityById.keys());
+  for (const companion of bundle.youtubeCompanions) {
+    validateCompanion(companion, bundle, capabilityIds, issues);
+  }
+
+  return issues;
+}
+
+export function canPublishCapabilityLearningBundle(
+  bundle: CapabilityLearningBundle,
+) {
+  return validateCapabilityLearningBundle(bundle).length === 0;
+}

--- a/src/features/source-curation/data/free-source-libraries.ts
+++ b/src/features/source-curation/data/free-source-libraries.ts
@@ -1,0 +1,226 @@
+import type { SourceLibraryRegistry } from "@/features/source-curation/domain/source-libraries";
+
+const BASE_REVIEWS = [
+  "item_identity",
+  "license_and_allowed_uses",
+  "attribution",
+  "third_party_material",
+  "privacy_and_publicity",
+  "trademark_and_endorsement",
+  "audio_and_playback",
+  "transcript_and_speakers",
+  "clip_window",
+  "pedagogical_fit",
+] as const;
+
+/**
+ * Discovery registry, not a blanket permission list.
+ *
+ * Every selected item must still pass the item-level reviews listed here before
+ * it can become a SourceAsset in the licensed curriculum core.
+ */
+export const FREE_SOURCE_LIBRARY_REGISTRY: SourceLibraryRegistry = {
+  version: "2026-08-02.1",
+  libraries: [
+    {
+      id: "wikimedia_commons",
+      name: "Wikimedia Commons",
+      homepageUrl: "https://commons.wikimedia.org/",
+      termsUrl:
+        "https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia",
+      rightsModel: "per_item_open_license",
+      supportedRightsFamilies: [
+        "public_domain",
+        "cc0",
+        "cc_by",
+        "cc_by_sa_conditional",
+      ],
+      coreSuitability: "conditional",
+      conversationAvailability: "medium",
+      fallbackPriority: 1,
+      strengths: [
+        "Hosts public-domain and freely licensed video with file-level author and license metadata.",
+        "CC BY and public-domain items can support full transcript and derivative lesson workflows after review.",
+      ],
+      limitations: [
+        "License and attribution requirements differ by file and are not warranted by Wikimedia.",
+        "CC BY-SA items require a separate compatibility decision for the resulting adaptation.",
+        "Many videos are speeches, historical footage, or demonstrations rather than short natural conversation.",
+      ],
+      requiredReviews: [...BASE_REVIEWS, "share_alike_compatibility"],
+      discoveryQueries: [
+        "English conversation interview video",
+        "people introducing themselves English",
+        "conversation asking name English",
+        "clarification repair conversation English",
+      ],
+    },
+    {
+      id: "dvids",
+      name: "Defense Visual Information Distribution Service",
+      homepageUrl: "https://www.dvidshub.net/",
+      termsUrl: "https://www.dvidshub.net/about/copyright",
+      rightsModel: "government_media_guidelines",
+      supportedRightsFamilies: ["us_government_with_guidelines"],
+      coreSuitability: "conditional",
+      conversationAvailability: "medium",
+      fallbackPriority: 2,
+      strengths: [
+        "Large catalog of real interviews, briefings, and unscripted English from varied speakers.",
+        "Many item pages expose provenance, captions, and public-use notices.",
+      ],
+      limitations: [
+        "Some items contain third-party material even when hosted on a government platform.",
+        "Privacy, publicity, military marks, and non-endorsement conditions remain separate from copyright.",
+        "Interviews overproduce one-way self-introductions and may not contain repair or multi-turn exchanges.",
+      ],
+      requiredReviews: [...BASE_REVIEWS],
+      discoveryQueries: [
+        "interview my name is transcript",
+        "where are you from interview transcript",
+        "could you repeat interview",
+        "international exercise interview English transcript",
+      ],
+    },
+    {
+      id: "library_of_congress",
+      name: "Library of Congress free-to-use collections",
+      homepageUrl: "https://www.loc.gov/free-to-use/",
+      termsUrl:
+        "https://www.loc.gov/collections/national-screening-room/about-this-collection/rights-and-access/",
+      rightsModel: "per_item_open_license",
+      supportedRightsFamilies: ["public_domain", "us_government_with_guidelines"],
+      coreSuitability: "conditional",
+      conversationAvailability: "low",
+      fallbackPriority: 3,
+      strengths: [
+        "Provides films and recordings in collections identified as free to use and reuse or without known restrictions.",
+        "Catalog records and collection rights statements support provenance review.",
+      ],
+      limitations: [
+        "Rights statements vary by collection and item, and independent assessment remains required.",
+        "Much of the footage is historical, with dated audio quality, vocabulary, and interaction norms.",
+        "Some items are educational-use-only or affected by privacy, publicity, trademark, or foreign rights.",
+      ],
+      requiredReviews: [...BASE_REVIEWS],
+      discoveryQueries: [
+        "English interview motion picture",
+        "people meeting conversation film",
+        "telephone conversation motion picture",
+        "immigrant interview English film",
+      ],
+    },
+    {
+      id: "nasa_media",
+      name: "NASA images and media",
+      homepageUrl: "https://www.nasa.gov/multimedia/",
+      termsUrl: "https://www.nasa.gov/nasa-brand-center/images-and-media/",
+      rightsModel: "government_media_guidelines",
+      supportedRightsFamilies: ["us_government_with_guidelines"],
+      coreSuitability: "conditional",
+      conversationAvailability: "low",
+      fallbackPriority: 4,
+      strengths: [
+        "Provides real interviews, mission communication, and varied English speakers with strong provenance.",
+        "NASA-produced media is generally available for factual educational or informational use under its guidelines.",
+      ],
+      limitations: [
+        "NASA identifiers, logos, endorsement, people, and third-party material require separate checks.",
+        "Most content is domain-specific and too advanced for the first A0 capabilities.",
+        "Technical radio communication is not a substitute for ordinary face-to-face conversation.",
+      ],
+      requiredReviews: [...BASE_REVIEWS],
+      discoveryQueries: [
+        "astronaut introduction interview",
+        "international astronaut interview English",
+        "crew asks to repeat communication",
+        "visitor interview name origin",
+      ],
+    },
+    {
+      id: "pexels",
+      name: "Pexels Videos",
+      homepageUrl: "https://www.pexels.com/videos/",
+      termsUrl: "https://www.pexels.com/legal-pages/license/",
+      rightsModel: "platform_content_license",
+      supportedRightsFamilies: ["pexels_license"],
+      coreSuitability: "context_only",
+      conversationAvailability: "low",
+      fallbackPriority: 5,
+      strengths: [
+        "License permits free use and modification, including many commercial uses, subject to its restrictions.",
+        "Useful for owned narration, situational visuals, and context when authentic spoken interaction is unavailable.",
+      ],
+      limitations: [
+        "Most stock footage has no useful dialogue or synchronized authentic audio.",
+        "Recognizable people, brands, trademarks, and implied endorsement require review.",
+        "Unaltered standalone redistribution is prohibited and stock visuals must not be mistaken for learner evidence.",
+      ],
+      requiredReviews: [...BASE_REVIEWS],
+      discoveryQueries: [
+        "two people talking with audio",
+        "meeting someone conversation",
+        "hotel reception conversation audio",
+        "coworkers talking audio",
+      ],
+    },
+    {
+      id: "pixabay",
+      name: "Pixabay Videos",
+      homepageUrl: "https://pixabay.com/videos/",
+      termsUrl: "https://pixabay.com/service/license-summary/",
+      rightsModel: "platform_content_license",
+      supportedRightsFamilies: ["pixabay_license"],
+      coreSuitability: "context_only",
+      conversationAvailability: "low",
+      fallbackPriority: 6,
+      strengths: [
+        "Content license generally permits free use and adaptation subject to prohibited uses.",
+        "Can provide visual contexts for AtoEnglish-owned dialogue, prompts, and transfer situations.",
+      ],
+      limitations: [
+        "Stock videos usually lack natural, intelligible English conversation.",
+        "Standalone redistribution and some uses involving recognizable people, brands, or marks are restricted.",
+        "Platform availability does not remove third-party privacy, publicity, trademark, or property rights.",
+      ],
+      requiredReviews: [...BASE_REVIEWS],
+      discoveryQueries: [
+        "people talking English audio",
+        "introducing yourself conversation",
+        "customer staff conversation audio",
+        "phone call conversation audio",
+      ],
+    },
+    {
+      id: "openverse",
+      name: "Openverse discovery index",
+      homepageUrl: "https://openverse.org/",
+      termsUrl: "https://openverse.org/about/",
+      rightsModel: "discovery_index_only",
+      supportedRightsFamilies: [
+        "public_domain",
+        "cc0",
+        "cc_by",
+        "cc_by_sa_conditional",
+      ],
+      coreSuitability: "discovery_only",
+      conversationAvailability: "unknown",
+      fallbackPriority: 7,
+      strengths: [
+        "Indexes openly licensed and public-domain media from multiple repositories.",
+        "Can reveal source repositories and attribution metadata that would otherwise be hard to discover.",
+      ],
+      limitations: [
+        "Openverse does not verify each work's license or attribution accuracy.",
+        "Its primary search currently focuses on images and audio; video discovery can redirect to external sources.",
+        "The indexed record itself is never sufficient rights evidence for a curriculum SourceAsset.",
+      ],
+      requiredReviews: [...BASE_REVIEWS, "share_alike_compatibility"],
+      discoveryQueries: [
+        "English conversation audio",
+        "spoken English interview",
+        "conversation repair English",
+      ],
+    },
+  ],
+};

--- a/src/features/source-curation/domain/source-libraries.test.ts
+++ b/src/features/source-curation/domain/source-libraries.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { FREE_SOURCE_LIBRARY_REGISTRY } from "@/features/source-curation/data/free-source-libraries";
+import {
+  canUseSourceLibraryRegistry,
+  rankSourceLibrariesForGap,
+  validateSourceLibraryRegistry,
+} from "@/features/source-curation/domain/source-libraries";
+
+describe("Free source library registry", () => {
+  it("passes registry validation", () => {
+    expect(validateSourceLibraryRegistry(FREE_SOURCE_LIBRARY_REGISTRY)).toEqual([]);
+    expect(canUseSourceLibraryRegistry(FREE_SOURCE_LIBRARY_REGISTRY)).toBe(true);
+  });
+
+  it("never marks an external library as automatically preferred core media", () => {
+    expect(
+      FREE_SOURCE_LIBRARY_REGISTRY.libraries.every(
+        (library) => library.coreSuitability !== "preferred",
+      ),
+    ).toBe(true);
+  });
+
+  it("requires item-level rights, audio, transcript, timing, and pedagogical review everywhere", () => {
+    const mandatoryReviews = [
+      "item_identity",
+      "license_and_allowed_uses",
+      "third_party_material",
+      "privacy_and_publicity",
+      "audio_and_playback",
+      "transcript_and_speakers",
+      "clip_window",
+      "pedagogical_fit",
+    ] as const;
+
+    for (const library of FREE_SOURCE_LIBRARY_REGISTRY.libraries) {
+      for (const review of mandatoryReviews) {
+        expect(library.requiredReviews).toContain(review);
+      }
+    }
+  });
+
+  it("keeps Openverse as discovery evidence rather than reusable media", () => {
+    const openverse = FREE_SOURCE_LIBRARY_REGISTRY.libraries.find(
+      (library) => library.id === "openverse",
+    );
+
+    expect(openverse?.rightsModel).toBe("discovery_index_only");
+    expect(openverse?.coreSuitability).toBe("discovery_only");
+  });
+
+  it("prioritizes conversation-bearing archives above silent stock footage for multi-turn gaps", () => {
+    const ranked = rankSourceLibrariesForGap(FREE_SOURCE_LIBRARY_REGISTRY, {
+      capabilityId: "a0.request_repetition",
+      needsMultiTurnConversation: true,
+      needsAuthenticAudio: true,
+    });
+
+    const positions = new Map(
+      ranked.map(({ library }, index) => [library.id, index]),
+    );
+
+    expect(positions.get("wikimedia_commons")).toBeLessThan(
+      positions.get("pexels") ?? Number.POSITIVE_INFINITY,
+    );
+    expect(positions.get("dvids")).toBeLessThan(
+      positions.get("pixabay") ?? Number.POSITIVE_INFINITY,
+    );
+    expect(positions.has("openverse")).toBe(false);
+  });
+
+  it("allows stock libraries only as context-first fallbacks", () => {
+    for (const id of ["pexels", "pixabay"]) {
+      const library = FREE_SOURCE_LIBRARY_REGISTRY.libraries.find(
+        (candidate) => candidate.id === id,
+      );
+      expect(library?.coreSuitability).toBe("context_only");
+    }
+  });
+});

--- a/src/features/source-curation/domain/source-libraries.ts
+++ b/src/features/source-curation/domain/source-libraries.ts
@@ -1,0 +1,270 @@
+export type SourceLibraryRightsModel =
+  | "owned"
+  | "per_item_open_license"
+  | "government_media_guidelines"
+  | "platform_content_license"
+  | "discovery_index_only";
+
+export type SourceLibraryCoreSuitability =
+  | "preferred"
+  | "conditional"
+  | "context_only"
+  | "discovery_only";
+
+export type ConversationAvailability = "high" | "medium" | "low" | "unknown";
+
+export type SourceReviewDimension =
+  | "item_identity"
+  | "license_and_allowed_uses"
+  | "attribution"
+  | "third_party_material"
+  | "privacy_and_publicity"
+  | "trademark_and_endorsement"
+  | "audio_and_playback"
+  | "transcript_and_speakers"
+  | "clip_window"
+  | "pedagogical_fit"
+  | "share_alike_compatibility";
+
+export type SupportedRightsFamily =
+  | "owned"
+  | "written_permission"
+  | "public_domain"
+  | "cc0"
+  | "cc_by"
+  | "cc_by_sa_conditional"
+  | "us_government_with_guidelines"
+  | "pexels_license"
+  | "pixabay_license";
+
+export interface SourceLibraryDefinition {
+  id: string;
+  name: string;
+  homepageUrl: string;
+  termsUrl: string;
+  rightsModel: SourceLibraryRightsModel;
+  supportedRightsFamilies: SupportedRightsFamily[];
+  coreSuitability: SourceLibraryCoreSuitability;
+  conversationAvailability: ConversationAvailability;
+  fallbackPriority: number;
+  strengths: string[];
+  limitations: string[];
+  requiredReviews: SourceReviewDimension[];
+  discoveryQueries: string[];
+}
+
+export interface SourceLibraryRegistry {
+  version: string;
+  libraries: SourceLibraryDefinition[];
+}
+
+export type SourceLibraryValidationCode =
+  | "missing_registry_version"
+  | "duplicate_library_id"
+  | "missing_library_field"
+  | "invalid_url"
+  | "invalid_fallback_priority"
+  | "missing_rights_family"
+  | "missing_required_review"
+  | "unsafe_core_suitability"
+  | "discovery_index_misclassified";
+
+export interface SourceLibraryValidationIssue {
+  code: SourceLibraryValidationCode;
+  path: string;
+  message: string;
+}
+
+const MANDATORY_ITEM_REVIEWS: SourceReviewDimension[] = [
+  "item_identity",
+  "license_and_allowed_uses",
+  "third_party_material",
+  "privacy_and_publicity",
+  "audio_and_playback",
+  "transcript_and_speakers",
+  "clip_window",
+  "pedagogical_fit",
+];
+
+function addIssue(
+  issues: SourceLibraryValidationIssue[],
+  code: SourceLibraryValidationCode,
+  path: string,
+  message: string,
+) {
+  issues.push({ code, path, message });
+}
+
+function isHttpsUrl(value: string) {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function duplicates(values: readonly string[]) {
+  const seen = new Set<string>();
+  const duplicateValues = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicateValues.add(value);
+    seen.add(value);
+  }
+  return [...duplicateValues];
+}
+
+export function validateSourceLibraryRegistry(
+  registry: SourceLibraryRegistry,
+): SourceLibraryValidationIssue[] {
+  const issues: SourceLibraryValidationIssue[] = [];
+
+  if (!registry.version.trim()) {
+    addIssue(
+      issues,
+      "missing_registry_version",
+      "registry.version",
+      "Source library registry version is required.",
+    );
+  }
+
+  for (const duplicateId of duplicates(
+    registry.libraries.map((library) => library.id),
+  )) {
+    addIssue(
+      issues,
+      "duplicate_library_id",
+      "registry.libraries",
+      `Duplicate library ID: ${duplicateId}`,
+    );
+  }
+
+  for (const library of registry.libraries) {
+    const path = `libraries.${library.id}`;
+
+    if (
+      !library.id.trim() ||
+      !library.name.trim() ||
+      library.strengths.length === 0 ||
+      library.limitations.length === 0 ||
+      library.discoveryQueries.length === 0
+    ) {
+      addIssue(
+        issues,
+        "missing_library_field",
+        path,
+        "Library identity, strengths, limitations, and discovery queries are required.",
+      );
+    }
+
+    if (!isHttpsUrl(library.homepageUrl) || !isHttpsUrl(library.termsUrl)) {
+      addIssue(
+        issues,
+        "invalid_url",
+        path,
+        "Library homepage and terms URLs must be valid HTTPS URLs.",
+      );
+    }
+
+    if (!Number.isInteger(library.fallbackPriority) || library.fallbackPriority < 1) {
+      addIssue(
+        issues,
+        "invalid_fallback_priority",
+        `${path}.fallbackPriority`,
+        "Fallback priority must be a positive integer.",
+      );
+    }
+
+    if (library.supportedRightsFamilies.length === 0) {
+      addIssue(
+        issues,
+        "missing_rights_family",
+        `${path}.supportedRightsFamilies`,
+        "At least one supported rights family is required.",
+      );
+    }
+
+    for (const review of MANDATORY_ITEM_REVIEWS) {
+      if (!library.requiredReviews.includes(review)) {
+        addIssue(
+          issues,
+          "missing_required_review",
+          `${path}.requiredReviews`,
+          `Every reusable video source requires ${review} review.`,
+        );
+      }
+    }
+
+    if (
+      library.rightsModel !== "owned" &&
+      library.coreSuitability === "preferred"
+    ) {
+      addIssue(
+        issues,
+        "unsafe_core_suitability",
+        `${path}.coreSuitability`,
+        "Only owned material can be preferred without per-item external-rights uncertainty.",
+      );
+    }
+
+    if (
+      library.rightsModel === "discovery_index_only" &&
+      library.coreSuitability !== "discovery_only"
+    ) {
+      addIssue(
+        issues,
+        "discovery_index_misclassified",
+        `${path}.coreSuitability`,
+        "A discovery index cannot itself be classified as reusable core media.",
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function canUseSourceLibraryRegistry(registry: SourceLibraryRegistry) {
+  return validateSourceLibraryRegistry(registry).length === 0;
+}
+
+export interface SourceGapSearchRequest {
+  capabilityId: string;
+  needsMultiTurnConversation: boolean;
+  needsAuthenticAudio: boolean;
+  excludeLibraryIds?: string[];
+}
+
+export function rankSourceLibrariesForGap(
+  registry: SourceLibraryRegistry,
+  request: SourceGapSearchRequest,
+) {
+  const excluded = new Set(request.excludeLibraryIds ?? []);
+
+  return registry.libraries
+    .filter((library) => !excluded.has(library.id))
+    .filter((library) => library.coreSuitability !== "discovery_only")
+    .map((library) => {
+      let score = 100 - library.fallbackPriority * 5;
+
+      if (library.coreSuitability === "preferred") score += 30;
+      if (library.coreSuitability === "conditional") score += 15;
+      if (library.coreSuitability === "context_only") score -= 25;
+
+      if (request.needsAuthenticAudio) {
+        if (library.conversationAvailability === "high") score += 25;
+        if (library.conversationAvailability === "medium") score += 10;
+        if (library.conversationAvailability === "low") score -= 30;
+      }
+
+      if (request.needsMultiTurnConversation) {
+        if (library.conversationAvailability === "high") score += 20;
+        if (library.conversationAvailability === "low") score -= 25;
+      }
+
+      return { library, score };
+    })
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.library.fallbackPriority - right.library.fallbackPriority,
+    );
+}


### PR DESCRIPTION
## Owner intent

Keep AtoEnglish lessons complete even when YouTube does not contain a suitable or reusable example.

The product now uses a two-lane learner model and a multi-source discovery fallback:

- **Licensed Curriculum** provides all required knowledge, practice, transfer, and mastery evidence.
- **YouTube Companion** provides optional authentic exposure without stored transcripts or derivative lesson claims.
- **Free/open source fallbacks** search Wikimedia Commons, DVIDS, Library of Congress, NASA media, Pexels, Pixabay, and discovery indexes when YouTube is missing or unsuitable.

## Outcome

This PR adds:

- a two-lane capability bundle contract;
- publication gates that forbid companion-only capabilities;
- complete knowledge coverage fields for meaning/use, chunks, grammar, speech, interaction, pragmatics, and Vietnamese learner risks;
- reviewed first-A0 knowledge plans for five capabilities;
- YouTube Companion policy that forbids transcript storage, ASR, media download, detached audio, derivative lesson use, and mastery evidence;
- a free/open source-library registry with ranking and review gates;
- source fallback documentation and tests.

## Completeness guarantee

Every learner-facing capability must remain fully teachable and assessable after all companion items are removed.

The licensed core must independently contain:

1. comprehension;
2. productive retrieval;
3. multi-turn or personal use;
4. changed-context or unseen-input transfer;
5. delayed evidence;
6. complete knowledge coverage across seven categories.

Companion media cannot unlock the next capability or repair missing core content.

## Source fallback order

```text
usable YouTube source
→ Wikimedia Commons
→ DVIDS and government media
→ Library of Congress
→ NASA when pedagogically relevant
→ Pexels/Pixabay for visual context or verified audio
→ AtoEnglish-owned gap-filling capture
```

This is a discovery heuristic, not blanket permission. Every item still requires rights, attribution, third-party, privacy/publicity, trademark/endorsement, playback/audio, transcript/speaker, timing, and pedagogical review.

## Important classifications

- Wikimedia Commons: conditional core source after file-level license review; CC BY-SA requires compatibility review.
- DVIDS: conditional core source; government origin does not remove third-party, privacy, mark, or endorsement checks.
- Library of Congress: conditional archival source with collection/item rights review.
- NASA: conditional niche source under NASA media guidelines.
- Pexels/Pixabay: context-first sources; stock visuals do not count as authentic listening unless useful synchronized dialogue is verified.
- Openverse: discovery index only, never item-level rights evidence.

## Files

- `docs/curriculum/TWO_LANE_CONTENT_MODEL.md`
- `docs/curriculum/FREE_AND_OPEN_VIDEO_SOURCES.md`
- `src/features/curriculum-compiler/domain/content-lanes.ts`
- `src/features/curriculum-compiler/domain/content-lanes.test.ts`
- `src/features/curriculum-compiler/data/first-a0-knowledge-coverage.ts`
- `src/features/curriculum-compiler/data/first-a0-knowledge-coverage.test.ts`
- `src/features/source-curation/domain/source-libraries.ts`
- `src/features/source-curation/domain/source-libraries.test.ts`
- `src/features/source-curation/data/free-source-libraries.ts`

## Scope

No media download, scraping, transcript retrieval, real-source acceptance, player/UI changes, database migration, auth, analytics, FSRS changes, deployment, production, or merge.

## Stacking

- Base: `feature/curriculum-compiler-contracts` / PR #48.
- Head: `feature/two-lane-content-model`.
- PR #48 is stacked on PR #47.

## Exact-head verification

- Head: `4f94223bec700ca89afc42b47a01b84404585c5f`.
- GitHub Verify run #75, ID `30737838498`: **passed**.
- Passed: ESLint, TypeScript, unit tests, and content-standard tests.
- Analytics recovery run #123, ID `30737838496`: skipped as expected.
- Final compare against PR #48 head: nine added files, eleven commits, behind by zero.
- No route, database, provider, dependency, or deployment change.

The initial Verify run #74 failed only because one test callback lost its inferred string type through `Object.values`; the test now uses a typed knowledge-field list and the final head passes.

## Evidence sources represented

- Wikimedia Commons reuse and licensing guidance;
- DVIDS copyright, trademark, privacy/publicity, and non-endorsement notice;
- Library of Congress free-to-use and National Screening Room rights statements;
- NASA images and media guidelines;
- Pexels license;
- Pixabay content license;
- Openverse discovery and verification limitations;
- YouTube official embed and captions boundaries;
- CEFR action-oriented alignment.

Library-level guidance is never treated as item-level permission.

## Still unverified

- no actual Wikimedia, Library of Congress, NASA, Pexels, or Pixabay item has been accepted;
- no source audio or transcript has been reviewed in this PR;
- the fallback order has not been tested against real candidate yield;
- no learner UI or learner outcome evidence exists.

## Next safe action

Keep this PR draft and unmerged. The next source batch should search the highest-ranked libraries specifically for `ask name`, `where from`, and `request repetition`, recording yield and rejection reasons rather than collecting more generic introductions.