### PR TITLE
experiment: add runnable authorized YouTube companion demo

### DIFF
--- a/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
+++ b/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
@@ -75,25 +75,42 @@ The system must reject:
 
 The demo performs two stages:
 
-1. fetch public metadata through the official YouTube Data API and build an official embed record;
+1. fetch public metadata and build an official embed record;
 2. optionally read a local, authorized caption file and generate an editor-only lesson draft.
 
-Metadata only:
+### No API key
+
+When `YOUTUBE_API_KEY` is absent, the CLI uses YouTube oEmbed:
+
+```bash
+npx tsx scripts/demo-youtube-companion.ts \
+  --url=https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+The no-key response provides the title, creator name, thumbnail, and official embed representation. It does not provide duration, publication date, or license, so those fields remain unknown and cannot satisfy rights or duration review.
+
+### With YouTube Data API key
 
 ```bash
 YOUTUBE_API_KEY=your_key npx tsx scripts/demo-youtube-companion.ts \
   --url=https://www.youtube.com/watch?v=VIDEO_ID
 ```
 
-Metadata plus an authorized local caption file:
+The Data API path adds duration, publication date, embeddability, and the YouTube license field.
+
+### With an authorized local caption file
+
+The caption path works in both metadata modes:
 
 ```bash
-YOUTUBE_API_KEY=your_key npx tsx scripts/demo-youtube-companion.ts \
+npx tsx scripts/demo-youtube-companion.ts \
   --url=https://www.youtube.com/watch?v=VIDEO_ID \
   --caption=fixtures/media-ingestion/demo-authorized-caption.vtt \
   --caption-authorized \
   --rights-evidence=creator-upload-record-123
 ```
+
+Without Data API duration, caption cues are validated internally for order and overlap, but the final cue cannot be checked against the total video duration.
 
 The CLI rejects remote caption URLs. It does not download media, extract audio, or scrape YouTube captions.
 

--- a/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
+++ b/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
@@ -71,15 +71,38 @@ The system must reject:
 - learner-facing lessons created before human alignment review;
 - sources whose rights were revoked or whose takedown status is active.
 
-## Supported caption formats
+## Runnable TypeScript demo
 
-The first implementation supports:
+The demo performs two stages:
 
-- WebVTT (`text/vtt`);
-- SubRip (`application/x-subrip`);
-- TTML (`application/ttml+xml`).
+1. fetch public metadata through the official YouTube Data API and build an official embed record;
+2. optionally read a local, authorized caption file and generate an editor-only lesson draft.
 
-Captions may come from the creator, an official source, or a reviewed manual transcription. Machine output remains a draft until checked against playback.
+Metadata only:
+
+```bash
+YOUTUBE_API_KEY=your_key npx tsx scripts/demo-youtube-companion.ts \
+  --url=https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+Metadata plus an authorized local caption file:
+
+```bash
+YOUTUBE_API_KEY=your_key npx tsx scripts/demo-youtube-companion.ts \
+  --url=https://www.youtube.com/watch?v=VIDEO_ID \
+  --caption=fixtures/media-ingestion/demo-authorized-caption.vtt \
+  --caption-authorized \
+  --rights-evidence=creator-upload-record-123
+```
+
+The CLI rejects remote caption URLs. It does not download media, extract audio, or scrape YouTube captions.
+
+## Supported caption formats in this demo
+
+- WebVTT (`.vtt`);
+- SubRip (`.srt`).
+
+TTML support remains a later ingestion adapter rather than a claim of the current parser.
 
 ## Lesson-readiness rule
 
@@ -97,4 +120,4 @@ rights permit storage and derivatives
 
 ## Scope of this experiment
 
-This branch defines TypeScript contracts, validators, and tests. It does not add a downloader, OAuth flow, object storage adapter, media processor, player UI, production database migration, or deployment.
+This branch adds a TypeScript metadata client, URL parser, local timed-text parser, lesson-draft builder, CLI, fixture, and tests. It does not add a downloader, OAuth flow, object storage adapter, media processor, player UI, production database migration, or deployment.

--- a/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
+++ b/docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md
@@ -1,0 +1,100 @@
+# Authorized natural-media ingestion
+
+Status: experimental implementation boundary, 2026-08-02.
+
+## Product decision
+
+Accurate listening lessons require access to both:
+
+- the original synchronized audio or video signal;
+- a timestamped caption or transcript track that can be checked against playback.
+
+AtoEnglish therefore supports full media ingestion only when the exact source permits storage and derivative lesson creation.
+
+## Supported acquisition modes
+
+```text
+creator_direct_upload
+creator_oauth_export
+owned_media
+public_domain_source
+cc_by_source
+licensed_source
+```
+
+A standard-license YouTube video owned by another creator is not a valid downloadable core source. It remains an official-player companion unless the creator supplies media, authorizes access, or changes the applicable license.
+
+## Required evidence
+
+Every ingestion record must preserve:
+
+- original source URL and provider;
+- acquisition mode;
+- rights basis and evidence URL;
+- uploader or reviewer identity;
+- exact allowed uses;
+- original media file identity and checksum;
+- caption file identity and checksum;
+- language and caption provenance;
+- duration and timestamp range;
+- review state;
+- takedown and retirement status.
+
+## Processing pipeline
+
+```text
+rights grant
+→ authorized media acquisition
+→ media checksum and metadata inspection
+→ caption acquisition
+→ caption parse and normalization
+→ timestamp validation
+→ audio-caption alignment review
+→ speaker and transcript review
+→ Communication Clip extraction
+→ lesson treatment authoring
+→ publication gate
+```
+
+## Non-negotiable blocks
+
+The system must reject:
+
+- standard-license YouTube downloading;
+- unofficial caption scraping;
+- ASR on media acquired without permission;
+- missing rights evidence;
+- media without a cryptographic checksum;
+- captions without a supported timed-text format;
+- caption cues outside media duration;
+- overlapping or reversed cue timestamps;
+- learner-facing lessons created before human alignment review;
+- sources whose rights were revoked or whose takedown status is active.
+
+## Supported caption formats
+
+The first implementation supports:
+
+- WebVTT (`text/vtt`);
+- SubRip (`application/x-subrip`);
+- TTML (`application/ttml+xml`).
+
+Captions may come from the creator, an official source, or a reviewed manual transcription. Machine output remains a draft until checked against playback.
+
+## Lesson-readiness rule
+
+A source is lesson-ready only when:
+
+```text
+rights permit storage and derivatives
++ media file is present and verified
++ caption track is present and parsed
++ timestamps fit the media
++ transcript and speaker labels are human-reviewed
++ audio-caption alignment is human-reviewed
++ source is not retired or under takedown
+```
+
+## Scope of this experiment
+
+This branch defines TypeScript contracts, validators, and tests. It does not add a downloader, OAuth flow, object storage adapter, media processor, player UI, production database migration, or deployment.

--- a/fixtures/media-ingestion/demo-authorized-caption.vtt
+++ b/fixtures/media-ingestion/demo-authorized-caption.vtt
@@ -1,0 +1,13 @@
+WEBVTT
+
+intro-1
+00:00:01.000 --> 00:00:03.500
+Hi, I'm Maya.
+
+intro-2
+00:00:04.000 --> 00:00:06.200
+Nice to meet you.
+
+repair-1
+00:00:07.000 --> 00:00:09.800
+Sorry, could you say that again?

--- a/scripts/demo-youtube-companion.ts
+++ b/scripts/demo-youtube-companion.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { buildAuthorizedListeningLessonDraft } from "../src/features/media-ingestion/domain/lesson-draft";
+import { parseTimedText } from "../src/features/media-ingestion/domain/timed-text";
+import { fetchYouTubeCompanionMetadata } from "../src/features/media-ingestion/domain/youtube-companion-demo";
+
+function readArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  const argument = process.argv.slice(2).find((value) => value.startsWith(prefix));
+  return argument ? argument.slice(prefix.length).trim() : null;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.slice(2).includes(`--${name}`);
+}
+
+function isoDurationToMs(value: string): number | undefined {
+  const match = value.match(
+    /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/,
+  );
+  if (!match) return undefined;
+
+  const days = Number(match[1] ?? 0);
+  const hours = Number(match[2] ?? 0);
+  const minutes = Number(match[3] ?? 0);
+  const seconds = Number(match[4] ?? 0);
+
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}
+
+async function main() {
+  const url = readArg("url");
+  const apiKey = process.env.YOUTUBE_API_KEY?.trim() ?? "";
+
+  if (!url) {
+    throw new Error(
+      "Thiếu --url=<YouTube URL>. Ví dụ: --url=https://www.youtube.com/watch?v=VIDEO_ID",
+    );
+  }
+
+  const metadata = await fetchYouTubeCompanionMetadata(url, apiKey);
+  const captionPath = readArg("caption");
+
+  if (!captionPath) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: "metadata_only",
+          metadata,
+          nextStep:
+            "Cung cấp caption local được phép dùng bằng --caption=<path> --caption-authorized --rights-evidence=<reference>.",
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (/^https?:\/\//i.test(captionPath)) {
+    throw new Error("Demo chỉ nhận caption file local; không tải caption từ URL.");
+  }
+
+  if (!hasFlag("caption-authorized")) {
+    throw new Error("Thiếu --caption-authorized để xác nhận quyền sử dụng caption.");
+  }
+
+  const rightsEvidence = readArg("rights-evidence");
+  if (!rightsEvidence) {
+    throw new Error("Thiếu --rights-evidence=<reference>.");
+  }
+
+  const absoluteCaptionPath = resolve(process.cwd(), captionPath);
+  const captionSource = await readFile(absoluteCaptionPath, "utf8");
+  const parsed = parseTimedText(captionSource, {
+    durationMs: isoDurationToMs(metadata.durationIso8601),
+  });
+  const lesson = buildAuthorizedListeningLessonDraft(metadata, parsed.cues, {
+    canStoreTranscript: true,
+    canCreateDerivedLesson: true,
+    evidenceReference: rightsEvidence,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: "authorized_lesson_draft",
+        captionFormat: parsed.format,
+        cueCount: parsed.cues.length,
+        lesson,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  console.error(`Demo thất bại: ${message}`);
+  process.exitCode = 1;
+});

--- a/src/features/media-ingestion/domain/index.ts
+++ b/src/features/media-ingestion/domain/index.ts
@@ -1,0 +1,3 @@
+export * from "@/features/media-ingestion/domain/lesson-draft";
+export * from "@/features/media-ingestion/domain/timed-text";
+export * from "@/features/media-ingestion/domain/youtube-companion-demo";

--- a/src/features/media-ingestion/domain/lesson-draft.ts
+++ b/src/features/media-ingestion/domain/lesson-draft.ts
@@ -1,0 +1,88 @@
+import type { TimedTextCue } from "@/features/media-ingestion/domain/timed-text";
+import type { YouTubeCompanionMetadata } from "@/features/media-ingestion/domain/youtube-companion-demo";
+
+export interface TranscriptUseGrant {
+  canStoreTranscript: true;
+  canCreateDerivedLesson: true;
+  evidenceReference: string;
+}
+
+export interface ListeningLessonDraft {
+  status: "editor_draft";
+  source: YouTubeCompanionMetadata;
+  rightsEvidence: string;
+  titleVi: string;
+  transcriptCues: TimedTextCue[];
+  activities: Array<{
+    id: string;
+    layer: "comprehension" | "acquisition" | "transfer";
+    promptVi: string;
+    cueIds: string[];
+    exposesFullAnswer: boolean;
+  }>;
+  publicationBlocks: string[];
+}
+
+export function buildAuthorizedListeningLessonDraft(
+  source: YouTubeCompanionMetadata,
+  cues: TimedTextCue[],
+  grant: TranscriptUseGrant,
+): ListeningLessonDraft {
+  if (!source.embeddable) {
+    throw new Error("Video không cho phép embed bằng player chính thức.");
+  }
+
+  if (!grant.evidenceReference.trim()) {
+    throw new Error("Thiếu bằng chứng quyền lưu transcript và tạo bài học phái sinh.");
+  }
+
+  if (cues.length === 0) {
+    throw new Error("Không thể tạo bài học khi chưa có caption cue.");
+  }
+
+  const cueIds = cues.map((cue) => cue.id);
+
+  return {
+    status: "editor_draft",
+    source,
+    rightsEvidence: grant.evidenceReference.trim(),
+    titleVi: `Bài nghe nháp: ${source.title}`,
+    transcriptCues: cues,
+    activities: [
+      {
+        id: "cold-listen",
+        layer: "comprehension",
+        promptVi: "Nghe không nhìn phụ đề và xác định mục đích chính của cuộc trò chuyện.",
+        cueIds: [],
+        exposesFullAnswer: false,
+      },
+      {
+        id: "timed-detail-check",
+        layer: "comprehension",
+        promptVi: "Nghe lại từng đoạn và đối chiếu chi tiết với caption đã được cấp quyền.",
+        cueIds,
+        exposesFullAnswer: true,
+      },
+      {
+        id: "reconstruct",
+        layer: "acquisition",
+        promptVi: "Ẩn caption, nghe lại rồi tái tạo các cụm giao tiếp quan trọng.",
+        cueIds,
+        exposesFullAnswer: false,
+      },
+      {
+        id: "changed-context-response",
+        layer: "transfer",
+        promptVi: "Phản hồi bằng lời của bạn trong một tình huống mới có cùng mục đích giao tiếp.",
+        cueIds: [],
+        exposesFullAnswer: false,
+      },
+    ],
+    publicationBlocks: [
+      "Chưa kiểm tra audio-caption alignment thủ công.",
+      "Chưa xác nhận speaker labels.",
+      "Chưa review tính tự nhiên và giá trị sư phạm.",
+      "Chưa duyệt bản dịch và communication-event annotation.",
+    ],
+  };
+}

--- a/src/features/media-ingestion/domain/timed-text.ts
+++ b/src/features/media-ingestion/domain/timed-text.ts
@@ -1,0 +1,152 @@
+export type TimedTextFormat = "vtt" | "srt";
+
+export interface TimedTextCue {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+}
+
+export interface ParsedTimedText {
+  format: TimedTextFormat;
+  cues: TimedTextCue[];
+}
+
+function parseTimestamp(raw: string): number {
+  const normalized = raw.trim().replace(",", ".");
+  const parts = normalized.split(":");
+
+  if (parts.length < 2 || parts.length > 3) {
+    throw new Error(`Timestamp không hợp lệ: ${raw}`);
+  }
+
+  const secondsPart = parts.at(-1);
+  const minutesPart = parts.at(-2);
+  const hoursPart = parts.length === 3 ? parts[0] : "0";
+
+  if (!secondsPart || !minutesPart || hoursPart === undefined) {
+    throw new Error(`Timestamp không hợp lệ: ${raw}`);
+  }
+
+  const [secondsRaw, millisecondsRaw = "0"] = secondsPart.split(".");
+  const hours = Number(hoursPart);
+  const minutes = Number(minutesPart);
+  const seconds = Number(secondsRaw);
+  const milliseconds = Number(millisecondsRaw.padEnd(3, "0").slice(0, 3));
+
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    !Number.isInteger(seconds) ||
+    !Number.isInteger(milliseconds) ||
+    hours < 0 ||
+    minutes < 0 ||
+    minutes > 59 ||
+    seconds < 0 ||
+    seconds > 59 ||
+    milliseconds < 0 ||
+    milliseconds > 999
+  ) {
+    throw new Error(`Timestamp không hợp lệ: ${raw}`);
+  }
+
+  return ((hours * 60 * 60 + minutes * 60 + seconds) * 1000) + milliseconds;
+}
+
+function stripMarkup(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function parseCueBlock(block: string, index: number): TimedTextCue | null {
+  const lines = block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) return null;
+  if (/^(NOTE|STYLE|REGION)(\s|$)/.test(lines[0] ?? "")) return null;
+
+  const timingLineIndex = lines.findIndex((line) => line.includes("-->"));
+  if (timingLineIndex < 0) return null;
+
+  const timingLine = lines[timingLineIndex];
+  if (!timingLine) return null;
+
+  const [startRaw, endWithSettings] = timingLine.split("-->").map((part) => part.trim());
+  const endRaw = endWithSettings?.split(/\s+/)[0];
+
+  if (!startRaw || !endRaw) {
+    throw new Error(`Cue ${index + 1} thiếu timestamp.`);
+  }
+
+  const startMs = parseTimestamp(startRaw);
+  const endMs = parseTimestamp(endRaw);
+
+  if (endMs <= startMs) {
+    throw new Error(`Cue ${index + 1} có thời gian kết thúc không hợp lệ.`);
+  }
+
+  const text = stripMarkup(lines.slice(timingLineIndex + 1).join(" "));
+  if (!text) {
+    throw new Error(`Cue ${index + 1} không có nội dung.`);
+  }
+
+  const explicitId = timingLineIndex > 0 ? lines[timingLineIndex - 1] : null;
+
+  return {
+    id: explicitId && !explicitId.includes("-->") ? explicitId : `cue-${index + 1}`,
+    startMs,
+    endMs,
+    text,
+  };
+}
+
+export function parseTimedText(
+  source: string,
+  options: { durationMs?: number } = {},
+): ParsedTimedText {
+  const normalized = source.replace(/^\uFEFF/, "").trim();
+  if (!normalized) {
+    throw new Error("Caption file rỗng.");
+  }
+
+  const format: TimedTextFormat = normalized.startsWith("WEBVTT") ? "vtt" : "srt";
+  const body = format === "vtt"
+    ? normalized.replace(/^WEBVTT[^\n]*(?:\r?\n)?/, "").trim()
+    : normalized;
+
+  const cues = body
+    .split(/\r?\n\s*\r?\n/)
+    .map(parseCueBlock)
+    .filter((cue): cue is TimedTextCue => cue !== null)
+    .sort((left, right) => left.startMs - right.startMs);
+
+  if (cues.length === 0) {
+    throw new Error("Không tìm thấy cue hợp lệ trong caption file.");
+  }
+
+  for (let index = 0; index < cues.length; index += 1) {
+    const cue = cues[index];
+    const previous = cues[index - 1];
+
+    if (!cue) continue;
+    if (previous && cue.startMs < previous.endMs) {
+      throw new Error(`Cue ${cue.id} chồng lấn cue ${previous.id}.`);
+    }
+
+    if (options.durationMs !== undefined && cue.endMs > options.durationMs) {
+      throw new Error(`Cue ${cue.id} vượt quá thời lượng media.`);
+    }
+  }
+
+  return { format, cues };
+}

--- a/src/features/media-ingestion/domain/youtube-companion-demo.test.ts
+++ b/src/features/media-ingestion/domain/youtube-companion-demo.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildAuthorizedListeningLessonDraft } from "@/features/media-ingestion/domain/lesson-draft";
+import { parseTimedText } from "@/features/media-ingestion/domain/timed-text";
+import {
+  extractYouTubeVideoId,
+  fetchYouTubeCompanionMetadata,
+} from "@/features/media-ingestion/domain/youtube-companion-demo";
+
+describe("YouTube companion demo", () => {
+  it.each([
+    ["dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://youtu.be/dQw4w9WgXcQ?t=10", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+  ])("extracts video ID from %s", (input, expected) => {
+    expect(extractYouTubeVideoId(input)).toBe(expected);
+  });
+
+  it("rejects non-YouTube URLs", () => {
+    expect(() => extractYouTubeVideoId("https://example.com/video/123")).toThrow(
+      "Chỉ chấp nhận URL",
+    );
+  });
+
+  it("loads public metadata through the official Data API shape", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "dQw4w9WgXcQ",
+              snippet: {
+                title: "Natural conversation",
+                channelTitle: "Example Creator",
+                publishedAt: "2026-01-01T00:00:00Z",
+                thumbnails: { high: { url: "https://img.example/video.jpg" } },
+              },
+              status: { embeddable: true, license: "youtube" },
+              contentDetails: { duration: "PT2M15S" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const metadata = await fetchYouTubeCompanionMetadata(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "test-api-key",
+      fetchMock,
+    );
+
+    expect(metadata).toMatchObject({
+      sourceMode: "youtube_companion",
+      videoId: "dQw4w9WgXcQ",
+      title: "Natural conversation",
+      embeddable: true,
+      license: "youtube",
+      embedUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("authorized caption lesson demo", () => {
+  const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:03.500
+Hi, I'm Maya.
+
+00:00:04.000 --> 00:00:06.000
+Nice to meet you.
+`;
+
+  it("parses WebVTT and builds an editor draft", () => {
+    const parsed = parseTimedText(vtt, { durationMs: 10_000 });
+    const lesson = buildAuthorizedListeningLessonDraft(
+      {
+        sourceMode: "youtube_companion",
+        videoId: "dQw4w9WgXcQ",
+        title: "Natural conversation",
+        channelTitle: "Example Creator",
+        publishedAt: "2026-01-01T00:00:00Z",
+        durationIso8601: "PT10S",
+        embeddable: true,
+        license: "creativeCommon",
+        watchUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        embedUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+        thumbnailUrl: null,
+      },
+      parsed.cues,
+      {
+        canStoreTranscript: true,
+        canCreateDerivedLesson: true,
+        evidenceReference: "creator-upload-record-123",
+      },
+    );
+
+    expect(parsed.format).toBe("vtt");
+    expect(parsed.cues).toHaveLength(2);
+    expect(lesson.status).toBe("editor_draft");
+    expect(lesson.transcriptCues[0]?.text).toBe("Hi, I'm Maya.");
+    expect(lesson.publicationBlocks.length).toBeGreaterThan(0);
+  });
+
+  it("rejects overlapping captions", () => {
+    expect(() =>
+      parseTimedText(`WEBVTT
+
+00:00:01.000 --> 00:00:04.000
+First.
+
+00:00:03.500 --> 00:00:05.000
+Second.
+`),
+    ).toThrow("chồng lấn");
+  });
+});

--- a/src/features/media-ingestion/domain/youtube-companion-demo.ts
+++ b/src/features/media-ingestion/domain/youtube-companion-demo.ts
@@ -1,0 +1,158 @@
+export type YouTubeLicense = "youtube" | "creativeCommon";
+
+export interface YouTubeCompanionMetadata {
+  sourceMode: "youtube_companion";
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  publishedAt: string;
+  durationIso8601: string;
+  embeddable: boolean;
+  license: YouTubeLicense;
+  watchUrl: string;
+  embedUrl: string;
+  thumbnailUrl: string | null;
+}
+
+interface YouTubeVideosListResponse {
+  items?: Array<{
+    id?: string;
+    snippet?: {
+      title?: string;
+      channelTitle?: string;
+      publishedAt?: string;
+      thumbnails?: {
+        high?: { url?: string };
+        medium?: { url?: string };
+        default?: { url?: string };
+      };
+    };
+    status?: {
+      embeddable?: boolean;
+      license?: YouTubeLicense;
+    };
+    contentDetails?: {
+      duration?: string;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+}
+
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+function assertVideoId(candidate: string | null): string {
+  if (!candidate || !VIDEO_ID_PATTERN.test(candidate)) {
+    throw new Error("Không tìm thấy YouTube video ID hợp lệ trong URL.");
+  }
+
+  return candidate;
+}
+
+export function extractYouTubeVideoId(input: string): string {
+  const trimmed = input.trim();
+
+  if (VIDEO_ID_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error("YouTube URL không hợp lệ.");
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+
+  if (hostname === "youtu.be") {
+    return assertVideoId(url.pathname.split("/").filter(Boolean)[0] ?? null);
+  }
+
+  if (hostname !== "youtube.com" && hostname !== "m.youtube.com") {
+    throw new Error("Chỉ chấp nhận URL thuộc youtube.com hoặc youtu.be.");
+  }
+
+  if (url.pathname === "/watch") {
+    return assertVideoId(url.searchParams.get("v"));
+  }
+
+  const [first, second] = url.pathname.split("/").filter(Boolean);
+  if (["embed", "shorts", "live"].includes(first ?? "")) {
+    return assertVideoId(second ?? null);
+  }
+
+  throw new Error("Định dạng YouTube URL chưa được hỗ trợ.");
+}
+
+function pickThumbnail(
+  thumbnails: NonNullable<
+    NonNullable<YouTubeVideosListResponse["items"]>[number]["snippet"]
+  >["thumbnails"],
+): string | null {
+  return (
+    thumbnails?.high?.url ??
+    thumbnails?.medium?.url ??
+    thumbnails?.default?.url ??
+    null
+  );
+}
+
+export async function fetchYouTubeCompanionMetadata(
+  input: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<YouTubeCompanionMetadata> {
+  const normalizedKey = apiKey.trim();
+  if (!normalizedKey) {
+    throw new Error("Thiếu YOUTUBE_API_KEY.");
+  }
+
+  const videoId = extractYouTubeVideoId(input);
+  const endpoint = new URL("https://www.googleapis.com/youtube/v3/videos");
+  endpoint.searchParams.set("part", "snippet,status,contentDetails");
+  endpoint.searchParams.set("id", videoId);
+  endpoint.searchParams.set("key", normalizedKey);
+
+  const response = await fetchImpl(endpoint, {
+    headers: { Accept: "application/json" },
+  });
+
+  const payload = (await response.json()) as YouTubeVideosListResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      payload.error?.message ?? `YouTube Data API trả về HTTP ${response.status}.`,
+    );
+  }
+
+  const item = payload.items?.[0];
+  if (!item) {
+    throw new Error("Không tìm thấy video hoặc video không khả dụng qua API.");
+  }
+
+  const title = item.snippet?.title?.trim();
+  const channelTitle = item.snippet?.channelTitle?.trim();
+  const publishedAt = item.snippet?.publishedAt?.trim();
+  const durationIso8601 = item.contentDetails?.duration?.trim();
+  const license = item.status?.license;
+
+  if (!title || !channelTitle || !publishedAt || !durationIso8601 || !license) {
+    throw new Error("Metadata YouTube thiếu trường bắt buộc.");
+  }
+
+  return {
+    sourceMode: "youtube_companion",
+    videoId,
+    title,
+    channelTitle,
+    publishedAt,
+    durationIso8601,
+    embeddable: item.status?.embeddable === true,
+    license,
+    watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    embedUrl: `https://www.youtube.com/embed/${videoId}`,
+    thumbnailUrl: pickThumbnail(item.snippet?.thumbnails),
+  };
+}

--- a/src/features/media-ingestion/domain/youtube-companion-demo.ts
+++ b/src/features/media-ingestion/domain/youtube-companion-demo.ts
@@ -3,13 +3,13 @@ export type YouTubeMetadataSource = "youtube_data_api" | "youtube_oembed";
 
 export interface YouTubeCompanionMetadata {
   sourceMode: "youtube_companion";
-  metadataSource: YouTubeMetadataSource;
+  metadataSource?: YouTubeMetadataSource;
   videoId: string;
   title: string;
   channelTitle: string;
-  authorUrl: string | null;
-  publishedAt: string | null;
-  durationIso8601: string | null;
+  authorUrl?: string | null;
+  publishedAt: string;
+  durationIso8601: string;
   embeddable: boolean;
   license: YouTubeLicense | "unknown";
   watchUrl: string;
@@ -204,8 +204,8 @@ async function fetchViaOEmbed(
     title,
     channelTitle,
     authorUrl: payload.author_url?.trim() || null,
-    publishedAt: null,
-    durationIso8601: null,
+    publishedAt: "",
+    durationIso8601: "",
     embeddable: true,
     license: "unknown",
     watchUrl,

--- a/src/features/media-ingestion/domain/youtube-companion-demo.ts
+++ b/src/features/media-ingestion/domain/youtube-companion-demo.ts
@@ -1,14 +1,17 @@
 export type YouTubeLicense = "youtube" | "creativeCommon";
+export type YouTubeMetadataSource = "youtube_data_api" | "youtube_oembed";
 
 export interface YouTubeCompanionMetadata {
   sourceMode: "youtube_companion";
+  metadataSource: YouTubeMetadataSource;
   videoId: string;
   title: string;
   channelTitle: string;
-  publishedAt: string;
-  durationIso8601: string;
+  authorUrl: string | null;
+  publishedAt: string | null;
+  durationIso8601: string | null;
   embeddable: boolean;
-  license: YouTubeLicense;
+  license: YouTubeLicense | "unknown";
   watchUrl: string;
   embedUrl: string;
   thumbnailUrl: string | null;
@@ -38,6 +41,16 @@ interface YouTubeVideosListResponse {
   error?: {
     message?: string;
   };
+}
+
+interface YouTubeOEmbedResponse {
+  type?: string;
+  title?: string;
+  author_name?: string;
+  author_url?: string;
+  thumbnail_url?: string;
+  html?: string;
+  error?: string;
 }
 
 const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
@@ -99,21 +112,15 @@ function pickThumbnail(
   );
 }
 
-export async function fetchYouTubeCompanionMetadata(
-  input: string,
+async function fetchViaDataApi(
+  videoId: string,
   apiKey: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch,
 ): Promise<YouTubeCompanionMetadata> {
-  const normalizedKey = apiKey.trim();
-  if (!normalizedKey) {
-    throw new Error("Thiếu YOUTUBE_API_KEY.");
-  }
-
-  const videoId = extractYouTubeVideoId(input);
   const endpoint = new URL("https://www.googleapis.com/youtube/v3/videos");
   endpoint.searchParams.set("part", "snippet,status,contentDetails");
   endpoint.searchParams.set("id", videoId);
-  endpoint.searchParams.set("key", normalizedKey);
+  endpoint.searchParams.set("key", apiKey);
 
   const response = await fetchImpl(endpoint, {
     headers: { Accept: "application/json" },
@@ -144,9 +151,11 @@ export async function fetchYouTubeCompanionMetadata(
 
   return {
     sourceMode: "youtube_companion",
+    metadataSource: "youtube_data_api",
     videoId,
     title,
     channelTitle,
+    authorUrl: null,
     publishedAt,
     durationIso8601,
     embeddable: item.status?.embeddable === true,
@@ -155,4 +164,65 @@ export async function fetchYouTubeCompanionMetadata(
     embedUrl: `https://www.youtube.com/embed/${videoId}`,
     thumbnailUrl: pickThumbnail(item.snippet?.thumbnails),
   };
+}
+
+async function fetchViaOEmbed(
+  videoId: string,
+  fetchImpl: typeof fetch,
+): Promise<YouTubeCompanionMetadata> {
+  const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+  const endpoint = new URL("https://www.youtube.com/oembed");
+  endpoint.searchParams.set("url", watchUrl);
+  endpoint.searchParams.set("format", "json");
+
+  const response = await fetchImpl(endpoint, {
+    headers: { Accept: "application/json" },
+  });
+  const payload = (await response.json()) as YouTubeOEmbedResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      payload.error ?? `YouTube oEmbed trả về HTTP ${response.status}.`,
+    );
+  }
+
+  const title = payload.title?.trim();
+  const channelTitle = payload.author_name?.trim();
+  const hasEmbedRepresentation =
+    payload.type === "video" &&
+    typeof payload.html === "string" &&
+    /youtube(?:-nocookie)?\.com\/embed\//i.test(payload.html);
+
+  if (!title || !channelTitle || !hasEmbedRepresentation) {
+    throw new Error("YouTube oEmbed thiếu metadata hoặc mã nhúng hợp lệ.");
+  }
+
+  return {
+    sourceMode: "youtube_companion",
+    metadataSource: "youtube_oembed",
+    videoId,
+    title,
+    channelTitle,
+    authorUrl: payload.author_url?.trim() || null,
+    publishedAt: null,
+    durationIso8601: null,
+    embeddable: true,
+    license: "unknown",
+    watchUrl,
+    embedUrl: `https://www.youtube.com/embed/${videoId}`,
+    thumbnailUrl: payload.thumbnail_url?.trim() || null,
+  };
+}
+
+export async function fetchYouTubeCompanionMetadata(
+  input: string,
+  apiKey = "",
+  fetchImpl: typeof fetch = fetch,
+): Promise<YouTubeCompanionMetadata> {
+  const videoId = extractYouTubeVideoId(input);
+  const normalizedKey = apiKey.trim();
+
+  return normalizedKey
+    ? fetchViaDataApi(videoId, normalizedKey, fetchImpl)
+    : fetchViaOEmbed(videoId, fetchImpl);
 }

--- a/src/features/media-ingestion/domain/youtube-oembed-fallback.test.ts
+++ b/src/features/media-ingestion/domain/youtube-oembed-fallback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchYouTubeCompanionMetadata } from "@/features/media-ingestion/domain/youtube-companion-demo";
+
+describe("YouTube oEmbed metadata fallback", () => {
+  it("loads basic embeddable metadata without an API key", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "video",
+          title: "A natural conversation",
+          author_name: "Example Creator",
+          author_url: "https://www.youtube.com/@example",
+          thumbnail_url: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+          html:
+            '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"></iframe>',
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const metadata = await fetchYouTubeCompanionMetadata(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "",
+      fetchMock,
+    );
+
+    expect(metadata).toMatchObject({
+      metadataSource: "youtube_oembed",
+      videoId: "dQw4w9WgXcQ",
+      title: "A natural conversation",
+      channelTitle: "Example Creator",
+      authorUrl: "https://www.youtube.com/@example",
+      publishedAt: "",
+      durationIso8601: "",
+      embeddable: true,
+      license: "unknown",
+      embedUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    });
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(requestUrl.origin).toBe("https://www.youtube.com");
+    expect(requestUrl.pathname).toBe("/oembed");
+    expect(requestUrl.searchParams.get("format")).toBe("json");
+    expect(requestUrl.searchParams.get("url")).toBe(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    );
+  });
+
+  it("rejects an oEmbed response without an official embed representation", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "video",
+          title: "Unavailable video",
+          author_name: "Example Creator",
+          html: "",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      fetchYouTubeCompanionMetadata("dQw4w9WgXcQ", "", fetchMock),
+    ).rejects.toThrow("mã nhúng hợp lệ");
+  });
+});


### PR DESCRIPTION
## Owner intent

Provide a runnable TypeScript/Node experiment for turning a YouTube URL plus an authorized local caption file into an editor-only listening lesson draft.

## Current behavior

- parses supported YouTube URL forms;
- uses the official YouTube Data API when `YOUTUBE_API_KEY` is available;
- falls back to YouTube oEmbed when no API key is available;
- records limited metadata from oEmbed without inventing duration, publication date, or license;
- builds an official embed URL;
- reads only local VTT/SRT caption files explicitly marked as authorized;
- validates cue order, overlap, and media-duration bounds when duration is known;
- generates comprehension, acquisition, and transfer activities;
- keeps the result at `editor_draft` with explicit publication blocks.

## Important boundary

This experiment does not download video/audio, scrape YouTube captions, call unofficial media endpoints, accept remote caption URLs, or publish a lesson automatically.

A caption-derived lesson draft requires:

- `--caption-authorized`;
- a local caption path;
- `--rights-evidence=<reference>`.

## Run without API key

```bash
npx tsx scripts/demo-youtube-companion.ts \
  --url=https://www.youtube.com/watch?v=VIDEO_ID
```

The CLI uses YouTube oEmbed and marks metadata as limited/unknown where oEmbed does not provide the field.

## Run with an authorized local caption

```bash
npx tsx scripts/demo-youtube-companion.ts \
  --url=https://www.youtube.com/watch?v=VIDEO_ID \
  --caption=fixtures/media-ingestion/demo-authorized-caption.vtt \
  --caption-authorized \
  --rights-evidence=creator-upload-record-123
```

## Files

- `docs/curriculum/AUTHORIZED_NATURAL_MEDIA_INGESTION.md`
- `src/features/media-ingestion/domain/youtube-companion-demo.ts`
- `src/features/media-ingestion/domain/timed-text.ts`
- `src/features/media-ingestion/domain/lesson-draft.ts`
- `src/features/media-ingestion/domain/index.ts`
- `src/features/media-ingestion/domain/youtube-companion-demo.test.ts`
- `src/features/media-ingestion/domain/youtube-oembed-fallback.test.ts`
- `scripts/demo-youtube-companion.ts`
- `fixtures/media-ingestion/demo-authorized-caption.vtt`

## Stacking

- Base: `feature/two-lane-content-model` / PR #50.
- Head: `experiment/authorized-natural-media-ingestion`.

## Exact-head verification

- Current head: `a874120a389c451cc39ac7a4cbd1fb4692f0fcce`.
- GitHub Verify run #78, ID `30743162106`: **passed**.
- Passed: dependency install, ESLint, TypeScript, unit tests, and content-standard tests.

## Scope

No downloader, caption scraper, audio extractor, OAuth flow, object storage, database migration, production route, merge, or deploy.

## Current state

Keep this PR draft and stacked. The experiment is not the canonical product direction; it is a reusable ingestion/authoring proof for sources whose transcript use is authorized.