### PR TITLE
docs: define YouTube-to-private-lesson MVP plan

### DIFF
--- a/.specify/README.md
+++ b/.specify/README.md
@@ -1,87 +1,65 @@
 # AtoEnglish Spec Kit Workflow
 
-This repository uses GitHub Spec Kit's spec-driven sequence as its development
-control plane:
+This repository uses the sequence:
 
 ```text
 constitution
-→ specify
-→ clarify/checklist
-→ plan
-→ tasks
-→ analyze
-→ implement
-→ converge
+→ specification
+→ clarification/checklist
+→ plan/research/data/contracts
+→ dependency-ordered tasks
+→ cross-artifact analysis
+→ implementation by user story
+→ convergence and owner review
 ```
 
-## Repository layout
+## Governing product decision
+
+The owner confirmed on 2026-08-03 that the core product remains:
+
+```text
+Paste a YouTube URL
+→ generate an owner-private personal English lesson
+→ learn, save, and return
+```
+
+A fixed reviewed catalog does not replace this workflow. Public sharing and human
+publication review are later features.
+
+## Current artifacts
 
 ```text
 .specify/memory/constitution.md
-specs/<feature>/spec.md
-specs/<feature>/plan.md
-specs/<feature>/research.md
-specs/<feature>/data-model.md
-specs/<feature>/quickstart.md
-specs/<feature>/contracts/
-specs/<feature>/checklists/
-specs/<feature>/tasks.md
-specs/<feature>/analysis.md
-```
-
-The repository was initially bootstrapped manually because the first agent session
-did not have a local working tree or the `specify` CLI. The manual bootstrap does
-not claim that CLI integration files, scripts, or slash commands are installed.
-
-## Governing specs
-
-Rebuild roadmap:
-
-```text
 specs/000-atoenglish-rebuild-roadmap/
-```
-
-Existing compiler/provenance feature and evidence:
-
-```text
 specs/001-private-natural-lesson-compiler/
-```
-
-Proposed MVP convergence feature:
-
-```text
 specs/002-mvp-product-convergence/
 ```
 
-Spec 002 planning artifacts are prepared for owner review. They do not authorize
-implementation, hosted migration, preview deployment, merge, or production
-deployment. After owner acceptance, its `tasks.md` becomes the only active MVP
-implementation queue.
+- Spec 001 contains reusable compiler, transcript, Gemini, evidence, private-draft,
+  RLS, hosted, and browser work.
+- Spec 002 converges that work onto current main as the learner-facing
+  YouTube-to-private-lesson MVP.
 
-Spec 001 remains reusable evidence and source code material. Its diverged branch
-must not be merged wholesale into the future MVP branch.
+Implementation must start from current `main` and selectively port accepted work.
+The diverged Real Talk branch/PR #54 must not be merged wholesale.
 
-## Optional local CLI initialization
+## Repository Rules
 
-When working from a local clone, verify the official CLI and initialize the
-preferred agent integration without discarding existing artifacts. Review the
-CLI's proposed changes before accepting them.
+- No non-trivial implementation begins without an active spec and task mapping.
+- Checked tasks require observed evidence, not code existence.
+- Live transcript/Gemini/browser/hosted checks are not replaced by mocks.
+- Generated lessons remain private AI drafts unless a later human-review feature
+  approves publication.
+- Hosted migrations, Vercel preview, merge, and production deployment require
+  explicit authorization at their respective gates.
+- Agents do not merge or deploy automatically.
 
-Example:
+## Planning State
 
-```bash
-specify version
-specify init --here --force --integration codex --integration-options="--skills"
+```text
+Core direction:           confirmed
+Spec 002 planning:        revised and converged
+Implementation permission: not yet recorded
+Implementation branch:    not created
+Preview/merge/deploy:     not authorized
 ```
-
-Do not overwrite `.specify/memory/constitution.md` or feature artifacts without an
-explicit constitution amendment or approved spec update.
-
-## Repository rule
-
-No non-trivial implementation begins from an ad-hoc prompt alone. It must map to
-an accepted feature under `specs/`, and its pull request must state which tasks are
-complete, which evidence was observed, and which blockers remain.
-
-A planning document is not implementation permission. Migrations, previews,
-merge, and production deployment remain separate owner-gated actions.

--- a/.specify/README.md
+++ b/.specify/README.md
@@ -14,11 +14,7 @@ constitution
 → converge
 ```
 
-## Current bootstrap
-
-The repository was bootstrapped manually on `agent/rebuild-learning-core` because
-this agent session did not have a local working tree or the `specify` CLI. The
-file layout and artifacts follow the official Spec Kit structure:
+## Repository layout
 
 ```text
 .specify/memory/constitution.md
@@ -30,10 +26,40 @@ specs/<feature>/quickstart.md
 specs/<feature>/contracts/
 specs/<feature>/checklists/
 specs/<feature>/tasks.md
+specs/<feature>/analysis.md
 ```
 
-The manual bootstrap does not claim that CLI integration files, scripts, or agent
-slash commands are installed.
+The repository was initially bootstrapped manually because the first agent session
+did not have a local working tree or the `specify` CLI. The manual bootstrap does
+not claim that CLI integration files, scripts, or slash commands are installed.
+
+## Governing specs
+
+Rebuild roadmap:
+
+```text
+specs/000-atoenglish-rebuild-roadmap/
+```
+
+Existing compiler/provenance feature and evidence:
+
+```text
+specs/001-private-natural-lesson-compiler/
+```
+
+Proposed MVP convergence feature:
+
+```text
+specs/002-mvp-product-convergence/
+```
+
+Spec 002 planning artifacts are prepared for owner review. They do not authorize
+implementation, hosted migration, preview deployment, merge, or production
+deployment. After owner acceptance, its `tasks.md` becomes the only active MVP
+implementation queue.
+
+Spec 001 remains reusable evidence and source code material. Its diverged branch
+must not be merged wholesale into the future MVP branch.
 
 ## Optional local CLI initialization
 
@@ -41,30 +67,21 @@ When working from a local clone, verify the official CLI and initialize the
 preferred agent integration without discarding existing artifacts. Review the
 CLI's proposed changes before accepting them.
 
-Example for Codex skills mode:
+Example:
 
 ```bash
 specify version
 specify init --here --force --integration codex --integration-options="--skills"
 ```
 
-Do not overwrite `.specify/memory/constitution.md` or active feature artifacts
-without an explicit constitution amendment or spec update.
+Do not overwrite `.specify/memory/constitution.md` or feature artifacts without an
+explicit constitution amendment or approved spec update.
 
 ## Repository rule
 
 No non-trivial implementation begins from an ad-hoc prompt alone. It must map to
-an active feature under `specs/`, and the pull request must state which tasks are
+an accepted feature under `specs/`, and its pull request must state which tasks are
 complete, which evidence was observed, and which blockers remain.
 
-The active feature is:
-
-```text
-specs/001-private-natural-lesson-compiler/
-```
-
-The rebuild roadmap is:
-
-```text
-specs/000-atoenglish-rebuild-roadmap/
-```
+A planning document is not implementation permission. Migrations, previews,
+merge, and production deployment remain separate owner-gated actions.

--- a/docs/product/CURRENT_PRIORITY.md
+++ b/docs/product/CURRENT_PRIORITY.md
@@ -1,115 +1,105 @@
-# AtoEnglish current priority
+# AtoEnglish Current Priority
 
 **Updated:** 2026-08-03  
 **Owner:** Thunderkill016  
-**Development method:** GitHub Spec Kit / Spec-Driven Development
+**Method:** GitHub Spec Kit / Spec-Driven Development
 
-## Governing artifacts
+## Confirmed Product Direction
+
+AtoEnglish's core product remains:
 
 ```text
-.specify/memory/constitution.md
-specs/000-atoenglish-rebuild-roadmap/roadmap.md
-specs/001-private-natural-lesson-compiler/
-specs/002-mvp-product-convergence/
+Dán link video YouTube
+→ tạo bài học tiếng Anh cá nhân từ video đó
+→ học, lưu và quay lại
 ```
 
-## North star
+The MVP must make this private URL-to-lesson workflow reliable and usable. It must
+not replace it with a fixed reviewed catalog.
 
-Help a Vietnamese adult understand and respond inside a natural English
-communication environment, then attempt the same practical goal with changed data
-or context.
-
-## Proposed active feature: 002 — MVP Product Convergence
-
-The repository already contains substantial UI, authentication, Supabase,
-learning, Real Talk, analytics, test, and Vercel infrastructure. The current
-problem is not a missing platform. It is that the product surface is fragmented
-across conflicting landing promises, legacy curriculum/navigation, broad feature
-routes, experimental authoring, and unreviewed static lesson fallback.
-
-The proposed MVP outcome is:
+## Proposed Active Feature: 002 — YouTube-to-Private-Lesson MVP
 
 ```text
 truthful landing
 → signup/login
-→ idempotent account bootstrap
-→ focused dashboard
-→ reviewed natural lesson catalog
-→ first listening encounter
-→ progressive support
-→ productive retrieval
-→ speak-and-confirm
-→ changed-context transfer
-→ bounded private progress
-→ return and continue/review
+→ URL-first dashboard
+→ validate supported YouTube source
+→ timed English transcript acquisition
+→ bounded interaction selection
+→ live Gemini structured generation
+→ source-evidence validation
+→ atomic owner-private ai_draft
+→ first listen / support / retrieval / speech / transfer
+→ bounded progress
+→ private library and return
 ```
-
-The first release is intentionally small:
-
-- one natural communication environment;
-- at least three human-reviewed lessons;
-- at least two speakers or contexts;
-- one complete desktop/mobile learner journey;
-- the existing hosted Supabase and Vercel projects;
-- one owner-reviewed preview.
 
 ## Relationship to Spec 001
 
-Spec 001 produced valuable verified contracts and infrastructure for:
+Spec 001 already produced the strongest reusable foundation:
 
-- authenticated private generation;
-- evidence validation;
-- owner-private draft persistence and RLS;
-- transcript provenance and independent review;
-- approved reviewed-source adapter;
-- persisted desktop/mobile preview.
+- authentication before transcript/Gemini work;
+- URL/source and transcript adapter contracts;
+- bounded interaction selection;
+- Gemini structured output;
+- schema and source-evidence validation;
+- stable failure codes;
+- deterministic owner-private identity;
+- atomic private persistence and RLS;
+- provenance/warnings;
+- persisted desktop/mobile private preview.
 
-It is not a branch that should be merged wholesale. Its current implementation
-branch is diverged hundreds of commits from `main` and carries conflicting legacy
-state. Spec 002 requires a fresh integration branch from current `main` and a
-file-level port manifest.
+Its branch is diverged from main and cannot be merged wholesale. Spec 002 ports
+only accepted files/contracts/tests onto a fresh branch from current main.
 
-## Ordered next actions
+## Ordered Next Actions
 
-1. Owner reviews and accepts or changes the MVP promise and scope.
-2. Confirm the initial environment, defaulting to **Meet someone new**.
-3. Confirm that at least three source packages can receive lawful-use and full
-   human review.
-4. Create a fresh implementation branch from current `main`.
-5. Complete Phase 1 of `specs/002-mvp-product-convergence/tasks.md` before learner
-   code changes.
-6. Implement by user story and stop at each independent checkpoint.
-7. Create exactly one intentional Vercel preview only after technical and hosted
-   gates pass.
-8. Obtain owner acceptance before preparing a main-targeted merge PR.
+1. Record explicit implementation authorization separately from the already
+   confirmed product correction.
+2. Freeze current main and create `integration/mvp-youtube-to-lesson`.
+3. Build the file-level port manifest.
+4. Align package/toolchain and Supabase types/project reference.
+5. Make landing/auth/dashboard center on the YouTube URL form.
+6. Finalize the private-production transcript adapter decision and supported-video
+   failure behavior.
+7. Verify live Gemini success/failure with a bounded secret.
+8. Integrate atomic private generation, lesson runtime, progress, and private library.
+9. Run hosted RLS, live provider, desktop/mobile Vercel preview, and runtime checks.
+10. Obtain owner acceptance before any merge/deployment decision.
 
-## Explicit MVP exclusions
+## Hard Release Blockers
 
-- broad A0–B2 curriculum or capability graph;
-- arbitrary YouTube generation in the learner product;
-- automatic transcript approval/publication;
-- unrestricted chatbot;
-- pronunciation scoring;
-- raw learner audio or free-text storage;
-- XP, streak, league, achievement, challenge, certificate, or social expansion;
-- grammar, writing, broad speaking tools, business track, and push-notification
-  systems as core MVP surfaces;
-- subscriptions, payments, native apps;
-- whole-branch merge of PR #54;
-- automatic merge or deployment.
+- no accepted transcript adapter/private-production decision;
+- missing live `GEMINI_API_KEY` verification;
+- generation not cleanly integrated onto current main;
+- unsupported-video failures not proven;
+- atomic owner-private persistence/RLS not proven on final head;
+- no complete desktop/mobile URL-to-lesson/return preview;
+- owner acceptance missing.
 
-## Decision status
+## Explicit MVP Exclusions
+
+- public/shared catalog as the primary product;
+- automatic publication;
+- full reviewer UI;
+- bulk crawling/generation;
+- support for every YouTube video;
+- media downloading/re-hosting;
+- broad curriculum, XP/streak/league, writing, grammar, business, broad speaking,
+  notifications, payments, social, or native apps;
+- pronunciation scoring or raw learner audio/transcript storage;
+- wholesale merge of PR #54;
+- autonomous merge/deployment.
+
+## Decision Status
 
 ```text
-Spec quality:             prepared
-Planning convergence:     pass
-Implementation approval:  pending owner acceptance
-Implementation branch:    not created
-Hosted migration:         not authorized
-Vercel preview:           not authorized
-Merge:                    not authorized
-Production deployment:    not authorized
+Core product direction:    confirmed
+Planning artifacts:        revised and converged
+Implementation permission: not yet recorded
+Implementation branch:     not created
+Hosted migration:          not authorized
+Vercel preview:            not authorized
+Merge:                     not authorized
+Production deployment:     not authorized
 ```
-
-Until the owner accepts Spec 002, the repository remains in planning/review mode.
-No task may infer implementation permission merely because the plan exists.

--- a/docs/product/CURRENT_PRIORITY.md
+++ b/docs/product/CURRENT_PRIORITY.md
@@ -1,6 +1,6 @@
 # AtoEnglish current priority
 
-**Updated:** 2026-08-02  
+**Updated:** 2026-08-03  
 **Owner:** Thunderkill016  
 **Development method:** GitHub Spec Kit / Spec-Driven Development
 
@@ -8,114 +8,108 @@
 
 ```text
 .specify/memory/constitution.md
-specs/000-atoenglish-rebuild-roadmap/spec.md
 specs/000-atoenglish-rebuild-roadmap/roadmap.md
 specs/001-private-natural-lesson-compiler/
+specs/002-mvp-product-convergence/
 ```
-
-The task ledger at
-`specs/001-private-natural-lesson-compiler/tasks.md` is the only active delivery
-queue. This document summarizes it; it does not replace it.
 
 ## North star
 
 Help a Vietnamese adult understand and respond inside a natural English
-communication environment, then demonstrate the same goal with changed data or
-context.
+communication environment, then attempt the same practical goal with changed data
+or context.
 
-## Active feature: 001 — Private Natural Lesson Compiler
+## Proposed active feature: 002 — MVP Product Convergence
 
-The immediate outcome is:
+The repository already contains substantial UI, authentication, Supabase,
+learning, Real Talk, analytics, test, and Vercel infrastructure. The current
+problem is not a missing platform. It is that the product surface is fragmented
+across conflicting landing promises, legacy curriculum/navigation, broad feature
+routes, experimental authoring, and unreviewed static lesson fallback.
 
-```text
-authenticated editor
-→ approved source evidence
-→ bounded natural interaction window
-→ Gemini environment lesson proposal
-→ typed and source-evidence validation
-→ owner-private ai_draft
-→ human-reviewable preview with transfer
-```
-
-The current branch already contains substantial implementation. It is not
-converged and not production-ready.
-
-## Ordered work
-
-### 1. Complete compiler contracts and tests
-
-- extract a real `TranscriptSourceAdapter` boundary;
-- isolate the current unofficial transcript mechanism as experimental;
-- add stable machine-readable failure codes;
-- make persistence failure explicit;
-- complete the invalid-output and prompt-injection fixture matrix;
-- test that authentication happens before transcript/Gemini calls.
-
-### 2. Verify owner-private persistence
-
-- run the migration in an authorized non-production Supabase project;
-- verify anonymous, ownerA, and ownerB RLS behavior;
-- verify ordinary users cannot approve or publish drafts;
-- verify environment, communication events, transfer, warnings, and model survive reload;
-- regenerate Supabase types after migration.
-
-### 3. Verify the natural lesson preview
-
-- add component tests for environment-first presentation;
-- require source-backed phrase production acknowledgement;
-- require a changed-context response before completion;
-- verify no pronunciation or mastery claim appears;
-- run desktop and mobile browser preview with one controlled draft.
-
-### 4. Run exact-head convergence checks
-
-- lint;
-- TypeScript;
-- unit tests;
-- content-standard tests;
-- production build;
-- live Gemini success and failure paths with a bounded test key;
-- manual source, transcript, speaker, translation, safety, and pedagogy review;
-- final requirement-to-evidence mapping.
-
-## Explicit blockers
-
-Spec 001 cannot converge while any of these remain unresolved:
-
-1. production policy for transcript acquisition;
-2. experimental adapter isolation;
-3. stable failure and persistence behavior;
-4. full automated test coverage;
-5. non-production RLS and migration evidence;
-6. exact-head repository checks;
-7. live Gemini and browser evidence;
-8. human source and lesson review.
-
-## What comes next
-
-Only after spec 001 converges may work start on:
+The proposed MVP outcome is:
 
 ```text
-002 — Human Review and Publication Gate
+truthful landing
+→ signup/login
+→ idempotent account bootstrap
+→ focused dashboard
+→ reviewed natural lesson catalog
+→ first listening encounter
+→ progressive support
+→ productive retrieval
+→ speak-and-confirm
+→ changed-context transfer
+→ bounded private progress
+→ return and continue/review
 ```
 
-Specs for curriculum sequencing, delayed transfer, analytics, rewards, payments,
-social systems, or catalog expansion are not active.
+The first release is intentionally small:
 
-## Out of scope now
+- one natural communication environment;
+- at least three human-reviewed lessons;
+- at least two speakers or contexts;
+- one complete desktop/mobile learner journey;
+- the existing hosted Supabase and Vercel projects;
+- one owner-reviewed preview.
 
-- automatic publication;
-- broad source scraping infrastructure;
-- downloading or re-hosting YouTube media;
-- visible grammar-first curriculum rebuild;
-- unrestricted AI conversation tutor;
-- phoneme or pronunciation claims without an approved acoustic provider;
-- XP, streak, league, payment, or social expansion;
-- production migration, merge, or deployment by an agent.
+## Relationship to Spec 001
 
-## Completion rule
+Spec 001 produced valuable verified contracts and infrastructure for:
 
-The active phase is complete only when all required tasks in
-`specs/001-private-natural-lesson-compiler/tasks.md` are checked from observed
-evidence, the requirements checklist is complete, cross-artifact analysis finds
-no critical conflict, and the owner accepts the exact final state.
+- authenticated private generation;
+- evidence validation;
+- owner-private draft persistence and RLS;
+- transcript provenance and independent review;
+- approved reviewed-source adapter;
+- persisted desktop/mobile preview.
+
+It is not a branch that should be merged wholesale. Its current implementation
+branch is diverged hundreds of commits from `main` and carries conflicting legacy
+state. Spec 002 requires a fresh integration branch from current `main` and a
+file-level port manifest.
+
+## Ordered next actions
+
+1. Owner reviews and accepts or changes the MVP promise and scope.
+2. Confirm the initial environment, defaulting to **Meet someone new**.
+3. Confirm that at least three source packages can receive lawful-use and full
+   human review.
+4. Create a fresh implementation branch from current `main`.
+5. Complete Phase 1 of `specs/002-mvp-product-convergence/tasks.md` before learner
+   code changes.
+6. Implement by user story and stop at each independent checkpoint.
+7. Create exactly one intentional Vercel preview only after technical and hosted
+   gates pass.
+8. Obtain owner acceptance before preparing a main-targeted merge PR.
+
+## Explicit MVP exclusions
+
+- broad A0–B2 curriculum or capability graph;
+- arbitrary YouTube generation in the learner product;
+- automatic transcript approval/publication;
+- unrestricted chatbot;
+- pronunciation scoring;
+- raw learner audio or free-text storage;
+- XP, streak, league, achievement, challenge, certificate, or social expansion;
+- grammar, writing, broad speaking tools, business track, and push-notification
+  systems as core MVP surfaces;
+- subscriptions, payments, native apps;
+- whole-branch merge of PR #54;
+- automatic merge or deployment.
+
+## Decision status
+
+```text
+Spec quality:             prepared
+Planning convergence:     pass
+Implementation approval:  pending owner acceptance
+Implementation branch:    not created
+Hosted migration:         not authorized
+Vercel preview:           not authorized
+Merge:                    not authorized
+Production deployment:    not authorized
+```
+
+Until the owner accepts Spec 002, the repository remains in planning/review mode.
+No task may infer implementation permission merely because the plan exists.

--- a/specs/000-atoenglish-rebuild-roadmap/roadmap.md
+++ b/specs/000-atoenglish-rebuild-roadmap/roadmap.md
@@ -11,6 +11,37 @@ No child spec may silently absorb another. A later feature may depend on an
 approved contract from an earlier feature, but it must remain independently
 reviewable and stoppable.
 
+## Proposed owner reprioritization — 2026-08-03
+
+Repository and infrastructure audit found that AtoEnglish already has substantial
+compiler, auth, database, UI, learning, analytics, and deployment infrastructure,
+but it does not yet present one coherent usable product. The Real Talk branch is
+also diverged hundreds of commits from `main`, and the current learner surface
+contains conflicting product promises and unreviewed static lesson fallbacks.
+
+The proposed next active feature is therefore:
+
+```text
+002 — MVP Product Convergence
+```
+
+This is a bounded orchestration spec, not permission for a broad rewrite. It
+combines only the minimum slices required to prove one complete learner value
+loop:
+
+- truthful landing and authentication;
+- focused dashboard/navigation;
+- one environment with at least three human-reviewed lessons;
+- reviewed learner catalog and lawful playback;
+- environment-first runtime with retrieval, speech confirmation, and transfer;
+- bounded private progress and return;
+- privacy-safe pilot evidence and one preview.
+
+This reprioritization remains **proposed** until the owner accepts
+`specs/002-mvp-product-convergence/`. Until that decision, no implementation,
+hosted migration, preview, merge, or deployment is authorized by this roadmap
+change.
+
 ## Ordered feature specs
 
 ### 001 — Private Natural Lesson Compiler
@@ -21,45 +52,67 @@ evidence-bound, owner-private AI lesson draft.
 **Independent value**: Safe creation and preview of one draft without public
 publication.
 
-**Current branch status**: Active. Existing implementation work on
-`agent/rebuild-learning-core` is governed retroactively and prospectively by this
-spec.
+**Current evidence status**: Substantial implementation and hosted verification
+exist on `agent/rebuild-learning-core`, including private drafts, provenance,
+trusted transcript review, an approved source adapter, RLS, atomic persistence,
+and desktop/mobile persisted preview. The spec is not fully converged because
+live Gemini, final human lesson review, public learner routing, and owner
+acceptance remain open.
 
-**Hard boundary**: No public catalog publication, no curriculum sequencing, no
-production claim that unreviewed caption scraping is approved.
+**Relationship to MVP**: Spec 001 is a source of contracts, security mechanisms,
+tests, and evidence. Its diverged branch MUST NOT be merged wholesale. Spec 002
+selectively ports only accepted work onto current `main`.
 
----
-
-### 002 — Human Review and Publication Gate
-
-**Outcome**: Authorized reviewers inspect source availability, rights,
-transcript, timestamps, speakers, safety, authenticity, and pedagogy before an
-immutable reviewed lesson is published.
-
-**Independent value**: A small trustworthy public catalog can exist without
-trusting generation output.
-
-**Depends on**: 001 draft and evidence contracts.
-
-**Hard boundary**: No automatic approval, no bulk publishing, no learner
-progression logic.
+**Hard boundary**: No automatic publication and no production claim that an
+experimental transcript path is approved.
 
 ---
 
-### 003 — Natural Environment Lesson Runtime
+### 002 — MVP Product Convergence
 
-**Outcome**: A learner completes one reviewed lesson through situation setup,
-cold listening, scaffolded comprehension, retrieval, spoken production,
-changed-context transfer, and honest completion feedback.
+**Outcome**: A Vietnamese beginner completes one coherent hosted product journey
+from truthful landing and authentication through one reviewed natural lesson,
+changed-context transfer, bounded persistence, and return.
 
-**Independent value**: One complete learning experience that can be tested with
-real learners.
+**Independent value**: A small real product can be tested with learners instead
+of continuing to accumulate disconnected routes, tools, and experiments.
 
-**Depends on**: 002 reviewed lesson contract. A static reviewed fixture may be
-used before the publication UI is complete.
+**Depends on**:
 
-**Hard boundary**: No broad curriculum map, no open-ended chatbot, no claimed
-phoneme assessment without an approved provider.
+- current `main` product/auth/database foundation;
+- selected Spec 001 provenance, private-draft, reviewed-source, and runtime work;
+- actual human review of at least three lessons in one environment;
+- connected Supabase and Vercel projects.
+
+**Hard boundary**:
+
+- one environment and a tiny reviewed corpus;
+- no whole-branch merge of the diverged Real Talk work;
+- no arbitrary learner-facing generation;
+- no broad curriculum graph;
+- no XP/streak/league, writing, notification, payment, social, or native-app
+  expansion;
+- no automatic merge or deployment.
+
+**Status**: Planning artifacts prepared on `spec/mvp-product-convergence`; owner
+acceptance is required before implementation.
+
+---
+
+### 003 — Full Human Review and Publication Operations
+
+**Outcome**: Authorized reviewers can inspect, correct, approve, reject, publish,
+unpublish, and audit source/lesson packages through a durable operational
+interface.
+
+**Independent value**: The owner can grow a trustworthy reviewed catalog without
+controlled scripts or ad-hoc database operations.
+
+**Depends on**: Spec 001 evidence contracts and the minimal controlled
+publication boundary proven by Spec 002.
+
+**Hard boundary**: No automatic approval, no bulk autonomous publishing, and no
+curriculum sequencing.
 
 ---
 
@@ -72,7 +125,8 @@ machinery from the learner.
 **Independent value**: Natural content becomes a coherent progression rather than
 a random catalog.
 
-**Depends on**: 002 reviewed metadata and 003 runtime evidence.
+**Depends on**: Reviewed metadata and the learner runtime/attempt evidence proven
+by Specs 002–003.
 
 **Hard boundary**: No automatic source fabrication to fill coverage gaps. No
 visible grammar-unit navigation as the primary journey.
@@ -88,24 +142,23 @@ transfer are recorded separately.
 **Independent value**: The product can distinguish lesson completion from
 retention and transfer.
 
-**Depends on**: 003 attempts and 004 capability mapping.
+**Depends on**: Spec 002 attempts and Spec 004 capability mapping.
 
 **Hard boundary**: No raw audio retention by default and no mastery claims from a
 single attempt.
 
 ---
 
-### 006 — Pilot Operations and Product Evidence
+### 006 — Pilot Expansion and Product Evidence
 
-**Outcome**: The owner can run a bounded pilot and evaluate activation,
-completion, retry, return, delayed transfer, support cost, willingness to pay,
-and renewal intent.
+**Outcome**: The owner expands beyond the first environment only when activation,
+completion, retry, return, transfer, support cost, willingness to pay, and renewal
+signals justify it.
 
 **Independent value**: Evidence determines whether to continue, narrow, or stop
 the product direction.
 
-**Depends on**: One complete path through specs 001–005, but only for a small
-reviewed environment set.
+**Depends on**: A converged Spec 002 MVP and, when needed, Specs 003–005.
 
 **Hard boundary**: No broad catalog expansion, payments platform, social system,
 or vanity-metric roadmap before pilot evidence.
@@ -119,7 +172,8 @@ A child spec may enter implementation only when:
 3. its plan passes the constitution check;
 4. tasks have exact file paths and dependency order;
 5. cross-artifact analysis has no unresolved critical conflict;
-6. the pull request names what remains unverified.
+6. the pull request names what remains unverified; and
+7. the owner accepts the scope when the spec changes roadmap priority.
 
 A child spec may be considered complete only when:
 
@@ -130,13 +184,16 @@ A child spec may be considered complete only when:
 5. the owner accepts the result; and
 6. no automatic merge or deployment occurred.
 
-## Current decision
+## Current decision boundary
 
-The only active implementation spec is:
+Planning for Spec 002 is complete enough for owner review. Implementation remains
+blocked until the owner explicitly accepts its promise, scope, first environment,
+and fresh-main selective-port strategy.
 
 ```text
-specs/001-private-natural-lesson-compiler/
+Planning branch:        spec/mvp-product-convergence
+Implementation branch:  not created
+Merge:                  not authorized
+Preview deployment:     not authorized
+Production deployment:  not authorized
 ```
-
-Specs 002–006 remain roadmap entries until 001 converges or the owner explicitly
-changes priority.

--- a/specs/000-atoenglish-rebuild-roadmap/roadmap.md
+++ b/specs/000-atoenglish-rebuild-roadmap/roadmap.md
@@ -1,199 +1,148 @@
 # AtoEnglish Rebuild — Spec of Specs
 
-## Why this roadmap exists
+## Roadmap Purpose
 
-The rebuild is too large and too interdependent for one specification and one
-implementation pass. This roadmap decomposes the product into independently
-valuable feature specs. Each child spec MUST run through its own specification,
-clarification, plan, tasks, analysis, implementation, and convergence cycle.
+The rebuild is decomposed into independently testable specs. No child spec may
+silently absorb another, and no agent may merge or deploy automatically.
 
-No child spec may silently absorb another. A later feature may depend on an
-approved contract from an earlier feature, but it must remain independently
-reviewable and stoppable.
+## Owner Correction — 2026-08-03
 
-## Proposed owner reprioritization — 2026-08-03
-
-Repository and infrastructure audit found that AtoEnglish already has substantial
-compiler, auth, database, UI, learning, analytics, and deployment infrastructure,
-but it does not yet present one coherent usable product. The Real Talk branch is
-also diverged hundreds of commits from `main`, and the current learner surface
-contains conflicting product promises and unreviewed static lesson fallbacks.
-
-The proposed next active feature is therefore:
+The core AtoEnglish idea is confirmed as:
 
 ```text
-002 — MVP Product Convergence
+learner pastes a YouTube URL
+→ AtoEnglish generates a private personal English lesson
 ```
 
-This is a bounded orchestration spec, not permission for a broad rewrite. It
-combines only the minimum slices required to prove one complete learner value
-loop:
+A fixed reviewed lesson catalog must not replace this interaction. The roadmap is
+therefore ordered around making the private URL-to-lesson workflow usable first.
 
-- truthful landing and authentication;
-- focused dashboard/navigation;
-- one environment with at least three human-reviewed lessons;
-- reviewed learner catalog and lawful playback;
-- environment-first runtime with retrieval, speech confirmation, and transfer;
-- bounded private progress and return;
-- privacy-safe pilot evidence and one preview.
-
-This reprioritization remains **proposed** until the owner accepts
-`specs/002-mvp-product-convergence/`. Until that decision, no implementation,
-hosted migration, preview, merge, or deployment is authorized by this roadmap
-change.
-
-## Ordered feature specs
+## Ordered Feature Specs
 
 ### 001 — Private Natural Lesson Compiler
 
-**Outcome**: An authenticated editor turns approved source evidence into a typed,
-evidence-bound, owner-private AI lesson draft.
+**Outcome:** An authenticated user turns supported YouTube transcript evidence into
+a typed, evidence-bound, owner-private AI lesson draft.
 
-**Independent value**: Safe creation and preview of one draft without public
-publication.
+**Current evidence:** Substantial implementation exists on
+`agent/rebuild-learning-core`: authentication ordering, transcript adapter/policy,
+bounded segment selection, Gemini structured output, evidence validation, atomic
+private persistence, RLS, provenance, stable failures, and desktop/mobile persisted
+preview.
 
-**Current evidence status**: Substantial implementation and hosted verification
-exist on `agent/rebuild-learning-core`, including private drafts, provenance,
-trusted transcript review, an approved source adapter, RLS, atomic persistence,
-and desktop/mobile persisted preview. The spec is not fully converged because
-live Gemini, final human lesson review, public learner routing, and owner
-acceptance remain open.
+**Remaining blockers:** final private-production transcript decision, live Gemini
+key/path, clean integration with current main, exact-head hosted/Vercel learner
+journey, and owner release acceptance.
 
-**Relationship to MVP**: Spec 001 is a source of contracts, security mechanisms,
-tests, and evidence. Its diverged branch MUST NOT be merged wholesale. Spec 002
-selectively ports only accepted work onto current `main`.
-
-**Hard boundary**: No automatic publication and no production claim that an
-experimental transcript path is approved.
+**Hard boundary:** generated lessons remain private AI drafts; no automatic
+publication and no claim that every YouTube video is supported.
 
 ---
 
-### 002 — MVP Product Convergence
+### 002 — YouTube-to-Private-Lesson MVP Convergence
 
-**Outcome**: A Vietnamese beginner completes one coherent hosted product journey
-from truthful landing and authentication through one reviewed natural lesson,
-changed-context transfer, bounded persistence, and return.
+**Outcome:** A Vietnamese learner completes the full hosted product journey:
 
-**Independent value**: A small real product can be tested with learners instead
-of continuing to accumulate disconnected routes, tools, and experiments.
+```text
+landing
+→ auth
+→ paste supported YouTube URL
+→ transcript + live Gemini generation
+→ private ai_draft
+→ transfer-gated lesson
+→ private progress/library
+→ return
+```
 
-**Depends on**:
+**Independent value:** The actual product idea becomes usable instead of remaining
+a disconnected compiler branch beside a legacy course application.
 
-- current `main` product/auth/database foundation;
-- selected Spec 001 provenance, private-draft, reviewed-source, and runtime work;
-- actual human review of at least three lessons in one environment;
-- connected Supabase and Vercel projects.
+**Depends on:** current main foundation, selected Spec 001 code/evidence, hosted
+Supabase/Vercel, an accepted transcript adapter decision, and live Gemini access.
 
-**Hard boundary**:
+**Hard boundary:**
 
-- one environment and a tiny reviewed corpus;
-- no whole-branch merge of the diverged Real Talk work;
-- no arbitrary learner-facing generation;
-- no broad curriculum graph;
-- no XP/streak/league, writing, notification, payment, social, or native-app
-  expansion;
+- supported YouTube subset only;
+- official playback, no media re-hosting;
+- owner-private drafts and owner-only RLS;
+- no whole-branch merge of PR #54;
+- no public catalog/publication requirement;
+- no broad curriculum, gamification, writing, social, payment, or native-app expansion;
 - no automatic merge or deployment.
 
-**Status**: Planning artifacts prepared on `spec/mvp-product-convergence`; owner
-acceptance is required before implementation.
+**Status:** Planning corrected on `spec/mvp-product-convergence`. Core direction is
+confirmed; implementation authorization is still a separate decision.
 
 ---
 
-### 003 — Full Human Review and Publication Operations
+### 003 — Human Review, Sharing, and Publication
 
-**Outcome**: Authorized reviewers can inspect, correct, approve, reject, publish,
-unpublish, and audit source/lesson packages through a durable operational
-interface.
+**Outcome:** Authorized reviewers can inspect, correct, approve, reject, publish,
+unpublish, and audit selected generated/source lesson packages.
 
-**Independent value**: The owner can grow a trustworthy reviewed catalog without
-controlled scripts or ad-hoc database operations.
+**Independent value:** Private lessons can later become trustworthy shared/catalog
+content without making every generated draft public.
 
-**Depends on**: Spec 001 evidence contracts and the minimal controlled
-publication boundary proven by Spec 002.
+**Depends on:** private draft/provenance contracts from Specs 001–002.
 
-**Hard boundary**: No automatic approval, no bulk autonomous publishing, and no
-curriculum sequencing.
+**Hard boundary:** no automatic approval or mass autonomous publication.
 
 ---
 
-### 004 — Invisible Capability Graph
+### 004 — Private Library Intelligence and Capability Progression
 
-**Outcome**: Reviewed lessons map to communication capabilities and prerequisites.
-The system recommends the next environment while hiding academic curriculum
-machinery from the learner.
+**Outcome:** Private/generated and reviewed lessons map to communication
+capabilities; the product can recommend what to generate, revisit, or learn next
+without presenting a grammar syllabus.
 
-**Independent value**: Natural content becomes a coherent progression rather than
-a random catalog.
+**Depends on:** real learner attempt evidence from Spec 002 and reviewed metadata
+when available.
 
-**Depends on**: Reviewed metadata and the learner runtime/attempt evidence proven
-by Specs 002–003.
-
-**Hard boundary**: No automatic source fabrication to fill coverage gaps. No
-visible grammar-unit navigation as the primary journey.
+**Hard boundary:** no fabrication to fill coverage gaps and no grammar-first
+learner navigation.
 
 ---
 
-### 005 — Delayed Transfer and Learner Evidence
+### 005 — Delayed Transfer and Retention Evidence
 
-**Outcome**: The learner returns for reduced-support tasks with a new speaker or
-changed context. Immediate comprehension, recall, interactional use, and delayed
-transfer are recorded separately.
+**Outcome:** Learners return for reduced-support tasks with changed speakers/data
+and the product separates immediate completion from delayed retention/transfer.
 
-**Independent value**: The product can distinguish lesson completion from
-retention and transfer.
+**Depends on:** bounded attempts from Spec 002 and capability mapping from Spec 004.
 
-**Depends on**: Spec 002 attempts and Spec 004 capability mapping.
-
-**Hard boundary**: No raw audio retention by default and no mastery claims from a
-single attempt.
+**Hard boundary:** no raw audio retention by default and no mastery claims from one
+attempt.
 
 ---
 
 ### 006 — Pilot Expansion and Product Evidence
 
-**Outcome**: The owner expands beyond the first environment only when activation,
-completion, retry, return, transfer, support cost, willingness to pay, and renewal
-signals justify it.
+**Outcome:** Use activation, successful generation, unsupported-source rate,
+lesson completion, return, support cost, willingness to pay, and renewal evidence
+to decide whether to expand.
 
-**Independent value**: Evidence determines whether to continue, narrow, or stop
-the product direction.
+**Hard boundary:** no broad catalog, payments platform, social system, or vanity
+roadmap before evidence.
 
-**Depends on**: A converged Spec 002 MVP and, when needed, Specs 003–005.
+## Delivery Gates
 
-**Hard boundary**: No broad catalog expansion, payments platform, social system,
-or vanity-metric roadmap before pilot evidence.
+A spec may enter implementation only when its product decision is accepted, user
+stories are testable, plan/tasks/analysis are consistent, exact dependencies are
+visible, and the owner grants implementation permission when required.
 
-## Delivery gates
+A spec is complete only after exact-head repository, hosted database, required
+live-provider, browser, security, and owner evidence. Merge and deployment remain
+separate owner decisions.
 
-A child spec may enter implementation only when:
-
-1. its user stories are independently testable;
-2. unresolved decisions are visible or clarified;
-3. its plan passes the constitution check;
-4. tasks have exact file paths and dependency order;
-5. cross-artifact analysis has no unresolved critical conflict;
-6. the pull request names what remains unverified; and
-7. the owner accepts the scope when the spec changes roadmap priority.
-
-A child spec may be considered complete only when:
-
-1. all required tasks and acceptance scenarios have observed evidence;
-2. technical checks ran against the exact final head;
-3. required browser, database, external-service, and human review checks ran;
-4. no later spec is being used to hide incomplete scope;
-5. the owner accepts the result; and
-6. no automatic merge or deployment occurred.
-
-## Current decision boundary
-
-Planning for Spec 002 is complete enough for owner review. Implementation remains
-blocked until the owner explicitly accepts its promise, scope, first environment,
-and fresh-main selective-port strategy.
+## Current State
 
 ```text
-Planning branch:        spec/mvp-product-convergence
-Implementation branch:  not created
-Merge:                  not authorized
-Preview deployment:     not authorized
-Production deployment:  not authorized
+Planning branch:          spec/mvp-product-convergence
+Core product direction:   confirmed
+Implementation branch:    not created
+Implementation:           not yet explicitly authorized
+Hosted migration:         not authorized
+Preview:                  not authorized
+Merge:                    not authorized
+Production deployment:    not authorized
 ```

--- a/specs/002-mvp-product-convergence/analysis.md
+++ b/specs/002-mvp-product-convergence/analysis.md
@@ -1,0 +1,230 @@
+# Cross-Artifact Analysis: AtoEnglish MVP Product Convergence
+
+**Analyzed:** 2026-08-03  
+**Artifacts:** constitution, roadmap, Spec 001 evidence, Spec 002 specification,
+plan, research, data model, product contract, quickstart, requirements checklist,
+and task ledger
+
+## Executive Result
+
+```text
+Specification completeness: PASS
+Constitution alignment:     PASS
+Task coverage:              PASS
+Implementation readiness:   CONDITIONAL
+Critical contradictions:    1 roadmap numbering conflict to reconcile
+Owner authorization:        NOT GRANTED
+```
+
+The MVP has a coherent product boundary and dependency-ordered plan. It is not yet
+authorized for implementation because owner decisions, initial source feasibility,
+and roadmap priority must be confirmed.
+
+## Product Consistency
+
+All Spec 002 artifacts define the same critical learner journey:
+
+```text
+truthful landing
+→ authentication and idempotent bootstrap
+→ focused dashboard
+→ database-only reviewed catalog
+→ environment-first lesson
+→ first encounter
+→ progressive support
+→ productive retrieval
+→ speak-and-confirm
+→ changed-context transfer
+→ bounded private persistence
+→ return/continue/review
+```
+
+No artifact requires XP, streak, leagues, flashcards, grammar, writing, broad
+speaking tools, notifications, payments, or social systems for MVP completion.
+
+## Constitution Alignment Matrix
+
+| Constitution principle | Spec 002 implementation |
+| --- | --- |
+| Natural Communication First | One environment and reviewed natural lessons are the entire learner-facing learning surface. |
+| Evidence-Bound Generation | Database catalog fails closed; static samples and unreviewed drafts are forbidden. |
+| Transfer Before Completion | Runtime and database completion require a changed-context attempt. |
+| Rights, Privacy, Safety | Provider-neutral lawful playback, human review, RLS, bounded attempt data, no raw audio/free text. |
+| Small Independently Testable Delivery | One environment, three lessons, one complete journey, legacy modules deferred. |
+| Measurable Learner/Product Evidence | Funnel events and attempts are bounded; CI is not treated as effectiveness evidence. |
+
+No constitutional waiver is required.
+
+## Requirement-to-Task Coverage
+
+| Requirement | Primary tasks | Coverage result |
+| --- | --- | --- |
+| FR-001 truthful promise | T011–T014, T075 | Covered |
+| FR-002 protected MVP routes | T020–T021, T027 | Covered |
+| FR-003 server/idempotent bootstrap | T015–T019 | Covered |
+| FR-004 focused navigation | T022, T075–T076 | Covered |
+| FR-005 DB-only catalog/no static fallback | T035–T037, T043 | Covered |
+| FR-006 reviewed publication eligibility | T035, T039–T044 | Covered |
+| FR-007 lawful official playback | T030–T034 | Covered |
+| FR-008 provider-neutral sources | T030–T034, T044 | Covered |
+| FR-009 traceable learner claims | T039–T043, T091 | Covered |
+| FR-010 completion gates | T049–T055, T089–T090 | Covered |
+| FR-011 microphone-independent speech | T052, T056 | Covered |
+| FR-012 bounded owner-private persistence | T058–T068 | Covered |
+| FR-013 idempotent writes | T016–T017, T059–T066 | Covered |
+| FR-014 focused dashboard | T023–T025 | Covered |
+| FR-015 deferred routes not MVP | T022, T075–T076 | Covered |
+| FR-016 reuse hosted infrastructure | T006–T007, T044, T079 | Covered |
+| FR-017 same project/types/environment | T006–T007, T079 | Covered |
+| FR-018 fresh-main selective port | T002–T005, T028 | Covered |
+| FR-019 disable experimental ingestion/generation | T036–T038, T043 | Covered |
+| FR-020 three human-reviewed lessons | T039–T044, T091 | Covered |
+| FR-021 privacy-safe events | T070–T073 | Covered |
+| FR-022 complete verification gate | T080–T093 | Covered |
+| FR-023 preview runtime health | T094–T097 | Covered |
+| FR-024 owner release gates | T098–T104 | Covered |
+
+All functional requirements map to one or more exact implementation/verification
+tasks. No orphan requirement was found.
+
+## User Story Independence
+
+### US1 — Entry/auth/dashboard
+
+Can be developed and demonstrated with controlled reviewed-lesson fixtures before
+hosted publication. It creates value by proving activation and shell coherence.
+
+### US2 — Reviewed catalog
+
+Can be verified independently with hosted reviewed/public/private rows. It does
+not require learner attempt persistence.
+
+### US3 — Lesson runtime
+
+Can be tested against a reviewed immutable fixture/package before final hosted
+publication. Completion semantics are independent of dashboard complexity.
+
+### US4 — Persistence/return
+
+Can be tested with one reviewed lesson and two authenticated users. It does not
+require analytics or broad catalog expansion.
+
+### US5 — Pilot operations
+
+Depends on the first four stories but does not change their product semantics. It
+adds bounded instrumentation, resilience, preview, and operational evidence.
+
+The story split is independently stoppable and respects the constitution.
+
+## Data-Model Consistency
+
+The product contract requires bounded progress fields. The data model offers two
+valid implementation paths:
+
+1. strict typed reuse of existing evidence storage; or
+2. a small `real_talk_attempts` table.
+
+Task T058 forces a recorded decision before DDL. This is not a contradiction; it
+is an intentionally deferred implementation choice with the same external
+contract.
+
+Provider-neutral source fields are required because the verified source pipeline
+already uses Wikimedia/DVIDS while the current video table requires YouTube
+identity. Tasks T030–T034 and T044 cover the migration, playback, and hosted
+verification.
+
+## Branch and Toolchain Consistency
+
+All artifacts agree that:
+
+- implementation begins from current `main`;
+- PR #54/Real Talk branch is not merged wholesale;
+- the current main package/lock/toolchain baseline is retained;
+- selected Real Talk security/domain/runtime work is ported through a manifest;
+- hosted Supabase and Vercel projects are reused;
+- deployment and migration remain owner-gated.
+
+No artifact authorizes branch-level merge, automatic deployment, or replacement
+infrastructure.
+
+## Critical Conflict: Roadmap Numbering
+
+The existing rebuild roadmap defines its planned `002` as **Human Review and
+Publication Gate**. This planning branch introduces `002-mvp-product-convergence`.
+The new MVP spec includes only the minimum controlled publication operation and
+runtime necessary for a usable product; it does not implement the future full
+reviewer/publication system.
+
+**Required resolution before implementation**:
+
+- update `specs/000-atoenglish-rebuild-roadmap/roadmap.md` to record the owner
+  reprioritization;
+- make `002 — MVP Product Convergence` the active spec;
+- move the full reviewer/publication operations to a later spec number;
+- preserve Spec 001 as reusable compiler/provenance evidence rather than claiming
+  it converged.
+
+Task T008 covers this change after owner acceptance. Until then, implementation
+readiness remains conditional.
+
+## Non-Critical Open Decisions
+
+These decisions are bounded and do not change the MVP promise:
+
+1. **Initial environment** — default `Meet someone new`; owner/source feasibility
+   may select another initial environment.
+2. **Three source packages** — must pass lawful-use and human-review gates.
+3. **Attempt storage** — strict reuse versus new bounded table.
+4. **Publication status values** — reconcile exact existing constraints before
+   writing the public query/migration.
+5. **Deferred routes** — hide only versus redirect/feature flag when direct access
+   creates a critical contradiction.
+6. **Playback composition** — final mix of YouTube embed versus direct reviewed
+   public-domain/owned media.
+
+Each decision has an explicit owner/task gate and no task assumes its outcome.
+
+## Scope-Escape Checks
+
+The following potential expansions are explicitly blocked:
+
+- broad curriculum/capability graph;
+- five-environment catalog;
+- delayed transfer scheduler;
+- full reviewer dashboard;
+- arbitrary source ingestion;
+- pronunciation assessment;
+- raw audio/transcript retention;
+- XP/streak/league redesign;
+- removal/refactor of every legacy route;
+- new microservice or analytics platform;
+- payments/social/native apps.
+
+A task requiring one of these must stop and create a separate approved spec.
+
+## Verification Completeness
+
+The task ledger distinguishes:
+
+- local/unit/contract evidence;
+- hosted Supabase migration/RLS/advisor/type evidence;
+- human content review;
+- production-build browser evidence;
+- Vercel preview/runtime-log evidence;
+- owner product acceptance;
+- merge and production deployment authorization.
+
+No mock or old branch check is accepted as a substitute for final exact-head
+browser, hosted, human, or owner evidence.
+
+## Planning Convergence Decision
+
+```text
+Planning artifacts:       CONVERGED
+Implementation scope:     WELL-BOUNDED
+Implementation start:     BLOCKED ON OWNER ACCEPTANCE + ROADMAP RECONCILIATION
+Merge recommendation:     NOT APPLICABLE — PLANNING ONLY
+Deployment recommendation: DO NOT DEPLOY
+```
+
+After owner acceptance, complete T001–T010 before changing learner-facing code.

--- a/specs/002-mvp-product-convergence/analysis.md
+++ b/specs/002-mvp-product-convergence/analysis.md
@@ -1,9 +1,9 @@
 # Cross-Artifact Analysis: AtoEnglish MVP Product Convergence
 
 **Analyzed:** 2026-08-03  
-**Artifacts:** constitution, roadmap, Spec 001 evidence, Spec 002 specification,
-plan, research, data model, product contract, quickstart, requirements checklist,
-and task ledger
+**Artifacts:** constitution, proposed roadmap reprioritization, Spec 001 evidence,
+Spec 002 specification, plan, research, data model, product contract, quickstart,
+requirements checklist, current priority, and task ledger
 
 ## Executive Result
 
@@ -11,14 +11,16 @@ and task ledger
 Specification completeness: PASS
 Constitution alignment:     PASS
 Task coverage:              PASS
+Roadmap consistency:        PASS AS PROPOSAL
 Implementation readiness:   CONDITIONAL
-Critical contradictions:    1 roadmap numbering conflict to reconcile
+Critical contradictions:    0
 Owner authorization:        NOT GRANTED
 ```
 
-The MVP has a coherent product boundary and dependency-ordered plan. It is not yet
-authorized for implementation because owner decisions, initial source feasibility,
-and roadmap priority must be confirmed.
+The MVP has a coherent product boundary, dependency-ordered plan, and proposed
+roadmap position. It is not yet authorized for implementation because owner
+acceptance, initial source feasibility, and owner-gated infrastructure actions
+remain open.
 
 ## Product Consistency
 
@@ -147,25 +149,26 @@ All artifacts agree that:
 No artifact authorizes branch-level merge, automatic deployment, or replacement
 infrastructure.
 
-## Critical Conflict: Roadmap Numbering
+## Roadmap Consistency
 
-The existing rebuild roadmap defines its planned `002` as **Human Review and
-Publication Gate**. This planning branch introduces `002-mvp-product-convergence`.
-The new MVP spec includes only the minimum controlled publication operation and
-runtime necessary for a usable product; it does not implement the future full
-reviewer/publication system.
+The planning branch now proposes the following ordered roadmap:
 
-**Required resolution before implementation**:
+```text
+001 — Private Natural Lesson Compiler
+002 — MVP Product Convergence
+003 — Full Human Review and Publication Operations
+004 — Invisible Capability Graph
+005 — Delayed Transfer and Learner Evidence
+006 — Pilot Expansion and Product Evidence
+```
 
-- update `specs/000-atoenglish-rebuild-roadmap/roadmap.md` to record the owner
-  reprioritization;
-- make `002 — MVP Product Convergence` the active spec;
-- move the full reviewer/publication operations to a later spec number;
-- preserve Spec 001 as reusable compiler/provenance evidence rather than claiming
-  it converged.
+This resolves the previous duplicate `002` numbering without claiming owner
+approval. The roadmap and current-priority documents explicitly label Spec 002 as
+a proposal and keep implementation blocked until owner acceptance.
 
-Task T008 covers this change after owner acceptance. Until then, implementation
-readiness remains conditional.
+Spec 002 uses only a controlled publication operation and one reviewed runtime
+slice. It does not silently absorb the future full reviewer/publication operations
+now assigned to Spec 003.
 
 ## Non-Critical Open Decisions
 
@@ -220,10 +223,10 @@ browser, hosted, human, or owner evidence.
 ## Planning Convergence Decision
 
 ```text
-Planning artifacts:       CONVERGED
-Implementation scope:     WELL-BOUNDED
-Implementation start:     BLOCKED ON OWNER ACCEPTANCE + ROADMAP RECONCILIATION
-Merge recommendation:     NOT APPLICABLE — PLANNING ONLY
+Planning artifacts:        CONVERGED
+Implementation scope:      WELL-BOUNDED
+Implementation start:      BLOCKED ON OWNER ACCEPTANCE
+Merge recommendation:      NOT APPLICABLE — PLANNING ONLY
 Deployment recommendation: DO NOT DEPLOY
 ```
 

--- a/specs/002-mvp-product-convergence/analysis.md
+++ b/specs/002-mvp-product-convergence/analysis.md
@@ -1,233 +1,136 @@
-# Cross-Artifact Analysis: AtoEnglish MVP Product Convergence
+# Cross-Artifact Analysis: YouTube-to-Private-Lesson MVP
 
-**Analyzed:** 2026-08-03  
-**Artifacts:** constitution, proposed roadmap reprioritization, Spec 001 evidence,
-Spec 002 specification, plan, research, data model, product contract, quickstart,
-requirements checklist, current priority, and task ledger
+**Analyzed:** 2026-08-03 after owner correction  
+**Artifacts:** constitution, roadmap, Spec 001 evidence, revised Spec 002 spec/plan/research/data model/contract/quickstart/tasks/checklist, current priority, owner decision
 
 ## Executive Result
 
 ```text
-Specification completeness: PASS
-Constitution alignment:     PASS
-Task coverage:              PASS
-Roadmap consistency:        PASS AS PROPOSAL
-Implementation readiness:   CONDITIONAL
-Critical contradictions:    0
-Owner authorization:        NOT GRANTED
+Core owner product decision: CONFIRMED
+Specification completeness:  PASS
+Constitution alignment:      PASS FOR PRIVATE AI-DRAFT FLOW
+Task coverage:               PASS
+Critical contradictions:     0
+Implementation readiness:    CONDITIONAL
+Implementation authorization: NOT YET RECORDED
 ```
 
-The MVP has a coherent product boundary, dependency-ordered plan, and proposed
-roadmap position. It is not yet authorized for implementation because owner
-acceptance, initial source feasibility, and owner-gated infrastructure actions
-remain open.
+## Corrected Product Consistency
 
-## Product Consistency
-
-All Spec 002 artifacts define the same critical learner journey:
+Every revised artifact now defines the same journey:
 
 ```text
-truthful landing
-→ authentication and idempotent bootstrap
-→ focused dashboard
-→ database-only reviewed catalog
-→ environment-first lesson
-→ first encounter
-→ progressive support
-→ productive retrieval
-→ speak-and-confirm
-→ changed-context transfer
-→ bounded private persistence
-→ return/continue/review
+truthful YouTube-to-lesson landing
+→ authentication
+→ URL-first dashboard
+→ supported YouTube validation
+→ timed transcript acquisition
+→ bounded natural interaction selection
+→ live Gemini structured generation
+→ source-evidence validation
+→ atomic owner-private ai_draft
+→ first listen / support / retrieval / speech / transfer
+→ bounded progress
+→ private library and return
 ```
 
-No artifact requires XP, streak, leagues, flashcards, grammar, writing, broad
-speaking tools, notifications, payments, or social systems for MVP completion.
+No artifact treats a fixed public catalog as the MVP. Human review/publication is
+reserved for later sharing/catalog scope.
 
-## Constitution Alignment Matrix
+## Constitution Alignment
 
-| Constitution principle | Spec 002 implementation |
+| Principle | Revised MVP response |
 | --- | --- |
-| Natural Communication First | One environment and reviewed natural lessons are the entire learner-facing learning surface. |
-| Evidence-Bound Generation | Database catalog fails closed; static samples and unreviewed drafts are forbidden. |
-| Transfer Before Completion | Runtime and database completion require a changed-context attempt. |
-| Rights, Privacy, Safety | Provider-neutral lawful playback, human review, RLS, bounded attempt data, no raw audio/free text. |
-| Small Independently Testable Delivery | One environment, three lessons, one complete journey, legacy modules deferred. |
-| Measurable Learner/Product Evidence | Funnel events and attempts are bounded; CI is not treated as effectiveness evidence. |
+| Natural Communication First | The learner chooses a real YouTube interaction; the lesson begins from its situation and practical goal. |
+| Evidence-Bound Generation | Source-dependent generated content validates against bounded timed cues; unsupported output is rejected. |
+| Transfer Before Completion | Retrieval, speak confirmation, and changed-context transfer are completion gates. |
+| Rights, Privacy, Safety | Official playback, no re-hosting, private AI drafts, visible warnings, owner RLS, no raw learner audio/free text. |
+| Small Testable Delivery | One supported URL-to-private-lesson vertical slice. |
+| Measurable Evidence | Repo checks, live provider evidence, browser behavior, and product/learning outcomes remain distinct. |
 
-No constitutional waiver is required.
+Potential tension between human review and learner-visible AI content is resolved by
+the existing private-draft boundary: generated content is visibly unreviewed,
+owner-private, source-evidence checked, and not eligible for public publication.
+Public/shared use still requires human review.
 
 ## Requirement-to-Task Coverage
 
-| Requirement | Primary tasks | Coverage result |
+| Requirement area | Primary tasks | Result |
 | --- | --- | --- |
-| FR-001 truthful promise | T011–T014, T075 | Covered |
-| FR-002 protected MVP routes | T020–T021, T027 | Covered |
-| FR-003 server/idempotent bootstrap | T015–T019 | Covered |
-| FR-004 focused navigation | T022, T075–T076 | Covered |
-| FR-005 DB-only catalog/no static fallback | T035–T037, T043 | Covered |
-| FR-006 reviewed publication eligibility | T035, T039–T044 | Covered |
-| FR-007 lawful official playback | T030–T034 | Covered |
-| FR-008 provider-neutral sources | T030–T034, T044 | Covered |
-| FR-009 traceable learner claims | T039–T043, T091 | Covered |
-| FR-010 completion gates | T049–T055, T089–T090 | Covered |
-| FR-011 microphone-independent speech | T052, T056 | Covered |
-| FR-012 bounded owner-private persistence | T058–T068 | Covered |
-| FR-013 idempotent writes | T016–T017, T059–T066 | Covered |
-| FR-014 focused dashboard | T023–T025 | Covered |
-| FR-015 deferred routes not MVP | T022, T075–T076 | Covered |
-| FR-016 reuse hosted infrastructure | T006–T007, T044, T079 | Covered |
-| FR-017 same project/types/environment | T006–T007, T079 | Covered |
-| FR-018 fresh-main selective port | T002–T005, T028 | Covered |
-| FR-019 disable experimental ingestion/generation | T036–T038, T043 | Covered |
-| FR-020 three human-reviewed lessons | T039–T044, T091 | Covered |
-| FR-021 privacy-safe events | T070–T073 | Covered |
-| FR-022 complete verification gate | T080–T093 | Covered |
-| FR-023 preview runtime health | T094–T097 | Covered |
-| FR-024 owner release gates | T098–T104 | Covered |
+| Owner decision/fresh-main integration | T001–T010 | Covered |
+| Truthful landing/auth/bootstrap | T011–T020 | Covered |
+| URL-first dashboard/navigation | T021–T025 | Covered |
+| YouTube URL/source/playback | T026–T029 | Covered |
+| Transcript adapter/policy/failures | T030–T040 | Covered |
+| Compiler/Gemini/schema/evidence | T041–T048 | Covered |
+| Deterministic atomic private draft | T049–T058 | Covered |
+| Environment-first lesson runtime | T059–T069 | Covered |
+| Bounded progress/private library/return | T070–T076 | Covered |
+| Privacy-safe analytics/resilience/pruning | T077–T082 | Covered |
+| Exact-head repo/hosted/live/browser gates | T083–T096 | Covered |
+| Convergence/owner/merge/deploy gates | T097–T102 | Covered |
 
-All functional requirements map to one or more exact implementation/verification
-tasks. No orphan requirement was found.
+No functional requirement is orphaned.
 
 ## User Story Independence
 
-### US1 — Entry/auth/dashboard
-
-Can be developed and demonstrated with controlled reviewed-lesson fixtures before
-hosted publication. It creates value by proving activation and shell coherence.
-
-### US2 — Reviewed catalog
-
-Can be verified independently with hosted reviewed/public/private rows. It does
-not require learner attempt persistence.
-
-### US3 — Lesson runtime
-
-Can be tested against a reviewed immutable fixture/package before final hosted
-publication. Completion semantics are independent of dashboard complexity.
-
-### US4 — Persistence/return
-
-Can be tested with one reviewed lesson and two authenticated users. It does not
-require analytics or broad catalog expansion.
-
-### US5 — Pilot operations
-
-Depends on the first four stories but does not change their product semantics. It
-adds bounded instrumentation, resilience, preview, and operational evidence.
-
-The story split is independently stoppable and respects the constitution.
-
-## Data-Model Consistency
-
-The product contract requires bounded progress fields. The data model offers two
-valid implementation paths:
-
-1. strict typed reuse of existing evidence storage; or
-2. a small `real_talk_attempts` table.
-
-Task T058 forces a recorded decision before DDL. This is not a contradiction; it
-is an intentionally deferred implementation choice with the same external
-contract.
-
-Provider-neutral source fields are required because the verified source pipeline
-already uses Wikimedia/DVIDS while the current video table requires YouTube
-identity. Tasks T030–T034 and T044 cover the migration, playback, and hosted
-verification.
+- **US1** can prove landing/auth/URL-first dashboard with controlled generation stubs while preserving provider gates.
+- **US2** can prove supported/unsupported source handling, transcript, live compiler, evidence validation, and atomic private persistence.
+- **US3** can run against one persisted controlled private draft and prove learning completion semantics.
+- **US4** can prove library/return and two-user isolation with one generated lesson.
+- **US5** adds final hosted/live/Vercel evidence without changing product semantics.
 
 ## Branch and Toolchain Consistency
 
-All artifacts agree that:
+All artifacts agree:
 
 - implementation begins from current `main`;
-- PR #54/Real Talk branch is not merged wholesale;
-- the current main package/lock/toolchain baseline is retained;
-- selected Real Talk security/domain/runtime work is ported through a manifest;
-- hosted Supabase and Vercel projects are reused;
-- deployment and migration remain owner-gated.
+- PR #54 is not merged wholesale;
+- main's Node/npm/package-lock baseline is retained;
+- selected Spec 001 code is ported through a manifest;
+- hosted Supabase/Vercel projects are reused;
+- environment/types must point to the same Supabase project;
+- migration, preview, merge, and production deploy remain owner-gated.
 
-No artifact authorizes branch-level merge, automatic deployment, or replacement
-infrastructure.
+## Data Consistency
 
-## Roadmap Consistency
+The revised data model reuses the hosted private draft tables and atomic RPC rather
+than designing around a public catalog. A bounded attempt table is conditional on
+an explicit storage decision. Static fixtures cannot satisfy live generation or
+private-library acceptance.
 
-The planning branch now proposes the following ordered roadmap:
+## Remaining Hard Decisions
 
-```text
-001 — Private Natural Lesson Compiler
-002 — MVP Product Convergence
-003 — Full Human Review and Publication Operations
-004 — Invisible Capability Graph
-005 — Delayed Transfer and Learner Evidence
-006 — Pilot Expansion and Product Evidence
-```
+1. Exact transcript adapter/private-production decision: mode, supported video conditions, reliability/terms/rights risks, warnings, rollback.
+2. Availability of a bounded `GEMINI_API_KEY` workflow for live success/failure verification.
+3. Existing progress/evidence storage versus a small `real_talk_attempts` table.
+4. Exact treatment of legacy routes outside primary navigation.
+5. Explicit authorization to begin implementation.
 
-This resolves the previous duplicate `002` numbering without claiming owner
-approval. The roadmap and current-priority documents explicitly label Spec 002 as
-a proposal and keep implementation blocked until owner acceptance.
-
-Spec 002 uses only a controlled publication operation and one reviewed runtime
-slice. It does not silently absorb the future full reviewer/publication operations
-now assigned to Spec 003.
-
-## Non-Critical Open Decisions
-
-These decisions are bounded and do not change the MVP promise:
-
-1. **Initial environment** — default `Meet someone new`; owner/source feasibility
-   may select another initial environment.
-2. **Three source packages** — must pass lawful-use and human-review gates.
-3. **Attempt storage** — strict reuse versus new bounded table.
-4. **Publication status values** — reconcile exact existing constraints before
-   writing the public query/migration.
-5. **Deferred routes** — hide only versus redirect/feature flag when direct access
-   creates a critical contradiction.
-6. **Playback composition** — final mix of YouTube embed versus direct reviewed
-   public-domain/owned media.
-
-Each decision has an explicit owner/task gate and no task assumes its outcome.
+Each decision has a task gate; none is silently assumed.
 
 ## Scope-Escape Checks
 
-The following potential expansions are explicitly blocked:
+Blocked without a new approved spec:
 
-- broad curriculum/capability graph;
-- five-environment catalog;
-- delayed transfer scheduler;
-- full reviewer dashboard;
-- arbitrary source ingestion;
-- pronunciation assessment;
-- raw audio/transcript retention;
-- XP/streak/league redesign;
-- removal/refactor of every legacy route;
-- new microservice or analytics platform;
-- payments/social/native apps.
-
-A task requiring one of these must stop and create a separate approved spec.
-
-## Verification Completeness
-
-The task ledger distinguishes:
-
-- local/unit/contract evidence;
-- hosted Supabase migration/RLS/advisor/type evidence;
-- human content review;
-- production-build browser evidence;
-- Vercel preview/runtime-log evidence;
-- owner product acceptance;
-- merge and production deployment authorization.
-
-No mock or old branch check is accepted as a substitute for final exact-head
-browser, hosted, human, or owner evidence.
+- public/shared lesson catalog;
+- automatic publication;
+- full reviewer UI;
+- bulk YouTube crawling/generation;
+- support for every YouTube video;
+- media download/re-hosting;
+- broad curriculum/gamification/social/payment/native-app expansion;
+- pronunciation scoring or raw learner audio retention.
 
 ## Planning Convergence Decision
 
 ```text
-Planning artifacts:        CONVERGED
-Implementation scope:      WELL-BOUNDED
-Implementation start:      BLOCKED ON OWNER ACCEPTANCE
-Merge recommendation:      NOT APPLICABLE — PLANNING ONLY
-Deployment recommendation: DO NOT DEPLOY
+Planning artifacts:         CONVERGED AFTER OWNER CORRECTION
+Core product direction:     YOUTUBE URL → PRIVATE LESSON
+Implementation scope:       WELL-BOUNDED
+Implementation start:       BLOCKED UNTIL EXPLICIT AUTHORIZATION
+Merge recommendation:       NOT APPLICABLE — PLANNING ONLY
+Deployment recommendation:  DO NOT DEPLOY
 ```
 
-After owner acceptance, complete T001–T010 before changing learner-facing code.
+After implementation authorization, execute T003–T010 before changing learner-facing code.

--- a/specs/002-mvp-product-convergence/checklists/requirements.md
+++ b/specs/002-mvp-product-convergence/checklists/requirements.md
@@ -1,0 +1,92 @@
+# Requirements Quality Checklist: AtoEnglish MVP Product Convergence
+
+**Purpose**: Verify that the MVP specification is complete, testable, bounded, and
+consistent before implementation begins.
+
+## Product Definition
+
+- [x] The specification defines one complete learner value loop rather than a list of existing features.
+- [x] The learner promise is consistent with natural communication and avoids fluency, CEFR, pronunciation, and mastery overclaims.
+- [x] The initial corpus scope is bounded to one environment and at least three human-reviewed lessons.
+- [x] The primary learner navigation and deferred product surfaces are explicit.
+- [x] Editor-only generation is separated from the learner product.
+- [x] MVP success can be demonstrated independently of broad curriculum, gamification, writing, notification, payment, or social systems.
+
+## User Stories and Acceptance
+
+- [x] User stories are prioritized and independently testable.
+- [x] Landing/auth/dashboard acceptance includes new, returning, unauthenticated, and failure paths.
+- [x] Catalog acceptance fails closed when no reviewed content exists.
+- [x] Lesson acceptance requires first encounter, retrieval, speaking confirmation, and changed-context transfer.
+- [x] Persistence acceptance includes reload, new session, idempotency, privacy, and cross-user denial.
+- [x] Pilot acceptance includes exact-head preview, desktop/mobile, hosted database, runtime logs, and owner review.
+
+## Source, Rights, and Content Integrity
+
+- [x] Learner-visible content requires human-reviewed source, transcript, speaker, timing, translation, safety, and pedagogy evidence.
+- [x] Static fixture/sample lessons are explicitly forbidden as production catalog fallback.
+- [x] A public URL is not treated as permission for transcript storage or derivatives.
+- [x] Playback is provider-neutral and limited to reviewed official/direct/external modes.
+- [x] Media download and re-hosting are outside scope.
+- [x] Missing evidence creates an empty state or publication block rather than fabrication.
+
+## Learning Contract
+
+- [x] Situation, roles, and practical goal appear before academic explanation.
+- [x] First encounter does not expose transcript or answer by default.
+- [x] Support is progressive rather than permanently showing the full answer.
+- [x] Productive retrieval is required.
+- [x] Speak-and-confirm works without microphone permission and produces no pronunciation score.
+- [x] Changed-context transfer is a completion gate.
+- [x] Completion language distinguishes immediate practice from retention/mastery.
+
+## Authentication and Privacy
+
+- [x] Authentication precedes protected learner routes.
+- [x] Account bootstrap derives user identity server-side and is idempotent.
+- [x] Email and OAuth bootstrap share one contract.
+- [x] No client-supplied user ID or reviewer/publication role is trusted.
+- [x] Learner attempt storage is bounded and excludes raw audio, unrestricted transcripts, names, employers, and free text.
+- [x] Cross-user access is covered by RLS acceptance scenarios.
+- [x] Analytics payloads are bounded and privacy-safe.
+
+## Repository and Infrastructure Convergence
+
+- [x] Implementation must start from current `main`.
+- [x] Whole-branch merge of the diverged Real Talk branch is prohibited.
+- [x] A file-level port manifest is required.
+- [x] Main toolchain and lockfile decisions remain authoritative.
+- [x] Supabase types, environment documentation, preview, and production must reference the same hosted project.
+- [x] Existing Vercel and Supabase projects are reused.
+- [x] Migrations, preview deployment, merge, and production deployment require explicit owner authorization at their respective gates.
+
+## Verification and Evidence
+
+- [x] Technical gates include lint, TypeScript, unit/contract tests, content standards, integration checks, and production build.
+- [x] Hosted database verification includes anonymous and two-user behavior.
+- [x] Browser verification covers the full journey on desktop and mobile.
+- [x] Runtime error inspection is required after preview deployment.
+- [x] Human lesson review is not replaced by automated checks.
+- [x] Product/learning effectiveness is not inferred from CI.
+- [x] Owner acceptance is a separate final gate.
+
+## Explicit Decisions Required Before or During Implementation
+
+- [ ] Owner accepts this MVP promise and scope.
+- [ ] Owner confirms the initial environment, defaulting to **Meet someone new**.
+- [ ] At least three source packages are identified as feasible for full human review and lawful learner use.
+- [ ] Existing evidence storage is accepted or a bounded `real_talk_attempts` table is approved after schema analysis.
+- [ ] Exact reviewed/public status values and the controlled publication operation are approved.
+- [ ] The treatment of deferred routes is chosen: hidden only, authenticated redirect, or temporary feature flag where needed.
+- [ ] Any hosted migration application is explicitly authorized.
+- [ ] The intentional Vercel preview is explicitly authorized after technical gates.
+- [ ] Final merge and production deployment are separately authorized.
+
+## Checklist Result
+
+Specification quality: **PASS**  
+Implementation authorization: **NOT YET GRANTED**
+
+No unchecked item above may be silently assumed. Implementation may perform
+research and propose a decision, but owner-gated writes and release actions remain
+blocked until explicitly authorized.

--- a/specs/002-mvp-product-convergence/checklists/requirements.md
+++ b/specs/002-mvp-product-convergence/checklists/requirements.md
@@ -1,92 +1,106 @@
-# Requirements Quality Checklist: AtoEnglish MVP Product Convergence
+# Requirements Quality Checklist: YouTube-to-Private-Lesson MVP
 
-**Purpose**: Verify that the MVP specification is complete, testable, bounded, and
-consistent before implementation begins.
+## Core Product Definition
 
-## Product Definition
+- [x] Owner decision explicitly preserves paste-YouTube-URL → private lesson as the core product.
+- [x] The specification does not replace generation with a fixed reviewed catalog.
+- [x] The critical journey is one complete private generation, learning, persistence, and return loop.
+- [x] The promise says `supported YouTube videos`, not every video.
+- [x] Generated lessons are explicitly owner-private AI drafts.
+- [x] Public sharing/catalog and full reviewer operations are deferred.
+- [x] Broad curriculum, gamification, writing, notifications, payments, social, and native apps are outside MVP.
 
-- [x] The specification defines one complete learner value loop rather than a list of existing features.
-- [x] The learner promise is consistent with natural communication and avoids fluency, CEFR, pronunciation, and mastery overclaims.
-- [x] The initial corpus scope is bounded to one environment and at least three human-reviewed lessons.
-- [x] The primary learner navigation and deferred product surfaces are explicit.
-- [x] Editor-only generation is separated from the learner product.
-- [x] MVP success can be demonstrated independently of broad curriculum, gamification, writing, notification, payment, or social systems.
+## Authentication and Dashboard
 
-## User Stories and Acceptance
+- [x] Authentication is required before transcript, metadata, or Gemini work.
+- [x] Email and OAuth share one idempotent server bootstrap contract.
+- [x] Client-supplied user identity and publication/review state are not trusted.
+- [x] The dashboard's primary action is a YouTube URL form.
+- [x] Recent private lessons expose start/continue/review/failure states.
+- [x] Landing, auth, dashboard, private lesson, account, and return paths are independently testable.
 
-- [x] User stories are prioritized and independently testable.
-- [x] Landing/auth/dashboard acceptance includes new, returning, unauthenticated, and failure paths.
-- [x] Catalog acceptance fails closed when no reviewed content exists.
-- [x] Lesson acceptance requires first encounter, retrieval, speaking confirmation, and changed-context transfer.
-- [x] Persistence acceptance includes reload, new session, idempotency, privacy, and cross-user denial.
-- [x] Pilot acceptance includes exact-head preview, desktop/mobile, hosted database, runtime logs, and owner review.
+## YouTube and Transcript Boundary
 
-## Source, Rights, and Content Integrity
+- [x] URL normalization/validation and supported host forms are specified.
+- [x] Official YouTube playback is required; media download/re-hosting is forbidden.
+- [x] Transcript acquisition is behind a replaceable adapter with explicit mode/status/warnings.
+- [x] Timed English cues are required.
+- [x] Unsupported/private/age-restricted/embed-disabled/transcriptless/non-English paths fail honestly.
+- [x] Transcript text is bounded, normalized, and treated as untrusted prompt data.
+- [x] The exact private-production transcript adapter decision is a release gate.
+- [x] Controlled supported and unsupported live checks are required.
 
-- [x] Learner-visible content requires human-reviewed source, transcript, speaker, timing, translation, safety, and pedagogy evidence.
-- [x] Static fixture/sample lessons are explicitly forbidden as production catalog fallback.
-- [x] A public URL is not treated as permission for transcript storage or derivatives.
-- [x] Playback is provider-neutral and limited to reviewed official/direct/external modes.
-- [x] Media download and re-hosting are outside scope.
-- [x] Missing evidence creates an empty state or publication block rather than fabrication.
+## AI Generation and Evidence
 
-## Learning Contract
+- [x] Gemini generation occurs only after authentication and rate limiting.
+- [x] Interaction selection is bounded to <=180 seconds and configured cue limits.
+- [x] Model output uses a typed structured schema and runtime validation.
+- [x] Source-dependent phrases, answers, timestamps, references, and transfer targets require evidence validation.
+- [x] Invalid output is rejected before persistence.
+- [x] Actual model, adapter/mode, selected window, digest, warnings, and failure codes are persisted/observable.
+- [x] Live Gemini success and failure are required; mocks do not satisfy the release gate.
+- [x] Absence of `GEMINI_API_KEY` remains a blocker.
 
-- [x] Situation, roles, and practical goal appear before academic explanation.
-- [x] First encounter does not expose transcript or answer by default.
-- [x] Support is progressive rather than permanently showing the full answer.
+## Private Draft and Security
+
+- [x] Successful generation is atomic and deterministic/idempotent.
+- [x] Generated video/lesson state remains private `ai_draft`.
+- [x] Ordinary users cannot approve or publish generated drafts.
+- [x] Owner-only read/write/delete and cross-user denial are required.
+- [x] Failed generation/persistence creates no partial lesson.
+- [x] Static fixtures cannot appear as generated private-library content.
+- [x] Hosted anonymous/ownerA/ownerB verification is required.
+
+## Learning Runtime
+
+- [x] Environment, roles, practical goal, source, AI label, and warnings precede activities.
+- [x] First encounter hides transcript/answers by default.
+- [x] Support reveals progressively.
 - [x] Productive retrieval is required.
 - [x] Speak-and-confirm works without microphone permission and produces no pronunciation score.
 - [x] Changed-context transfer is a completion gate.
-- [x] Completion language distinguishes immediate practice from retention/mastery.
+- [x] Completion copy distinguishes immediate practice from mastery/retention.
 
-## Authentication and Privacy
+## Persistence and Privacy
 
-- [x] Authentication precedes protected learner routes.
-- [x] Account bootstrap derives user identity server-side and is idempotent.
-- [x] Email and OAuth bootstrap share one contract.
-- [x] No client-supplied user ID or reviewer/publication role is trusted.
-- [x] Learner attempt storage is bounded and excludes raw audio, unrestricted transcripts, names, employers, and free text.
-- [x] Cross-user access is covered by RLS acceptance scenarios.
-- [x] Analytics payloads are bounded and privacy-safe.
+- [x] Progress storage is bounded to IDs, enums, booleans, counts, support level, and timestamps.
+- [x] Raw audio, unrestricted speech transcript, learner response text, names, employers, and arbitrary analytics are forbidden by default.
+- [x] Attempt writes derive the owner, validate lesson ownership, enforce RLS, and remain idempotent.
+- [x] Reload and new-session return behavior are acceptance requirements.
 
-## Repository and Infrastructure Convergence
+## Repository and Infrastructure
 
-- [x] Implementation must start from current `main`.
-- [x] Whole-branch merge of the diverged Real Talk branch is prohibited.
+- [x] Implementation starts from current `main`.
+- [x] Whole-branch merge of PR #54/Real Talk is prohibited.
 - [x] A file-level port manifest is required.
-- [x] Main toolchain and lockfile decisions remain authoritative.
-- [x] Supabase types, environment documentation, preview, and production must reference the same hosted project.
-- [x] Existing Vercel and Supabase projects are reused.
-- [x] Migrations, preview deployment, merge, and production deployment require explicit owner authorization at their respective gates.
+- [x] Main Node/npm/package-lock decisions remain authoritative.
+- [x] Repo types/environment/preview use Supabase `zpiwddskhduuykpxltun`.
+- [x] Existing Vercel project `atoenglish` is reused.
+- [x] Hosted migrations, preview, merge, and production deploy remain separately owner-gated.
 
-## Verification and Evidence
+## Verification
 
-- [x] Technical gates include lint, TypeScript, unit/contract tests, content standards, integration checks, and production build.
-- [x] Hosted database verification includes anonymous and two-user behavior.
-- [x] Browser verification covers the full journey on desktop and mobile.
-- [x] Runtime error inspection is required after preview deployment.
-- [x] Human lesson review is not replaced by automated checks.
-- [x] Product/learning effectiveness is not inferred from CI.
-- [x] Owner acceptance is a separate final gate.
+- [x] Exact-head lint, TypeScript, targeted tests, full tests, content checks, integration, and build are required.
+- [x] Live transcript and Gemini matrices are required.
+- [x] Desktop/mobile Playwright covers supported generation, unsupported failure, lesson, completion, logout/login, return, and cross-user denial.
+- [x] Vercel runtime error/log inspection is required.
+- [x] CI is not treated as proof of transcript correctness, learning effectiveness, or market demand.
+- [x] Owner acceptance is a separate release gate.
 
-## Explicit Decisions Required Before or During Implementation
+## Open Authorization/Implementation Decisions
 
-- [ ] Owner accepts this MVP promise and scope.
-- [ ] Owner confirms the initial environment, defaulting to **Meet someone new**.
-- [ ] At least three source packages are identified as feasible for full human review and lawful learner use.
-- [ ] Existing evidence storage is accepted or a bounded `real_talk_attempts` table is approved after schema analysis.
-- [ ] Exact reviewed/public status values and the controlled publication operation are approved.
-- [ ] The treatment of deferred routes is chosen: hidden only, authenticated redirect, or temporary feature flag where needed.
+- [x] Owner confirms paste-YouTube-URL → private personal lesson as the core MVP.
+- [ ] Owner explicitly authorizes implementation to begin.
+- [ ] Exact transcript adapter/private-production decision is accepted after technical/legal/reliability review.
+- [ ] `GEMINI_API_KEY` is available through a bounded secret workflow for live verification.
+- [ ] Existing progress storage is accepted or a bounded `real_talk_attempts` migration is approved.
 - [ ] Any hosted migration application is explicitly authorized.
-- [ ] The intentional Vercel preview is explicitly authorized after technical gates.
-- [ ] Final merge and production deployment are separately authorized.
+- [ ] Intentional Vercel preview is explicitly authorized after prerequisite gates.
+- [ ] Exact preview is accepted by the owner.
+- [ ] Merge and production deployment are separately authorized.
 
-## Checklist Result
+## Result
 
-Specification quality: **PASS**  
-Implementation authorization: **NOT YET GRANTED**
-
-No unchecked item above may be silently assumed. Implementation may perform
-research and propose a decision, but owner-gated writes and release actions remain
-blocked until explicitly authorized.
+Specification quality: **PASS AFTER OWNER CORRECTION**  
+Core product decision: **CONFIRMED**  
+Implementation authorization: **NOT YET RECORDED**

--- a/specs/002-mvp-product-convergence/contracts/mvp-contract.md
+++ b/specs/002-mvp-product-convergence/contracts/mvp-contract.md
@@ -1,0 +1,300 @@
+# Contract: AtoEnglish MVP Product Boundary
+
+## Purpose
+
+This contract defines what may be called the AtoEnglish MVP and prevents a green
+build, a large feature list, or an experimental content tool from being mistaken
+for a usable product.
+
+## Learner Promise
+
+AtoEnglish helps a Vietnamese beginner understand one short reviewed English
+interaction and attempt the same practical communication goal in a changed
+situation.
+
+The MVP does not promise:
+
+- fluency;
+- CEFR certification;
+- native pronunciation;
+- pronunciation scoring;
+- mastery or long-term retention from one lesson;
+- automatic personalization;
+- a complete A0–B2 curriculum;
+- correctness of AI-generated or unreviewed transcripts.
+
+## Critical User Journey
+
+```text
+GET /
+→ primary CTA
+→ /login
+→ authenticated bootstrap
+→ /dashboard
+→ reviewed lesson catalog/action
+→ /real-talk/[lessonSlug]
+→ first encounter
+→ progressive support
+→ retrieval
+→ speak-and-confirm
+→ changed-context transfer
+→ bounded completion persistence
+→ dashboard continue/review state
+→ logout and later return
+```
+
+Every production release candidate must demonstrate this journey on desktop and
+mobile against hosted Supabase.
+
+## Public Route Contract
+
+Public without authentication:
+
+- `/`
+- `/login`
+- `/auth/callback`
+- `/privacy`
+- `/terms`
+- `/api/health`
+
+Authenticated MVP routes:
+
+- `/dashboard`
+- `/real-talk`
+- `/real-talk/[lessonSlug]`
+- `/me`
+- the chosen review/continue route if separate
+
+Editor-only or disabled in learner production:
+
+- `/real-talk/create`
+- source submission/review operations
+- private draft preview routes not owned by the user
+
+Deferred routes are not part of the product contract even if they remain deployed.
+They must not appear in primary learner navigation or landing promises.
+
+## Catalog Contract
+
+The catalog response contains only reviewed public lessons.
+
+Pseudo-query contract:
+
+```text
+select reviewed lesson + source
+where video.is_public = true
+  and lesson reviewed/approved
+  and transcript human_verified
+  and reviewed_by/reviewed_at present
+  and provenance/playback pass policy
+```
+
+Forbidden behavior:
+
+- static fallback lessons;
+- merging fixture lessons into production output;
+- displaying private drafts;
+- displaying unreviewed transcripts;
+- displaying a lesson because a model response passed schema validation only;
+- exposing arbitrary generation as a learner CTA.
+
+If no lesson qualifies, return an honest empty state.
+
+## Reviewed Lesson Contract
+
+A learner-visible lesson package must include:
+
+- reviewed source identity and lawful playback boundary;
+- environment/setting;
+- learner role and partner role;
+- practical goal;
+- bounded source segment;
+- reviewed transcript and speaker/timing state;
+- source-backed communication events;
+- first-listen task without answer exposure;
+- progressive support;
+- two to five useful source-backed chunks;
+- productive retrieval;
+- speak-and-confirm fallback;
+- changed-context transfer task;
+- concise reviewed Vietnamese guidance;
+- honest completion copy.
+
+Human review must explicitly cover:
+
+- source availability and context;
+- rights/provenance;
+- audio language;
+- exact words;
+- timestamps;
+- speaker uncertainty;
+- translation/guidance;
+- answer evidence;
+- safety and age suitability;
+- level and task coherence;
+- transfer coherence.
+
+## Runtime Completion Contract
+
+The runtime may record `completed` only when:
+
+```text
+first listen completed
+AND retrieval attempted
+AND speaking self-confirmed
+AND changed-context transfer attempted
+```
+
+Comprehension score alone is insufficient.
+Watching alone is insufficient.
+Repetition alone is insufficient.
+
+Completion copy must use language such as:
+
+- “Bạn đã hoàn thành lượt luyện tập này.”
+- “Đây là bằng chứng luyện tập ngay lúc này, chưa chứng minh ghi nhớ lâu dài.”
+
+It must not use:
+
+- mastered;
+- fluent;
+- pronunciation score;
+- CEFR passed;
+- permanently learned.
+
+## Speech Contract
+
+MVP speech mode is `speak_and_confirm`.
+
+The learner:
+
+1. sees or recalls the target prompt according to the current support level;
+2. says the response aloud;
+3. confirms that an attempt occurred.
+
+No score is produced. Browser speech recognition may be used only as an optional
+sentence-match aid under a separate explicit label. It is not required for MVP
+completion and is not pronunciation assessment.
+
+## Persistence Contract
+
+Stored evidence is bounded:
+
+- lesson ID;
+- current checkpoint/status;
+- first-listen boolean;
+- comprehension counts;
+- maximum support level;
+- retrieval-attempt boolean;
+- speak-confirmed boolean;
+- transfer-attempt boolean;
+- timestamps.
+
+Never store by default:
+
+- raw microphone recording;
+- full speech transcript;
+- learner free-text transfer response;
+- name/employer in attempt data;
+- arbitrary analytics JSON.
+
+Writes derive the user server-side, enforce RLS, and are idempotent.
+
+## Account Bootstrap Contract
+
+Email and OAuth use the same server-owned bootstrap.
+
+The operation must:
+
+- authenticate first;
+- derive user ID from Supabase Auth;
+- create missing minimum records transactionally/idempotently;
+- return a safe route;
+- tolerate retry;
+- expose an actionable failure.
+
+It must not:
+
+- trust a client user ID;
+- silently claim personalization from defaulted answers;
+- directly grant reviewer/publication permissions;
+- leave partial rows after failure.
+
+## Dashboard Contract
+
+The dashboard answers one question:
+
+> What should I do next?
+
+It must render exactly one primary state:
+
+- start the first reviewed lesson;
+- continue an in-progress lesson;
+- review/retry a completed lesson;
+- honest no-content state.
+
+Secondary content is limited to the small reviewed corpus and account access.
+XP, streak, league, word-of-day, writing, challenge, and notification status are
+not required.
+
+## Navigation Contract
+
+Primary learner navigation:
+
+- Học
+- Ôn lại / Tiếp tục
+- Tôi
+
+Do not include editor generation or deferred product modules.
+
+## Pilot Analytics Contract
+
+The analytics layer may answer:
+
+- did the learner understand the promise and start auth?;
+- did auth complete?;
+- did they start a lesson?;
+- where did they abandon?;
+- how much support was used?;
+- did they attempt retrieval, speech, and transfer?;
+- did they complete?;
+- did they return?;
+
+It may not collect learner answer text, speech transcript, audio, names, employers,
+or unrestricted metadata.
+
+## Integration Contract
+
+Implementation begins from current `main`.
+
+For each candidate file or migration from open branches, the port manifest records:
+
+```text
+source branch and SHA
+path
+classification: port / adapt / reference / reject
+reason
+required tests
+destination path
+```
+
+A branch-level merge of `agent/rebuild-learning-core` is forbidden by this
+contract because it is diverged and carries stale/conflicting toolchain and product
+surface state.
+
+## Release Contract
+
+A merge candidate requires:
+
+- approved requirements checklist;
+- all required task evidence;
+- exact-head lint, TypeScript, unit, content, and build gates;
+- hosted database/type equivalence;
+- hosted RLS two-user verification;
+- three human-reviewed lessons;
+- desktop/mobile full journey;
+- Vercel preview and runtime-error inspection;
+- owner acceptance.
+
+Merge to `main` and production deployment are separate explicit owner decisions.
+A successful preview does not authorize either action.

--- a/specs/002-mvp-product-convergence/contracts/mvp-contract.md
+++ b/specs/002-mvp-product-convergence/contracts/mvp-contract.md
@@ -1,54 +1,35 @@
-# Contract: AtoEnglish MVP Product Boundary
-
-## Purpose
-
-This contract defines what may be called the AtoEnglish MVP and prevents a green
-build, a large feature list, or an experimental content tool from being mistaken
-for a usable product.
+# Contract: AtoEnglish YouTube-to-Private-Lesson MVP
 
 ## Learner Promise
 
-AtoEnglish helps a Vietnamese beginner understand one short reviewed English
-interaction and attempt the same practical communication goal in a changed
-situation.
+AtoEnglish lets a Vietnamese learner paste a supported YouTube video and receive a
+private AI-generated English lesson built from one useful interaction in that
+video.
 
-The MVP does not promise:
+The product does not promise that every YouTube video is supported, that captions
+are perfect, that AI output is human-reviewed, or that one lesson proves fluency,
+pronunciation, CEFR level, mastery, or long-term retention.
 
-- fluency;
-- CEFR certification;
-- native pronunciation;
-- pronunciation scoring;
-- mastery or long-term retention from one lesson;
-- automatic personalization;
-- a complete A0–B2 curriculum;
-- correctness of AI-generated or unreviewed transcripts.
-
-## Critical User Journey
+## Critical Journey
 
 ```text
-GET /
-→ primary CTA
-→ /login
-→ authenticated bootstrap
-→ /dashboard
-→ reviewed lesson catalog/action
-→ /real-talk/[lessonSlug]
-→ first encounter
-→ progressive support
-→ retrieval
-→ speak-and-confirm
-→ changed-context transfer
-→ bounded completion persistence
-→ dashboard continue/review state
-→ logout and later return
+landing
+→ authentication
+→ paste supported YouTube URL
+→ source/transcript validation
+→ bounded interaction selection
+→ Gemini structured generation
+→ source-evidence validation
+→ atomic owner-private ai_draft persistence
+→ private lesson runtime
+→ retrieval + speak-and-confirm + transfer
+→ bounded progress
+→ private library / return
 ```
 
-Every production release candidate must demonstrate this journey on desktop and
-mobile against hosted Supabase.
+## Route Contract
 
-## Public Route Contract
-
-Public without authentication:
+Public:
 
 - `/`
 - `/login`
@@ -57,131 +38,149 @@ Public without authentication:
 - `/terms`
 - `/api/health`
 
-Authenticated MVP routes:
+Authenticated MVP:
 
 - `/dashboard`
-- `/real-talk`
-- `/real-talk/[lessonSlug]`
+- `/real-talk/create` or the equivalent dashboard generation form
+- `/real-talk/[lessonSlug]` for owner-private lessons
+- `/real-talk` if used as the owner's private library
 - `/me`
-- the chosen review/continue route if separate
 
-Editor-only or disabled in learner production:
+No public catalog is required. Another user's private slug must resolve as denied
+or not found without confirming existence.
 
-- `/real-talk/create`
-- source submission/review operations
-- private draft preview routes not owned by the user
+## URL Submission Contract
 
-Deferred routes are not part of the product contract even if they remain deployed.
-They must not appear in primary learner navigation or landing promises.
-
-## Catalog Contract
-
-The catalog response contains only reviewed public lessons.
-
-Pseudo-query contract:
+Input:
 
 ```text
-select reviewed lesson + source
-where video.is_public = true
-  and lesson reviewed/approved
-  and transcript human_verified
-  and reviewed_by/reviewed_at present
-  and provenance/playback pass policy
+youtubeUrl
+approved target level
 ```
 
-Forbidden behavior:
+The server must:
 
-- static fallback lessons;
-- merging fixture lessons into production output;
-- displaying private drafts;
-- displaying unreviewed transcripts;
-- displaying a lesson because a model response passed schema validation only;
-- exposing arbitrary generation as a learner CTA.
+1. authenticate before external/provider work;
+2. validate and normalize a supported YouTube URL;
+3. derive video identity server-side;
+4. rate-limit by authenticated user and safe request bucket;
+5. return stable actionable failure codes;
+6. never trust a client user ID, owner ID, review state, or publication state.
 
-If no lesson qualifies, return an honest empty state.
+## Supported Source Contract
 
-## Reviewed Lesson Contract
+MVP supports only public YouTube videos that satisfy the selected adapter policy:
 
-A learner-visible lesson package must include:
+- canonical YouTube identity can be resolved;
+- official embed/watch playback is permitted/available;
+- usable timed English transcript evidence is obtainable;
+- transcript is non-empty and within configured safety/size limits;
+- source is not private, age-restricted, or otherwise unsupported by policy.
 
-- reviewed source identity and lawful playback boundary;
-- environment/setting;
-- learner role and partner role;
-- practical goal;
-- bounded source segment;
-- reviewed transcript and speaker/timing state;
-- source-backed communication events;
-- first-listen task without answer exposure;
-- progressive support;
-- two to five useful source-backed chunks;
-- productive retrieval;
-- speak-and-confirm fallback;
-- changed-context transfer task;
-- concise reviewed Vietnamese guidance;
-- honest completion copy.
+Unsupported videos fail honestly. The system must not fabricate a transcript,
+convert the whole video blindly, download media, or re-host video/audio.
 
-Human review must explicitly cover:
+## Transcript Contract
 
-- source availability and context;
-- rights/provenance;
-- audio language;
-- exact words;
-- timestamps;
-- speaker uncertainty;
-- translation/guidance;
-- answer evidence;
-- safety and age suitability;
-- level and task coherence;
-- transfer coherence.
+Every transcript result exposes:
 
-## Runtime Completion Contract
+- adapter ID;
+- acquisition mode;
+- language;
+- review status;
+- normalized timed cues;
+- cue digest;
+- warnings;
+- source identity.
 
-The runtime may record `completed` only when:
+Caption text is untrusted prompt data. It is normalized, bounded, delimited, and
+must not override generation rules.
+
+The exact production/private adapter decision is a release gate. Passing unit
+tests does not automatically approve an experimental acquisition mechanism.
+
+## Compiler Contract
+
+The compiler:
+
+- selects a deterministic interaction-rich window no longer than 180 seconds;
+- sends only bounded transcript/source context to Gemini;
+- requests structured output through the typed generation schema;
+- validates structure with Zod;
+- validates every source-dependent phrase, transcript reference, timestamp,
+  answer, and transfer target against selected cues;
+- rejects unsupported output before persistence;
+- records the actual model and warnings.
+
+## Private Draft Contract
+
+Every successful generation is:
 
 ```text
-first listen completed
-AND retrieval attempted
+owner = authenticated user
+is_public = false
+state = ai_draft
+reviewed_by = null
+reviewed_at = null
+```
+
+It persists atomically:
+
+- source/video identity and URL;
+- official playback identity;
+- selected window;
+- transcript adapter/mode/status/digest;
+- structured lesson;
+- model;
+- warnings;
+- deterministic owner-private identity.
+
+Ordinary users cannot approve, publish, or access another user's draft.
+
+## Learner UI Contract
+
+The private lesson always shows:
+
+- source identity and official playback;
+- `AI draft` label;
+- transcript/acquisition warning when not human-verified;
+- environment, roles, and practical goal;
+- honest failure/retry behavior.
+
+The UI must not imply that the lesson was human-reviewed or guaranteed correct.
+
+## Runtime Contract
+
+Completion requires:
+
+```text
+first encounter completed
+AND productive retrieval attempted
 AND speaking self-confirmed
 AND changed-context transfer attempted
 ```
 
-Comprehension score alone is insufficient.
-Watching alone is insufficient.
-Repetition alone is insufficient.
+Watching, multiple choice, cloze, or repetition alone is insufficient.
 
-Completion copy must use language such as:
-
-- “Bạn đã hoàn thành lượt luyện tập này.”
-- “Đây là bằng chứng luyện tập ngay lúc này, chưa chứng minh ghi nhớ lâu dài.”
-
-It must not use:
-
-- mastered;
-- fluent;
-- pronunciation score;
-- CEFR passed;
-- permanently learned.
+Support must reveal progressively. The first encounter does not expose transcript
+or answers by default.
 
 ## Speech Contract
 
-MVP speech mode is `speak_and_confirm`.
+MVP speech is `speak_and_confirm`.
 
-The learner:
+- Microphone/browser STT is optional.
+- No pronunciation score is required or claimed.
+- Optional transcript matching, if retained, must be labelled sentence match and
+  cannot block the fallback.
+- Raw audio and unrestricted speech transcript are not stored.
 
-1. sees or recalls the target prompt according to the current support level;
-2. says the response aloud;
-3. confirms that an attempt occurred.
+## Progress Contract
 
-No score is produced. Browser speech recognition may be used only as an optional
-sentence-match aid under a separate explicit label. It is not required for MVP
-completion and is not pronunciation assessment.
-
-## Persistence Contract
-
-Stored evidence is bounded:
+Stored learner evidence is bounded:
 
 - lesson ID;
-- current checkpoint/status;
+- checkpoint/status;
 - first-listen boolean;
 - comprehension counts;
 - maximum support level;
@@ -190,111 +189,63 @@ Stored evidence is bounded:
 - transfer-attempt boolean;
 - timestamps.
 
-Never store by default:
+No learner free-text transfer response is stored by default. Writes derive the
+user server-side, enforce RLS, validate lesson ownership, and remain idempotent.
 
-- raw microphone recording;
-- full speech transcript;
-- learner free-text transfer response;
-- name/employer in attempt data;
-- arbitrary analytics JSON.
+## Dashboard and Library Contract
 
-Writes derive the user server-side, enforce RLS, and are idempotent.
+The dashboard has one primary action: paste a YouTube URL.
 
-## Account Bootstrap Contract
+It also shows the owner's recent private lessons with states:
 
-Email and OAuth use the same server-owned bootstrap.
+- ready to start;
+- continue;
+- completed/review;
+- failed generation with safe retry guidance.
 
-The operation must:
+It does not require a public catalog, XP, streak, league, flashcards, writing,
+challenge, or fifty-unit progression.
 
-- authenticate first;
-- derive user ID from Supabase Auth;
-- create missing minimum records transactionally/idempotently;
-- return a safe route;
-- tolerate retry;
-- expose an actionable failure.
+## Static Fixture Contract
 
-It must not:
+Static sample lessons may be used only for tests, controlled demos, or development
+fixtures with explicit labeling. They must not:
 
-- trust a client user ID;
-- silently claim personalization from defaulted answers;
-- directly grant reviewer/publication permissions;
-- leave partial rows after failure.
+- appear as if generated from the user's URL;
+- be merged into the owner's private library;
+- satisfy hosted/live generation acceptance;
+- replace live Gemini or transcript verification.
 
-## Dashboard Contract
+## Analytics Contract
 
-The dashboard answers one question:
+Allowed events answer whether users authenticate, submit a URL, reach transcript,
+generate successfully/fail by bounded code, open a lesson, attempt required
+learning steps, complete, and return.
 
-> What should I do next?
-
-It must render exactly one primary state:
-
-- start the first reviewed lesson;
-- continue an in-progress lesson;
-- review/retry a completed lesson;
-- honest no-content state.
-
-Secondary content is limited to the small reviewed corpus and account access.
-XP, streak, league, word-of-day, writing, challenge, and notification status are
-not required.
-
-## Navigation Contract
-
-Primary learner navigation:
-
-- Học
-- Ôn lại / Tiếp tục
-- Tôi
-
-Do not include editor generation or deferred product modules.
-
-## Pilot Analytics Contract
-
-The analytics layer may answer:
-
-- did the learner understand the promise and start auth?;
-- did auth complete?;
-- did they start a lesson?;
-- where did they abandon?;
-- how much support was used?;
-- did they attempt retrieval, speech, and transfer?;
-- did they complete?;
-- did they return?;
-
-It may not collect learner answer text, speech transcript, audio, names, employers,
-or unrestricted metadata.
+Payloads may contain bounded IDs, enum codes, counts, booleans, durations, and
+timestamps. They may not contain source transcript text, learner answers, audio,
+email/name/employer, full URLs with sensitive query data, or provider secrets.
 
 ## Integration Contract
 
-Implementation begins from current `main`.
+Implementation starts from current `main`. For every Real Talk path from open
+branches, a manifest records source SHA, classification (`port`, `adapt`,
+`reference`, `reject`), reason, destination, and required evidence.
 
-For each candidate file or migration from open branches, the port manifest records:
-
-```text
-source branch and SHA
-path
-classification: port / adapt / reference / reject
-reason
-required tests
-destination path
-```
-
-A branch-level merge of `agent/rebuild-learning-core` is forbidden by this
-contract because it is diverged and carries stale/conflicting toolchain and product
-surface state.
+A branch-level merge of `agent/rebuild-learning-core` is forbidden.
 
 ## Release Contract
 
-A merge candidate requires:
+A release candidate requires:
 
-- approved requirements checklist;
-- all required task evidence;
-- exact-head lint, TypeScript, unit, content, and build gates;
-- hosted database/type equivalence;
-- hosted RLS two-user verification;
-- three human-reviewed lessons;
-- desktop/mobile full journey;
-- Vercel preview and runtime-error inspection;
+- accepted product scope;
+- documented transcript adapter/private-production decision;
+- live bounded Gemini success and failure evidence;
+- exact-head lint, TypeScript, tests, content checks, and build;
+- hosted atomic private persistence and two-user RLS evidence;
+- supported and unsupported YouTube browser paths;
+- desktop/mobile URL-to-lesson/return journey on Vercel preview;
+- no critical runtime errors;
 - owner acceptance.
 
-Merge to `main` and production deployment are separate explicit owner decisions.
-A successful preview does not authorize either action.
+Merge and production deployment remain separate explicit owner decisions.

--- a/specs/002-mvp-product-convergence/data-model.md
+++ b/specs/002-mvp-product-convergence/data-model.md
@@ -1,0 +1,312 @@
+# Data Model: AtoEnglish MVP Product Convergence
+
+## Design Rules
+
+- Hosted Supabase project `zpiwddskhduuykpxltun` remains the source of truth.
+- RLS is enabled on every exposed table.
+- Authenticated identity is derived server-side from `auth.uid()` / `getUser()`.
+- Learner evidence is bounded and machine-readable; no raw audio, unrestricted
+  transcript, name, employer, or free text is stored.
+- Reviewed source evidence and learner attempts are separate domains.
+- Publication and attempt writes are idempotent.
+- Existing tables are reused only when their semantics match the MVP contract;
+  legacy schema existence is not a reason to couple the MVP to XP/gamification.
+
+## Existing Entities Reused
+
+### `auth.users`
+
+Supabase Auth identity. The application does not duplicate passwords or provider
+credentials.
+
+### `public.user_progress`
+
+May remain the minimal account/profile bootstrap record if reduced to fields the
+MVP actually needs. Existing XP, streak, and CEFR fields are tolerated but not
+required by the MVP UI.
+
+Required MVP use:
+
+- `user_id`
+- optional display/account state already present
+- created/updated timestamps through existing schema
+
+The bootstrap operation must be idempotent and must not require fake survey
+answers.
+
+### `public.real_talk_transcript_sources`
+
+Trusted source registry already implemented by Spec 001.
+
+Required publication inputs:
+
+- provider and external source identity;
+- canonical source URL;
+- transcript/source reference;
+- language;
+- acquisition mode and rights basis/reference;
+- bounded cues;
+- cue digest;
+- independent submitter/reviewer;
+- `human_verified` review state;
+- immutable reviewed evidence.
+
+### `public.real_talk_videos`
+
+Existing media/source container. It requires a provider-neutral migration for MVP.
+
+Current useful fields:
+
+- `id`, `slug`
+- title/title_vi
+- thumbnail and duration
+- segment start/end
+- level/topics
+- speakers and speaker count
+- owner and public state
+- transcript provenance/review metadata
+- created timestamp
+
+### `public.real_talk_lessons`
+
+Existing structured lesson package.
+
+Useful fields:
+
+- environment;
+- communication events;
+- transcript;
+- pre/while/post phases;
+- transfer task;
+- generation model and warnings;
+- review identity/time;
+- generation/review status.
+
+The MVP query must require final reviewed/public eligibility rather than treating
+presence as publication.
+
+### `public.pilot_events`
+
+Existing privacy-safe event storage. Reuse only the event names and bounded scalar
+payloads needed by the MVP funnel.
+
+## Provider-Neutral Source Migration
+
+The current video record requires `youtube_id`, but the safest reviewed sources may
+come from Wikimedia, DVIDS, owned recordings, or other approved providers.
+
+Add or reconcile these fields:
+
+```text
+source_provider       text not null
+source_external_id    text not null
+canonical_source_url  text not null
+playback_kind         text not null
+playback_url          text not null
+embed_url             text null
+```
+
+Allowed `playback_kind` values:
+
+- `youtube_embed`
+- `direct_video`
+- `external_link`
+
+Rules:
+
+- `youtube_embed` requires an official HTTPS YouTube embed URL;
+- `direct_video` requires a reviewed HTTPS media URL permitted for playback;
+- `external_link` requires an HTTPS source URL and displays an honest external
+  playback boundary;
+- at least one safe playable URL must exist;
+- `youtube_id` becomes nullable or a derived compatibility field;
+- source provider/external ID is unique within provider;
+- media is not downloaded or copied by this migration.
+
+## Publication Eligibility
+
+A catalog lesson is eligible only when all conditions are true:
+
+```text
+video.is_public = true
+lesson generation/review state = reviewed/approved
+video transcript_review_status = human_verified
+video provenance metadata references a reviewed source
+lesson.reviewed_by is not null
+lesson.reviewed_at is not null
+source/playback references are safe
+```
+
+The exact status enum/string must be reconciled with existing constraints before
+DDL. The public query fails closed when any value is missing or unknown.
+
+## Proposed MVP Attempt Entity
+
+First test whether a strict repository wrapper over existing evidence tables can
+satisfy this contract. If it cannot, add `public.real_talk_attempts`.
+
+### `real_talk_attempts`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `id` | uuid | primary key, generated server/database side |
+| `user_id` | uuid | not null, FK auth.users, derived from auth |
+| `lesson_id` | uuid | not null, FK real_talk_lessons |
+| `status` | text | `started`, `in_progress`, `completed` |
+| `checkpoint` | text | bounded runtime checkpoint enum |
+| `first_listen_completed` | boolean | default false |
+| `comprehension_correct` | integer | bounded >= 0 |
+| `comprehension_total` | integer | bounded >= correct |
+| `max_support_level` | integer | bounded support scale, no content payload |
+| `retrieval_attempted` | boolean | default false |
+| `speak_confirmed` | boolean | default false; self-confirm only |
+| `transfer_attempted` | boolean | default false |
+| `started_at` | timestamptz | not null |
+| `updated_at` | timestamptz | not null |
+| `completed_at` | timestamptz | nullable; requires completion gates |
+
+Unique identity:
+
+```text
+unique (user_id, lesson_id)
+```
+
+This stores one current MVP attempt per learner and lesson. Immutable attempt
+history and delayed-transfer history are deferred.
+
+### Completion constraint
+
+A completed record requires:
+
+```text
+first_listen_completed = true
+retrieval_attempted = true
+speak_confirmed = true
+transfer_attempted = true
+completed_at is not null
+```
+
+The write path must enforce this in both application validation and database
+constraint/RPC logic.
+
+### RLS
+
+Authenticated learner:
+
+- may select only rows where `user_id = auth.uid()`;
+- may insert/update only their own attempt through a security-invoker or ordinary
+  RLS-bound write path;
+- cannot change `lesson_id` or `user_id` after creation;
+- cannot write completion unless required evidence is present;
+- cannot read another learner's attempts.
+
+Service/reviewer roles do not need learner-attempt access for the MVP unless a
+separate operational requirement is approved.
+
+## Account Bootstrap Contract
+
+Create one idempotent server operation, implemented as a transaction or
+security-invoker RPC, that derives the current user and ensures the minimum
+application records exist.
+
+Input:
+
+```text
+none beyond authenticated session and optional validated onboarding choice
+```
+
+Output:
+
+```text
+user_id
+created_or_existing
+safe_next_route
+```
+
+It must not:
+
+- accept a client-supplied user ID;
+- silently default multiple unasked personalization fields;
+- partially create one profile table and fail another without rollback;
+- grant publication/reviewer roles.
+
+## Dashboard Read Model
+
+The MVP dashboard does not query every legacy subsystem. Create one server read
+model:
+
+```ts
+interface MvpDashboardState {
+  learner: {
+    isAuthenticated: true;
+    displayLabel: string;
+  };
+  primaryAction:
+    | { kind: "start"; lessonSlug: string; title: string }
+    | { kind: "continue"; lessonSlug: string; checkpoint: string; title: string }
+    | { kind: "review"; lessonSlug: string; title: string }
+    | { kind: "empty"; reason: "no_reviewed_lessons" };
+  lessons: Array<{
+    slug: string;
+    titleVi: string;
+    environmentTitle: string;
+    durationMinutes: number;
+    status: "not_started" | "in_progress" | "completed";
+  }>;
+}
+```
+
+No XP, streak, league, word-of-day, writing, or notification query is required.
+
+## Pilot Event Contract
+
+Allowed event names:
+
+```text
+mvp_landing_viewed
+mvp_auth_started
+mvp_auth_completed
+mvp_dashboard_viewed
+mvp_lesson_started
+mvp_first_listen_completed
+mvp_support_revealed
+mvp_retrieval_attempted
+mvp_speak_confirmed
+mvp_transfer_attempted
+mvp_lesson_completed
+mvp_returned
+```
+
+Allowed payload fields are bounded identifiers and scalars only:
+
+- anonymous/authenticated ID according to existing event policy;
+- lesson ID or slug;
+- support level;
+- numeric correct/total;
+- boolean outcome;
+- source surface;
+- timestamp.
+
+Forbidden:
+
+- learner answer text;
+- speech transcript;
+- audio URL/blob;
+- name, email, employer;
+- arbitrary JSON/free text.
+
+## Data Migration and Rollback
+
+Before applying any MVP migration:
+
+1. generate a fresh hosted schema/type baseline;
+2. review existing constraints and grants;
+3. run Supabase security/performance advisors;
+4. apply only versioned migrations authorized by the owner;
+5. verify two-user and anonymous access;
+6. seed only reviewed corpus records;
+7. retain rollback SQL or a reversible data cleanup script;
+8. confirm preview uses the same hosted project.
+
+Because learner tables are nearly empty, destructive cleanup is not automatically
+safe; migration history and security invariants must still be preserved.

--- a/specs/002-mvp-product-convergence/data-model.md
+++ b/specs/002-mvp-product-convergence/data-model.md
@@ -1,273 +1,308 @@
-# Data Model: AtoEnglish MVP Product Convergence
+# Data Model: YouTube-to-Private-Lesson MVP
 
 ## Design Rules
 
 - Hosted Supabase project `zpiwddskhduuykpxltun` remains the source of truth.
-- RLS is enabled on every exposed table.
-- Authenticated identity is derived server-side from `auth.uid()` / `getUser()`.
-- Learner evidence is bounded and machine-readable; no raw audio, unrestricted
-  transcript, name, employer, or free text is stored.
-- Reviewed source evidence and learner attempts are separate domains.
-- Publication and attempt writes are idempotent.
-- Existing tables are reused only when their semantics match the MVP contract;
-  legacy schema existence is not a reason to couple the MVP to XP/gamification.
+- Authentication and ownership are derived server-side.
+- Every generated lesson is private by default and cannot be self-approved or
+  automatically published.
+- Source-dependent content remains traceable to a selected timed transcript window.
+- Generation and progress writes are idempotent.
+- RLS remains enabled.
+- Raw audio, unrestricted learner speech/transfer text, names, employers, and
+  arbitrary analytics JSON are not stored.
+- Existing hosted private-draft schema is reused where its exact contract matches.
 
 ## Existing Entities Reused
 
 ### `auth.users`
 
-Supabase Auth identity. The application does not duplicate passwords or provider
-credentials.
+Supabase Auth identity. All generation and private read/write operations derive the
+current user from the authenticated session.
 
-### `public.user_progress`
+### Minimal account/profile state
 
-May remain the minimal account/profile bootstrap record if reduced to fields the
-MVP actually needs. Existing XP, streak, and CEFR fields are tolerated but not
-required by the MVP UI.
+Reuse `public.user_progress` or an equivalent minimal bootstrap row only if needed
+by the shell. XP, streak, CEFR, league, and daily-goal fields are not required by
+the MVP UI.
 
-Required MVP use:
-
-- `user_id`
-- optional display/account state already present
-- created/updated timestamps through existing schema
-
-The bootstrap operation must be idempotent and must not require fake survey
-answers.
-
-### `public.real_talk_transcript_sources`
-
-Trusted source registry already implemented by Spec 001.
-
-Required publication inputs:
-
-- provider and external source identity;
-- canonical source URL;
-- transcript/source reference;
-- language;
-- acquisition mode and rights basis/reference;
-- bounded cues;
-- cue digest;
-- independent submitter/reviewer;
-- `human_verified` review state;
-- immutable reviewed evidence.
+Bootstrap must be server-owned, transactional/idempotent, and shared by email and
+OAuth.
 
 ### `public.real_talk_videos`
 
-Existing media/source container. It requires a provider-neutral migration for MVP.
+For the private-generation MVP this table is the source/video container and draft
+owner boundary.
 
-Current useful fields:
+Required semantics:
 
-- `id`, `slug`
-- title/title_vi
-- thumbnail and duration
-- segment start/end
-- level/topics
-- speakers and speaker count
-- owner and public state
-- transcript provenance/review metadata
-- created timestamp
+- `id`: generated UUID
+- `created_by`: authenticated owner
+- `slug`: deterministic owner-safe lesson route identity
+- `youtube_id`: normalized YouTube video ID
+- canonical source URL and metadata
+- official thumbnail/channel/title where available
+- selected `segment_start` / `segment_end`
+- target level
+- transcript acquisition mode and review/status metadata
+- transcript cue digest and source metadata
+- `is_public = false`
+- creation timestamp
+
+The existing atomic RPC and constraints must be verified against these semantics.
 
 ### `public.real_talk_lessons`
 
-Existing structured lesson package.
+Stores the structured private lesson generated from the selected source window.
 
-Useful fields:
+Required semantics:
 
-- environment;
-- communication events;
-- transcript;
-- pre/while/post phases;
-- transfer task;
-- generation model and warnings;
-- review identity/time;
-- generation/review status.
+- `video_id`
+- generated titles and level
+- environment and roles
+- communication events with transcript references
+- transcript cues/segments required by runtime
+- pre/while/post or equivalent activity structures
+- transfer task
+- generation model
+- generation warnings
+- generation status / review state equal to private `ai_draft`
+- `reviewed_by` / `reviewed_at` null for ordinary generated drafts
+- creation timestamp
 
-The MVP query must require final reviewed/public eligibility rather than treating
-presence as publication.
+A private draft may be used by its owner with warnings. It is not eligible for
+public catalog queries without a later human-review/publication flow.
+
+### `public.real_talk_transcript_sources`
+
+This reviewed-source registry remains useful for controlled tests, approved source
+re-use, and future public publication. It is not required to turn every user's
+private YouTube URL into a draft if equivalent provenance fields and cue evidence
+are stored with the private draft.
+
+The implementation must choose one explicit provenance path rather than silently
+mixing reviewed and experimental states.
 
 ### `public.pilot_events`
 
-Existing privacy-safe event storage. Reuse only the event names and bounded scalar
-payloads needed by the MVP funnel.
+May store a small allow-listed generation/lesson funnel. Payloads remain bounded
+and privacy-safe.
 
-## Provider-Neutral Source Migration
+## Generation Request Domain Model
 
-The current video record requires `youtube_id`, but the safest reviewed sources may
-come from Wikimedia, DVIDS, owned recordings, or other approved providers.
+The client sends no user ID.
 
-Add or reconcile these fields:
-
-```text
-source_provider       text not null
-source_external_id    text not null
-canonical_source_url  text not null
-playback_kind         text not null
-playback_url          text not null
-embed_url             text null
+```ts
+interface GeneratePrivateLessonInput {
+  youtubeUrl: string;
+  level: "A0" | "A1" | "A2" | "B1" | "B2";
+}
 ```
 
-Allowed `playback_kind` values:
+Server-derived context:
 
-- `youtube_embed`
-- `direct_video`
-- `external_link`
+```ts
+interface GenerationContext {
+  userId: string;
+  normalizedYoutubeId: string;
+  requestIpBucket: string;
+  requestedAt: string;
+}
+```
+
+Validated request identity:
+
+```text
+owner user ID
++ normalized YouTube video ID
++ selected level
++ compiler contract version
+```
+
+This identity supports retry-safe deterministic persistence. Exact slug/unique-key
+behavior must match the hosted atomic RPC.
+
+## Transcript Source Record
+
+The compiler receives an explicit transcript result:
+
+```ts
+interface TranscriptSourceResult {
+  adapterId: string;
+  acquisitionMode: string;
+  reviewStatus: "unreviewed" | "machine_checked" | "human_verified";
+  language: "en";
+  videoId: string;
+  canonicalUrl: string;
+  cues: Array<{
+    index: number;
+    startSeconds: number;
+    durationSeconds: number;
+    text: string;
+  }>;
+  cueDigest: string;
+  warnings: string[];
+}
+```
 
 Rules:
 
-- `youtube_embed` requires an official HTTPS YouTube embed URL;
-- `direct_video` requires a reviewed HTTPS media URL permitted for playback;
-- `external_link` requires an HTTPS source URL and displays an honest external
-  playback boundary;
-- at least one safe playable URL must exist;
-- `youtube_id` becomes nullable or a derived compatibility field;
-- source provider/external ID is unique within provider;
-- media is not downloaded or copied by this migration.
+- timed English cues are required;
+- cue count/duration is bounded;
+- HTML/caption artifacts are normalized deterministically;
+- transcript text is treated as untrusted data in prompts;
+- adapter/mode/status/warnings survive persistence;
+- unsupported source conditions return machine-readable errors, not an empty
+  transcript disguised as success.
 
-## Publication Eligibility
+## Selected Source Window
 
-A catalog lesson is eligible only when all conditions are true:
-
-```text
-video.is_public = true
-lesson generation/review state = reviewed/approved
-video transcript_review_status = human_verified
-video provenance metadata references a reviewed source
-lesson.reviewed_by is not null
-lesson.reviewed_at is not null
-source/playback references are safe
+```ts
+interface InteractionWindow {
+  startSeconds: number;
+  endSeconds: number;
+  cueIndices: number[];
+  interactionScore: number;
+  selectionVersion: string;
+}
 ```
 
-The exact status enum/string must be reconciled with existing constraints before
-DDL. The public query fails closed when any value is missing or unknown.
+Constraints:
 
-## Proposed MVP Attempt Entity
+- duration <= 180 seconds;
+- cue count <= configured maximum;
+- start/end align to selected cues;
+- deterministic for the same normalized transcript and selection version;
+- interaction-rich selection is preferred over a fixed opening slice.
 
-First test whether a strict repository wrapper over existing evidence tables can
-satisfy this contract. If it cannot, add `public.real_talk_attempts`.
+## Generation Result
 
-### `real_talk_attempts`
+Use an explicit discriminated union with stable codes:
 
-| Column | Type | Rules |
+```ts
+type GenerateLessonResult =
+  | { ok: true; lessonSlug: string; videoId: string; lessonId: string; warnings: string[] }
+  | { ok: false; code: GenerateLessonFailureCode; message: string; retryable: boolean; retryAfterSeconds?: number };
+```
+
+Required failure families:
+
+- unauthenticated
+- invalid URL / unsupported host
+- source unavailable/private/age-restricted/embed-disabled
+- transcript unavailable/empty/non-English/invalid timing
+- transcript adapter failure
+- rate limited
+- Gemini unavailable/rate limited/invalid structured output
+- evidence validation failure
+- persistence failure
+- unknown safe failure
+
+Failure results must not leak secrets, provider payloads, or internal stack traces.
+
+## Private Draft Invariants
+
+After successful persistence:
+
+```text
+video.created_by = auth.uid()
+video.is_public = false
+lesson state = ai_draft
+lesson reviewed_by/reviewed_at = null
+source identity and selected window are persisted
+adapter/mode/cue digest are persisted
+actual Gemini model and warnings are persisted
+video + lesson are written atomically
+```
+
+Ordinary users cannot:
+
+- set `is_public = true`;
+- mark a lesson reviewed/approved;
+- access another owner's draft;
+- substitute another user ID;
+- change immutable source identity after persistence.
+
+## Account Bootstrap Contract
+
+One server operation derives the current Auth user and ensures only the minimum
+application records exist.
+
+It must not silently store unasked goal/time/obstacle defaults or grant content
+review/publication permissions.
+
+## Private Library Read Model
+
+```ts
+interface PrivateLessonLibraryState {
+  primaryAction: { kind: "generate" };
+  recentLessons: Array<{
+    slug: string;
+    youtubeId: string;
+    sourceTitle: string;
+    lessonTitleVi: string;
+    level: string;
+    generationState: "ready" | "failed";
+    learningState: "not_started" | "in_progress" | "completed";
+    warningCount: number;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  continueLesson?: {
+    slug: string;
+    checkpoint: string;
+  };
+}
+```
+
+No public/shared catalog is required.
+
+## Bounded Learner Attempt
+
+First evaluate strict reuse of existing evidence storage. If insufficient, add
+`public.real_talk_attempts`.
+
+| Column | Type | Rule |
 | --- | --- | --- |
-| `id` | uuid | primary key, generated server/database side |
-| `user_id` | uuid | not null, FK auth.users, derived from auth |
-| `lesson_id` | uuid | not null, FK real_talk_lessons |
+| `id` | uuid | generated primary key |
+| `user_id` | uuid | owner, derived from Auth |
+| `lesson_id` | uuid | FK private lesson |
 | `status` | text | `started`, `in_progress`, `completed` |
-| `checkpoint` | text | bounded runtime checkpoint enum |
+| `checkpoint` | text | bounded enum |
 | `first_listen_completed` | boolean | default false |
 | `comprehension_correct` | integer | bounded >= 0 |
 | `comprehension_total` | integer | bounded >= correct |
-| `max_support_level` | integer | bounded support scale, no content payload |
+| `max_support_level` | integer | bounded support scale |
 | `retrieval_attempted` | boolean | default false |
-| `speak_confirmed` | boolean | default false; self-confirm only |
+| `speak_confirmed` | boolean | self-confirm only |
 | `transfer_attempted` | boolean | default false |
-| `started_at` | timestamptz | not null |
-| `updated_at` | timestamptz | not null |
-| `completed_at` | timestamptz | nullable; requires completion gates |
+| `started_at` | timestamptz | required |
+| `updated_at` | timestamptz | required |
+| `completed_at` | timestamptz | nullable; gated |
 
-Unique identity:
+Unique key:
 
 ```text
 unique (user_id, lesson_id)
 ```
 
-This stores one current MVP attempt per learner and lesson. Immutable attempt
-history and delayed-transfer history are deferred.
+Completion requires first listen, retrieval, speak confirmation, transfer, and
+`completed_at`.
 
-### Completion constraint
+RLS restricts every read/write to `user_id = auth.uid()` and ensures the referenced
+lesson belongs to the same owner.
 
-A completed record requires:
-
-```text
-first_listen_completed = true
-retrieval_attempted = true
-speak_confirmed = true
-transfer_attempted = true
-completed_at is not null
-```
-
-The write path must enforce this in both application validation and database
-constraint/RPC logic.
-
-### RLS
-
-Authenticated learner:
-
-- may select only rows where `user_id = auth.uid()`;
-- may insert/update only their own attempt through a security-invoker or ordinary
-  RLS-bound write path;
-- cannot change `lesson_id` or `user_id` after creation;
-- cannot write completion unless required evidence is present;
-- cannot read another learner's attempts.
-
-Service/reviewer roles do not need learner-attempt access for the MVP unless a
-separate operational requirement is approved.
-
-## Account Bootstrap Contract
-
-Create one idempotent server operation, implemented as a transaction or
-security-invoker RPC, that derives the current user and ensures the minimum
-application records exist.
-
-Input:
-
-```text
-none beyond authenticated session and optional validated onboarding choice
-```
-
-Output:
-
-```text
-user_id
-created_or_existing
-safe_next_route
-```
-
-It must not:
-
-- accept a client-supplied user ID;
-- silently default multiple unasked personalization fields;
-- partially create one profile table and fail another without rollback;
-- grant publication/reviewer roles.
-
-## Dashboard Read Model
-
-The MVP dashboard does not query every legacy subsystem. Create one server read
-model:
-
-```ts
-interface MvpDashboardState {
-  learner: {
-    isAuthenticated: true;
-    displayLabel: string;
-  };
-  primaryAction:
-    | { kind: "start"; lessonSlug: string; title: string }
-    | { kind: "continue"; lessonSlug: string; checkpoint: string; title: string }
-    | { kind: "review"; lessonSlug: string; title: string }
-    | { kind: "empty"; reason: "no_reviewed_lessons" };
-  lessons: Array<{
-    slug: string;
-    titleVi: string;
-    environmentTitle: string;
-    durationMinutes: number;
-    status: "not_started" | "in_progress" | "completed";
-  }>;
-}
-```
-
-No XP, streak, league, word-of-day, writing, or notification query is required.
-
-## Pilot Event Contract
-
-Allowed event names:
+## Pilot Event Allow-List
 
 ```text
 mvp_landing_viewed
-mvp_auth_started
 mvp_auth_completed
-mvp_dashboard_viewed
-mvp_lesson_started
+mvp_generation_submitted
+mvp_source_validated
+mvp_transcript_acquired
+mvp_generation_succeeded
+mvp_generation_failed
+mvp_private_lesson_opened
 mvp_first_listen_completed
 mvp_support_revealed
 mvp_retrieval_attempted
@@ -277,36 +312,22 @@ mvp_lesson_completed
 mvp_returned
 ```
 
-Allowed payload fields are bounded identifiers and scalars only:
+Allowed payloads are bounded IDs, enum codes, booleans, counts, durations, support
+levels, and timestamps. No URL query data, transcript text, learner response text,
+audio, email, name, or provider secret is allowed.
 
-- anonymous/authenticated ID according to existing event policy;
-- lesson ID or slug;
-- support level;
-- numeric correct/total;
-- boolean outcome;
-- source surface;
-- timestamp.
+## Migration and Hosted Verification
 
-Forbidden:
+Before applying any new DDL:
 
-- learner answer text;
-- speech transcript;
-- audio URL/blob;
-- name, email, employer;
-- arbitrary JSON/free text.
+1. compare repo migrations/types to hosted schema;
+2. verify existing atomic draft RPC and RLS with two users;
+3. decide whether a new attempt table is necessary;
+4. use versioned migrations only;
+5. obtain explicit owner authorization;
+6. regenerate types from `zpiwddskhduuykpxltun`;
+7. run security/performance advisors;
+8. record rollback and cleanup;
+9. confirm Vercel preview uses the same project.
 
-## Data Migration and Rollback
-
-Before applying any MVP migration:
-
-1. generate a fresh hosted schema/type baseline;
-2. review existing constraints and grants;
-3. run Supabase security/performance advisors;
-4. apply only versioned migrations authorized by the owner;
-5. verify two-user and anonymous access;
-6. seed only reviewed corpus records;
-7. retain rollback SQL or a reversible data cleanup script;
-8. confirm preview uses the same hosted project.
-
-Because learner tables are nearly empty, destructive cleanup is not automatically
-safe; migration history and security invariants must still be preserved.
+The old unapplied `20260731162613_learning_attempts.sql` is not adopted by default.

--- a/specs/002-mvp-product-convergence/owner-decisions.md
+++ b/specs/002-mvp-product-convergence/owner-decisions.md
@@ -1,0 +1,25 @@
+# Owner Decisions
+
+## 2026-08-03 — Core MVP
+
+Owner decision: AtoEnglish's core product remains:
+
+```text
+Paste a YouTube URL
+→ generate a private personal English lesson
+→ learn and save it
+```
+
+A fixed reviewed catalog does not replace this workflow.
+
+Consequences:
+
+- YouTube URL generation is the primary learner action.
+- Generated lessons remain owner-private `ai_draft` records.
+- Transcript evidence, validation, warnings, rate limits, RLS, and atomic persistence are mandatory.
+- Unsupported videos fail honestly.
+- Official YouTube playback is used; media is not downloaded or re-hosted.
+- Human review is required only before later public sharing or catalog publication.
+- Implementation still starts from current `main` and selectively ports accepted Spec 001 work.
+
+This decision corrects the plan. It does not itself authorize migrations, preview deployment, merge, or production deployment.

--- a/specs/002-mvp-product-convergence/plan.md
+++ b/specs/002-mvp-product-convergence/plan.md
@@ -1,239 +1,266 @@
-# Implementation Plan: AtoEnglish MVP Product Convergence
+# Implementation Plan: AtoEnglish MVP — YouTube to Private Lesson
 
-**Branch for this plan:** `spec/mvp-product-convergence`  
-**Future implementation branch:** `integration/mvp-product-convergence` created from then-current `main`  
-**Application deployment:** none in planning phase
+**Planning branch:** `spec/mvp-product-convergence`  
+**Future implementation branch:** `integration/mvp-youtube-to-lesson`, created from then-current `main`  
+**Planning deployment:** none
+
+## Owner-Corrected Product Goal
+
+The product's core interaction is:
+
+```text
+paste YouTube URL
+→ generate a private evidence-bound lesson
+→ learn from that selected interaction
+→ save and revisit it
+```
+
+A fixed reviewed catalog is not the MVP. Human review/publication belongs to a
+later shared-content feature. The MVP serves the authenticated owner with a
+private `ai_draft` and visible transcript/AI uncertainty.
 
 ## Technical Context
 
-- Framework: Next.js 16.2.9 App Router, React 19.2, TypeScript 6
-- Styling/UI: Tailwind CSS v4, Base UI, Framer Motion, existing AtoEnglish design system
-- Database/Auth: hosted Supabase project `zpiwddskhduuykpxltun`, PostgreSQL 17, RLS
-- Hosting: Vercel project `atoenglish`, Node 24
-- Tests: Vitest, Playwright, content-standard checks, hosted Supabase integration checks
-- Monitoring: Sentry, Vercel Analytics/Speed Insights; current Vercel seven-day runtime error query returned no grouped errors
-- Current repository state:
-  - `main`: `961e779886ff95b1b5f67d5e6997520d1facdb1a`
-  - Real Talk branch: `e1642db1540046271f520f72f1b20a04e5d84f09`
-  - comparison: diverged, Real Talk branch 420 commits ahead and 7 commits behind `main`
-  - active Real Talk PR #54 targets a non-main baseline and MUST NOT be merged wholesale
+- Next.js 16.2.9 App Router, React 19, TypeScript, Tailwind CSS v4
+- Hosted Supabase: `zpiwddskhduuykpxltun`, Auth, PostgreSQL, RLS
+- Vercel project: `atoenglish`, Node 24
+- Generation provider: Gemini behind the existing typed provider contract
+- Source: supported public YouTube URL, official embed/watch playback
+- Transcript: replaceable timed-transcript adapter with explicit mode and failure codes
+- Tests: Vitest, Playwright, content checks, hosted RLS/integration, live bounded provider checks
+- Branch state: `agent/rebuild-learning-core` contains valuable Spec 001 work but is diverged 420 commits ahead and 7 behind `main`; it MUST NOT be merged wholesale
 
-## Constitution Check — Before Design
+## Constitution Check
 
 | Principle | Plan response |
 | --- | --- |
-| Natural Communication First | MVP surface is one reviewed natural environment, not the existing grammar/unit catalog. |
-| Evidence-Bound Generation | Learner catalog excludes static samples and unreviewed AI drafts. |
-| Transfer Before Completion | Transfer attempt is a hard completion gate. |
-| Rights, Privacy, Safety | Reviewed source packages only; official playback; no raw audio/free text. |
-| Small Testable Delivery | One environment, three reviewed lessons, one end-to-end loop. |
-| Measurable Evidence | Technical, lesson, learner-funnel, and owner-acceptance evidence remain separate. |
+| Natural Communication First | The compiler selects a bounded natural interaction from the learner's chosen video and builds the lesson around its situation and practical goal. |
+| Evidence-Bound Generation | All source-dependent generated claims validate against timed transcript cues; invalid output is rejected. |
+| Transfer Before Completion | The private lesson cannot complete without changed-context production. |
+| Rights, Privacy, Safety | Official playback only, no media re-hosting, owner-private drafts, visible warnings, RLS, no raw learner audio/free text. |
+| Small Testable Delivery | One supported YouTube-to-private-lesson journey, not a catalog/curriculum rebuild. |
+| Measurable Evidence | Technical, provider, browser, learner-flow, and owner evidence remain distinct. |
 
-**Gate result:** PASS for planning. Implementation remains blocked until the owner accepts this specification and the initial source-review capacity is confirmed.
+**Result:** PASS as a private-generation MVP. Public sharing remains blocked behind human review.
 
-## Repository Findings Driving the Plan
+## Repository Findings Driving the Revised Plan
 
-1. The production-shaped build exposes more than forty routes and 89 generated pages, while the product north star needs one focused learner loop.
-2. The current landing page still promises a 28-day speaking journey, while the governing product truth is natural communication / Real Talk.
-3. Login combines onboarding and authentication; the UI declares four survey questions but the current three-step path asks one and silently defaults the others.
-4. Signup performs profile/progress inserts directly from the browser, creating duplicated email/OAuth bootstrap paths and partial-state risk.
-5. The dashboard depends on legacy XP, streak, flashcards, speaking sessions, word-of-day, fifty-unit metadata, and multiple action calls; this is not required for MVP activation.
-6. Navigation still exposes lessons, speaking, writing, progress, leaderboard, roadmap, business, challenge, and pronunciation as product surfaces.
-7. The learner Real Talk catalog mixes database rows with static sample lessons. Static data includes transcript/speaker/pronunciation claims that did not pass the hosted review registry.
-8. The Real Talk hub exposes arbitrary YouTube lesson generation to learners, while the approved compiler is owner-private and the current transcript adapter remains experimental.
-9. Hosted Supabase has 26 public tables with RLS enabled; most application tables have zero rows. It has 3 Auth users, 16 pilot events, and no persisted learner progress or Real Talk catalog rows at audit time.
-10. Hosted Real Talk migrations and reviewed-source infrastructure are applied, but the current video schema remains YouTube-specific even though the controlled approved source is Wikimedia/DVIDS.
-11. `main` and the Real Talk branch do not share one dependency/type baseline. `main` removed the old `gtts` chain and pins Node/npm; the Real Talk branch still carries older package state. `main` also points `db:types` at a different Supabase project ID.
-12. Vercel is connected and recent preview deployments are READY, but the project reports no active production deployment for the current work.
+1. The existing Real Talk compiler already implements much of the desired product: authenticated generation, bounded transcript selection, Gemini structured output, evidence validation, private persistence, RLS, and a learner-like preview.
+2. The previous MVP plan incorrectly demoted `/real-talk/create` and arbitrary YouTube input. Owner correction makes that flow the primary learner action.
+3. Current landing/auth/dashboard/navigation still describe legacy 28-day, unit, XP, flashcard, writing, and gamification experiences instead of URL-to-lesson generation.
+4. The current create flow is production-blocked by transcript acquisition policy and missing live Gemini-key evidence, not by lack of UI or database infrastructure.
+5. Static sample lessons must not be mistaken for lessons generated from the user's URL. They may remain only as controlled fixtures/demos.
+6. The hosted database already contains private Real Talk schema, atomic persistence, transcript provenance, RLS, and reviewed-source infrastructure.
+7. Main and the Real Talk branch have different package/type baselines; implementation must preserve main's Node/npm/lockfile and selectively port only required files.
+8. The hosted Supabase project is mostly empty, so product convergence can focus on correct private-generation semantics without a large user-data migration.
 
-## MVP Architecture Decision
-
-Preserve the modular monolith and reduce the learner shell.
+## Target Product Architecture
 
 ```text
 src/app/
-├── page.tsx                         # truthful landing
-├── login/                           # auth only; no fake personalization
+├── page.tsx                              # promise: paste YouTube, get a private lesson
+├── login/                                # auth only
 └── (main)/
-    ├── dashboard/                   # one next action + continue/review
-    ├── real-talk/                   # reviewed catalog
-    ├── real-talk/[lessonSlug]/      # environment runtime
-    └── me/                          # account, logout, bounded history
-
-src/features/mvp/
-├── domain/                          # learner state and route decisions
-├── server/                          # account bootstrap and dashboard query
-└── components/                      # focused shell/empty/error states
+    ├── dashboard/                        # URL form + recent/continue/review lessons
+    ├── real-talk/create/                 # focused generation surface, or embedded in dashboard
+    ├── real-talk/[lessonSlug]/            # owner-private lesson runtime
+    └── me/                               # account/logout/private history
 
 src/features/real-talk/
-├── domain/                          # reviewed lesson/playback/attempt contracts
-├── server/                          # catalog, lesson, attempt repositories
-├── client/                          # bounded browser progress state
-└── components/                      # runtime phases
+├── application/generate-private-lesson.ts
+├── domain/                               # URL, transcript, result, prompt, draft identity, runtime
+├── server/                               # YouTube source, transcript adapter, Gemini, compiler, persistence
+├── components/                           # generation form/status + lesson runtime
+└── client/                               # bounded progress/checkpoint state
+
+src/features/mvp/
+├── domain/                               # dashboard/account states
+└── server/                               # bootstrap + recent private lesson query
 ```
 
-Legacy routes remain outside the primary shell. They are not rewritten during the
-MVP unless a route can leak an unsupported promise or bypass the MVP access model.
+No public catalog is required. `/real-talk` may become the owner's private lesson
+library or redirect to the dashboard.
 
-## Integration Strategy
+## Selective-Port Strategy
 
-### Do not merge PR #54 wholesale
+Create the implementation branch from current `main`. Build a file-level manifest
+with `port`, `adapt`, `reference`, or `reject` classifications.
 
-Create `integration/mvp-product-convergence` from current `main`. Produce a port
-manifest with each Real Talk file classified as:
+### High-priority port/adapt candidates
 
-- **port unchanged** — contract/security code already independently verified;
-- **port with adaptation** — useful behavior but tied to static samples, YouTube,
-  old navigation, or private-preview assumptions;
-- **reference only** — tests/evidence that guide a new implementation;
-- **reject** — experimental, conflicting, stale, or outside MVP.
-
-### Default port candidates
-
+- `src/features/real-talk/application/generate-private-lesson.ts`
 - `src/features/real-talk/domain/**`
-- `src/features/real-talk/server/transcript-provenance.ts`
+- `src/features/real-talk/server/private-lesson-compiler.ts`
+- `src/features/real-talk/server/gemini-lesson-provider.ts`
 - `src/features/real-talk/server/transcript-source-policy.ts`
-- `src/features/real-talk/server/transcript-sources/supabase-reviewed.ts`
+- `src/features/real-talk/server/transcript-sources/youtube-experimental.ts`
+- `src/features/real-talk/server/draft-repository.ts`
 - `src/features/real-talk/server/draft-mapping.ts`
-- selected lesson runtime components and their tests
-- reviewed-source Edge Function and versioned Real Talk migrations
-- Spec 001 security, RLS, hosted, and browser evidence
+- `src/app/actions/real-talk.ts`
+- `src/app/(main)/real-talk/create/page.tsx`
+- private lesson runtime components/tests
+- atomic private-draft/provenance migrations already applied to hosted Supabase
+- Spec 001 hosted/browser verification artifacts as evidence references
 
-### Default reject or isolate candidates
+### Reject/isolate from the MVP critical path
 
-- learner-facing `/real-talk/create`
-- `youtube-transcript` in production paths
-- static `src/lib/data/real-talk/videos.ts` as catalog fallback
-- static sample transcript, speaker, translation, pronunciation, and answer claims
-- old package/lockfile state and `gtts` dependency chain
-- broad mission, XP, streak, league, writing, notification, and curriculum changes
-- unapplied `20260731162613_learning_attempts.sql` unless a new data-model review explicitly adopts it
+- public static sample catalog fallback
+- automatic publication or shared catalog
+- broad mission/curriculum/gamification work
+- stale package/lockfile state and the `gtts` dependency chain
+- unapplied `20260731162613_learning_attempts.sql` unless separately adopted after model review
+
+## Transcript Acquisition Decision
+
+The URL-only product depends on timed transcript evidence. The implementation must
+make a production/private-MVP decision before release:
+
+1. identify the exact adapter used for supported YouTube videos;
+2. document acquisition mode, reliability, terms/rights risk, language/timing limits, and failure modes;
+3. keep the adapter replaceable;
+4. label generated lessons with acquisition mode and warnings;
+5. fail unsupported videos honestly;
+6. keep generated output owner-private;
+7. never download/re-host video or treat a URL as permission for public derivatives.
+
+The current experimental adapter may be used in a controlled preview only after
+this decision is documented. It cannot silently be promoted because tests pass.
 
 ## Data Strategy
 
-1. Align repository generated types and environment documentation to the hosted project `zpiwddskhduuykpxltun`.
-2. Add a provider-neutral playback/source migration rather than forcing Wikimedia or owned sources into `youtube_id`.
-3. Keep reviewed source provenance in `real_talk_transcript_sources`.
-4. Keep public lesson content in `real_talk_videos` and `real_talk_lessons`, with public eligibility enforced by database/query constraints.
-5. Add a dedicated bounded attempt/progress record only if existing `user_v2_lesson_progress` and `lesson_v2_evidence` cannot meet transfer/support/privacy requirements cleanly.
-6. Do not store raw speech, learner free text, names, or employers.
-7. Create one controlled publication/seed operation for the initial reviewed corpus; full reviewer/publication UI is deferred.
+Reuse the existing private draft tables and atomic persistence where their hosted
+schema matches the Spec 001 contracts:
+
+- `real_talk_videos`: source identity, owner, URL/video metadata, selected window, transcript provenance, private/public state
+- `real_talk_lessons`: generated structured lesson, model, warnings, environment, activities, transfer task, `ai_draft` state
+- `real_talk_transcript_sources`: optional reviewed/registered source evidence; not required for every private user-generated lesson if acquisition provenance is stored elsewhere
+
+Add or adapt a bounded learner-attempt record only when existing progress tables
+cannot express first listen, support, retrieval, speech confirmation, and transfer.
+
+Do not store raw recordings, unrestricted speech/transfer text, names, employers,
+or arbitrary analytics payloads.
 
 ## UI and Information Architecture
 
-### Public
+### Landing
 
-- Landing
-- Login/signup
-- Privacy/terms
+- Headline: turn a YouTube video into a personal English lesson
+- Explain supported-video limitations and AI/transcript uncertainty honestly
+- Primary CTA: paste a link after authentication
 
-### Authenticated primary shell
+### Authenticated dashboard
 
-- **Học**: dashboard and reviewed lesson catalog
-- **Ôn lại**: completed/in-progress lessons; no FSRS or mastery claim required
-- **Tôi**: account, logout, minimal history/settings
+- YouTube URL input is the primary action
+- Generation state: validating → reading transcript → selecting interaction → generating → validating → saving
+- Recent private lessons with `continue`, `review`, `retry`, or `failed` states
+- Clear supported/unsupported error guidance
 
-### Hidden/deferred from MVP primary navigation
+### Private lesson
 
-- `/learn` legacy unit catalog
-- `/flashcards` legacy SRS
-- `/grammar`
-- `/speaking/*` broad tools
-- `/writing/*`
-- `/leaderboard`
-- `/challenge`
-- `/certificate/*`
-- `/business`
-- `/roadmap`
-- `/pronunciation`
-- notifications/push engagement surfaces
+- Source and official playback
+- AI draft/transcript-mode warnings
+- environment briefing
+- first listening encounter
+- progressive support
+- productive retrieval
+- speak-and-confirm
+- changed-context transfer
+- honest completion
 
-Routes may remain reachable to developers during convergence, but the preview
-acceptance environment must expose one coherent product story.
+### Minimal navigation
+
+- Tạo bài / Học
+- Bài của tôi
+- Tôi
+
+Legacy modules stay out of the primary MVP shell.
 
 ## Delivery Phases
 
-### Phase 0 — Governance and branch convergence
+### Phase 0 — Governance and baseline
 
-- approve MVP spec;
-- freeze exact source SHAs;
-- create integration branch from current `main`;
-- create and review selective port manifest;
-- align toolchain, lockfile, Supabase project reference, and CI.
+- record owner correction;
+- create fresh-main implementation branch;
+- build selective-port manifest;
+- align package, Supabase types/project reference, CI, and environment docs.
 
-### Phase 1 — Product shell
+### Phase 1 — Entry, auth, and generation dashboard
 
-- replace landing promise and CTA;
-- simplify auth and create server-side account bootstrap;
-- protect dashboard/catalog/account routes;
-- reduce primary navigation;
-- replace dashboard with one next-action experience and honest empty/error states.
+- rewrite landing promise;
+- simplify auth and server-side bootstrap;
+- protect private routes;
+- make URL form/recent lessons the dashboard core;
+- remove fake personalization and unrelated navigation.
 
-### Phase 2 — Reviewed content and publication boundary
+### Phase 2 — YouTube source and transcript boundary
 
-- select one environment;
-- human-review at least three source packages;
-- generalize source playback fields;
-- create authorized public catalog records;
-- remove static sample fallback and learner-facing generation controls.
+- validate/normalize YouTube URLs;
+- verify official playback/embed availability;
+- finalize transcript adapter decision and failure codes;
+- implement supported-video checks and bounded transcript acquisition;
+- preserve source metadata/provenance/warnings.
 
-### Phase 3 — Learner runtime and persistence
+### Phase 3 — Private compiler and persistence
 
-- adapt reviewed lesson runtime to shared product layout;
-- implement cold listen, progressive support, retrieval, speaking confirmation,
-  transfer, and honest completion;
-- persist bounded attempt/progress evidence with RLS and idempotency;
-- surface continue/completed/review state on dashboard.
+- port compiler/Gemini/evidence contracts;
+- authenticate before provider calls;
+- run structured generation and source validation;
+- atomically persist deterministic owner-private `ai_draft`;
+- expose actionable generation status and retry behavior;
+- verify live Gemini success/failure with a bounded key.
 
-### Phase 4 — Pilot instrumentation and hardening
+### Phase 4 — Lesson runtime and return
 
-- reuse or narrow `pilot_events` for the MVP funnel;
-- add loading, empty, offline/media, auth, and persistence failure behavior;
-- run security/performance advisors;
-- verify no legacy or editor-only route is presented as the MVP.
+- adapt the environment-first preview into the owner learner runtime;
+- enforce retrieval, speaking confirmation, and transfer completion gates;
+- persist bounded progress;
+- build recent/private library and return states;
+- prove cross-user denial.
 
-### Phase 5 — Preview, owner acceptance, and release decision
+### Phase 5 — Preview and release gates
 
 - exact-head technical gates;
-- hosted two-user RLS checks;
-- desktop/mobile full-journey Playwright;
-- one Vercel preview and runtime-log inspection;
-- human lesson review evidence;
+- hosted Auth/RLS/atomic-persistence checks;
+- controlled supported/unsupported YouTube checks;
+- desktop/mobile end-to-end preview;
+- Vercel runtime error inspection;
 - owner acceptance;
-- only then prepare a main-targeted merge PR and separately authorize production deployment.
+- separate merge and production-deployment authorization.
 
 ## Risk Register
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| Whole-branch merge reintroduces removed dependencies and conflicts | High | Fresh integration branch plus exact port manifest. |
-| Static samples leak unreviewed content | High | Database-only catalog; fail closed with empty state. |
-| No human-reviewed three-lesson corpus | High | Content review is a release blocker, not post-launch cleanup. |
-| YouTube-specific schema blocks safer public-domain sources | High | Provider-neutral playback migration before corpus seed. |
-| Auth bootstrap creates partial rows | High | One server-side idempotent transaction/RPC. |
-| Legacy dashboard/navigation confuses product test | High | MVP shell replaces primary paths; deferred features hidden. |
-| Progress schema stores excessive learner content | High | Bounded evidence schema and privacy contract tests. |
-| CI passes but preview product is incoherent | High | Full browser journey and owner acceptance required. |
-| Vercel/Supabase envs point at different projects | High | Environment/type equivalence gate before preview. |
-| MVP expands into curriculum/gamification rewrite | Medium | Explicit route and task allow-list; stop on scope escape. |
+| Transcript adapter cannot reliably support arbitrary YouTube URLs | Critical | Promise only supported videos; explicit adapter decision, failure codes, replacement boundary. |
+| Live Gemini key/provider path missing | Critical | Treat live success/failure as release blocker; never substitute mocks. |
+| Whole-branch merge reintroduces stale dependencies/product state | High | Fresh-main integration and exact port manifest. |
+| Generated transcript/lesson contains errors | High | Timed-cue evidence validation, AI-draft label, warnings, private-only state. |
+| User expects every video to work | High | Supported-video requirements and actionable failure copy on landing/form. |
+| Partial lesson persists after provider/database failure | High | Atomic deterministic persistence and cleanup tests. |
+| Cross-user private lesson leak | Critical | RLS, owner-derived queries, two-user hosted/browser tests. |
+| Static fixtures appear as user-generated output | High | Remove fixture fallback from private library/production generation paths. |
+| Legacy dashboard obscures core action | High | URL form and recent private lessons become the entire primary dashboard. |
+| CI passes without provider/browser reality | High | Live adapter/Gemini/hosted/preview evidence required. |
 
 ## Constitution Check — After Design
 
-- Natural communication remains the learner surface: PASS.
-- All learner content requires reviewed evidence: PASS.
-- Transfer is required before completion: PASS.
-- Privacy and source rights fail closed: PASS.
-- Delivery is one independently testable vertical slice: PASS.
-- Product evidence is not inferred from CI: PASS.
+- Natural interaction chosen by the learner is the content source: PASS.
+- Generated claims remain bounded to transcript evidence: PASS.
+- Private AI draft is not confused with reviewed/public content: PASS.
+- Transfer remains a completion gate: PASS.
+- Official playback and privacy boundaries remain intact: PASS.
+- One vertical slice can be independently tested: PASS.
 
 ## Stop Conditions
 
-Implementation stops and returns to planning when:
+Return to planning if:
 
-- fewer than three source packages can pass human review;
-- the integration requires merging the Real Talk branch wholesale;
-- a new service or broad schema rewrite is proposed without a measured blocker;
-- playback or derivative rights are unresolved;
-- a required learner quote or answer cannot be traced to reviewed source evidence;
-- preview and hosted database cannot be made to use the same project/environment;
-- the owner changes the target environment or MVP promise.
+- no acceptable transcript acquisition method can support the URL-only workflow;
+- implementation would require a whole-branch merge;
+- hosted schema differs materially from the private-draft contract;
+- live Gemini cannot be tested safely;
+- source-dependent output cannot be validated against timed cues;
+- generated lessons cannot remain owner-private;
+- the product promise expands to every YouTube video rather than supported videos;
+- the owner changes the paste-URL core idea.

--- a/specs/002-mvp-product-convergence/plan.md
+++ b/specs/002-mvp-product-convergence/plan.md
@@ -1,0 +1,239 @@
+# Implementation Plan: AtoEnglish MVP Product Convergence
+
+**Branch for this plan:** `spec/mvp-product-convergence`  
+**Future implementation branch:** `integration/mvp-product-convergence` created from then-current `main`  
+**Application deployment:** none in planning phase
+
+## Technical Context
+
+- Framework: Next.js 16.2.9 App Router, React 19.2, TypeScript 6
+- Styling/UI: Tailwind CSS v4, Base UI, Framer Motion, existing AtoEnglish design system
+- Database/Auth: hosted Supabase project `zpiwddskhduuykpxltun`, PostgreSQL 17, RLS
+- Hosting: Vercel project `atoenglish`, Node 24
+- Tests: Vitest, Playwright, content-standard checks, hosted Supabase integration checks
+- Monitoring: Sentry, Vercel Analytics/Speed Insights; current Vercel seven-day runtime error query returned no grouped errors
+- Current repository state:
+  - `main`: `961e779886ff95b1b5f67d5e6997520d1facdb1a`
+  - Real Talk branch: `e1642db1540046271f520f72f1b20a04e5d84f09`
+  - comparison: diverged, Real Talk branch 420 commits ahead and 7 commits behind `main`
+  - active Real Talk PR #54 targets a non-main baseline and MUST NOT be merged wholesale
+
+## Constitution Check — Before Design
+
+| Principle | Plan response |
+| --- | --- |
+| Natural Communication First | MVP surface is one reviewed natural environment, not the existing grammar/unit catalog. |
+| Evidence-Bound Generation | Learner catalog excludes static samples and unreviewed AI drafts. |
+| Transfer Before Completion | Transfer attempt is a hard completion gate. |
+| Rights, Privacy, Safety | Reviewed source packages only; official playback; no raw audio/free text. |
+| Small Testable Delivery | One environment, three reviewed lessons, one end-to-end loop. |
+| Measurable Evidence | Technical, lesson, learner-funnel, and owner-acceptance evidence remain separate. |
+
+**Gate result:** PASS for planning. Implementation remains blocked until the owner accepts this specification and the initial source-review capacity is confirmed.
+
+## Repository Findings Driving the Plan
+
+1. The production-shaped build exposes more than forty routes and 89 generated pages, while the product north star needs one focused learner loop.
+2. The current landing page still promises a 28-day speaking journey, while the governing product truth is natural communication / Real Talk.
+3. Login combines onboarding and authentication; the UI declares four survey questions but the current three-step path asks one and silently defaults the others.
+4. Signup performs profile/progress inserts directly from the browser, creating duplicated email/OAuth bootstrap paths and partial-state risk.
+5. The dashboard depends on legacy XP, streak, flashcards, speaking sessions, word-of-day, fifty-unit metadata, and multiple action calls; this is not required for MVP activation.
+6. Navigation still exposes lessons, speaking, writing, progress, leaderboard, roadmap, business, challenge, and pronunciation as product surfaces.
+7. The learner Real Talk catalog mixes database rows with static sample lessons. Static data includes transcript/speaker/pronunciation claims that did not pass the hosted review registry.
+8. The Real Talk hub exposes arbitrary YouTube lesson generation to learners, while the approved compiler is owner-private and the current transcript adapter remains experimental.
+9. Hosted Supabase has 26 public tables with RLS enabled; most application tables have zero rows. It has 3 Auth users, 16 pilot events, and no persisted learner progress or Real Talk catalog rows at audit time.
+10. Hosted Real Talk migrations and reviewed-source infrastructure are applied, but the current video schema remains YouTube-specific even though the controlled approved source is Wikimedia/DVIDS.
+11. `main` and the Real Talk branch do not share one dependency/type baseline. `main` removed the old `gtts` chain and pins Node/npm; the Real Talk branch still carries older package state. `main` also points `db:types` at a different Supabase project ID.
+12. Vercel is connected and recent preview deployments are READY, but the project reports no active production deployment for the current work.
+
+## MVP Architecture Decision
+
+Preserve the modular monolith and reduce the learner shell.
+
+```text
+src/app/
+├── page.tsx                         # truthful landing
+├── login/                           # auth only; no fake personalization
+└── (main)/
+    ├── dashboard/                   # one next action + continue/review
+    ├── real-talk/                   # reviewed catalog
+    ├── real-talk/[lessonSlug]/      # environment runtime
+    └── me/                          # account, logout, bounded history
+
+src/features/mvp/
+├── domain/                          # learner state and route decisions
+├── server/                          # account bootstrap and dashboard query
+└── components/                      # focused shell/empty/error states
+
+src/features/real-talk/
+├── domain/                          # reviewed lesson/playback/attempt contracts
+├── server/                          # catalog, lesson, attempt repositories
+├── client/                          # bounded browser progress state
+└── components/                      # runtime phases
+```
+
+Legacy routes remain outside the primary shell. They are not rewritten during the
+MVP unless a route can leak an unsupported promise or bypass the MVP access model.
+
+## Integration Strategy
+
+### Do not merge PR #54 wholesale
+
+Create `integration/mvp-product-convergence` from current `main`. Produce a port
+manifest with each Real Talk file classified as:
+
+- **port unchanged** — contract/security code already independently verified;
+- **port with adaptation** — useful behavior but tied to static samples, YouTube,
+  old navigation, or private-preview assumptions;
+- **reference only** — tests/evidence that guide a new implementation;
+- **reject** — experimental, conflicting, stale, or outside MVP.
+
+### Default port candidates
+
+- `src/features/real-talk/domain/**`
+- `src/features/real-talk/server/transcript-provenance.ts`
+- `src/features/real-talk/server/transcript-source-policy.ts`
+- `src/features/real-talk/server/transcript-sources/supabase-reviewed.ts`
+- `src/features/real-talk/server/draft-mapping.ts`
+- selected lesson runtime components and their tests
+- reviewed-source Edge Function and versioned Real Talk migrations
+- Spec 001 security, RLS, hosted, and browser evidence
+
+### Default reject or isolate candidates
+
+- learner-facing `/real-talk/create`
+- `youtube-transcript` in production paths
+- static `src/lib/data/real-talk/videos.ts` as catalog fallback
+- static sample transcript, speaker, translation, pronunciation, and answer claims
+- old package/lockfile state and `gtts` dependency chain
+- broad mission, XP, streak, league, writing, notification, and curriculum changes
+- unapplied `20260731162613_learning_attempts.sql` unless a new data-model review explicitly adopts it
+
+## Data Strategy
+
+1. Align repository generated types and environment documentation to the hosted project `zpiwddskhduuykpxltun`.
+2. Add a provider-neutral playback/source migration rather than forcing Wikimedia or owned sources into `youtube_id`.
+3. Keep reviewed source provenance in `real_talk_transcript_sources`.
+4. Keep public lesson content in `real_talk_videos` and `real_talk_lessons`, with public eligibility enforced by database/query constraints.
+5. Add a dedicated bounded attempt/progress record only if existing `user_v2_lesson_progress` and `lesson_v2_evidence` cannot meet transfer/support/privacy requirements cleanly.
+6. Do not store raw speech, learner free text, names, or employers.
+7. Create one controlled publication/seed operation for the initial reviewed corpus; full reviewer/publication UI is deferred.
+
+## UI and Information Architecture
+
+### Public
+
+- Landing
+- Login/signup
+- Privacy/terms
+
+### Authenticated primary shell
+
+- **Học**: dashboard and reviewed lesson catalog
+- **Ôn lại**: completed/in-progress lessons; no FSRS or mastery claim required
+- **Tôi**: account, logout, minimal history/settings
+
+### Hidden/deferred from MVP primary navigation
+
+- `/learn` legacy unit catalog
+- `/flashcards` legacy SRS
+- `/grammar`
+- `/speaking/*` broad tools
+- `/writing/*`
+- `/leaderboard`
+- `/challenge`
+- `/certificate/*`
+- `/business`
+- `/roadmap`
+- `/pronunciation`
+- notifications/push engagement surfaces
+
+Routes may remain reachable to developers during convergence, but the preview
+acceptance environment must expose one coherent product story.
+
+## Delivery Phases
+
+### Phase 0 — Governance and branch convergence
+
+- approve MVP spec;
+- freeze exact source SHAs;
+- create integration branch from current `main`;
+- create and review selective port manifest;
+- align toolchain, lockfile, Supabase project reference, and CI.
+
+### Phase 1 — Product shell
+
+- replace landing promise and CTA;
+- simplify auth and create server-side account bootstrap;
+- protect dashboard/catalog/account routes;
+- reduce primary navigation;
+- replace dashboard with one next-action experience and honest empty/error states.
+
+### Phase 2 — Reviewed content and publication boundary
+
+- select one environment;
+- human-review at least three source packages;
+- generalize source playback fields;
+- create authorized public catalog records;
+- remove static sample fallback and learner-facing generation controls.
+
+### Phase 3 — Learner runtime and persistence
+
+- adapt reviewed lesson runtime to shared product layout;
+- implement cold listen, progressive support, retrieval, speaking confirmation,
+  transfer, and honest completion;
+- persist bounded attempt/progress evidence with RLS and idempotency;
+- surface continue/completed/review state on dashboard.
+
+### Phase 4 — Pilot instrumentation and hardening
+
+- reuse or narrow `pilot_events` for the MVP funnel;
+- add loading, empty, offline/media, auth, and persistence failure behavior;
+- run security/performance advisors;
+- verify no legacy or editor-only route is presented as the MVP.
+
+### Phase 5 — Preview, owner acceptance, and release decision
+
+- exact-head technical gates;
+- hosted two-user RLS checks;
+- desktop/mobile full-journey Playwright;
+- one Vercel preview and runtime-log inspection;
+- human lesson review evidence;
+- owner acceptance;
+- only then prepare a main-targeted merge PR and separately authorize production deployment.
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Whole-branch merge reintroduces removed dependencies and conflicts | High | Fresh integration branch plus exact port manifest. |
+| Static samples leak unreviewed content | High | Database-only catalog; fail closed with empty state. |
+| No human-reviewed three-lesson corpus | High | Content review is a release blocker, not post-launch cleanup. |
+| YouTube-specific schema blocks safer public-domain sources | High | Provider-neutral playback migration before corpus seed. |
+| Auth bootstrap creates partial rows | High | One server-side idempotent transaction/RPC. |
+| Legacy dashboard/navigation confuses product test | High | MVP shell replaces primary paths; deferred features hidden. |
+| Progress schema stores excessive learner content | High | Bounded evidence schema and privacy contract tests. |
+| CI passes but preview product is incoherent | High | Full browser journey and owner acceptance required. |
+| Vercel/Supabase envs point at different projects | High | Environment/type equivalence gate before preview. |
+| MVP expands into curriculum/gamification rewrite | Medium | Explicit route and task allow-list; stop on scope escape. |
+
+## Constitution Check — After Design
+
+- Natural communication remains the learner surface: PASS.
+- All learner content requires reviewed evidence: PASS.
+- Transfer is required before completion: PASS.
+- Privacy and source rights fail closed: PASS.
+- Delivery is one independently testable vertical slice: PASS.
+- Product evidence is not inferred from CI: PASS.
+
+## Stop Conditions
+
+Implementation stops and returns to planning when:
+
+- fewer than three source packages can pass human review;
+- the integration requires merging the Real Talk branch wholesale;
+- a new service or broad schema rewrite is proposed without a measured blocker;
+- playback or derivative rights are unresolved;
+- a required learner quote or answer cannot be traced to reviewed source evidence;
+- preview and hosted database cannot be made to use the same project/environment;
+- the owner changes the target environment or MVP promise.

--- a/specs/002-mvp-product-convergence/quickstart.md
+++ b/specs/002-mvp-product-convergence/quickstart.md
@@ -1,0 +1,232 @@
+# Quickstart: AtoEnglish MVP Product Convergence
+
+This guide is for the future implementation pass after the owner accepts the MVP
+specification. It does not authorize merge, migration, preview deployment, or
+production deployment by itself.
+
+## 1. Read the governing artifacts
+
+Read in this order:
+
+```text
+.specify/memory/constitution.md
+specs/002-mvp-product-convergence/spec.md
+specs/002-mvp-product-convergence/plan.md
+specs/002-mvp-product-convergence/research.md
+specs/002-mvp-product-convergence/data-model.md
+specs/002-mvp-product-convergence/contracts/mvp-contract.md
+specs/002-mvp-product-convergence/tasks.md
+specs/002-mvp-product-convergence/analysis.md
+specs/001-private-natural-lesson-compiler/
+```
+
+Spec 001 is evidence and reusable implementation material. Spec 002 governs the
+learner-facing MVP convergence.
+
+## 2. Freeze the implementation baseline
+
+Resolve the current `main` head immediately before implementation.
+
+```bash
+git fetch origin --prune
+git switch main
+git pull --ff-only origin main
+git rev-parse HEAD
+```
+
+Create the implementation branch from that exact `main` head:
+
+```bash
+git switch -c integration/mvp-product-convergence
+```
+
+Do not merge `agent/rebuild-learning-core` or PR #54 into this branch.
+
+## 3. Create the port manifest before copying code
+
+Create:
+
+```text
+specs/002-mvp-product-convergence/port-manifest.md
+```
+
+For every candidate path from Real Talk or other open branches, record:
+
+```text
+source branch
+source SHA
+source path
+classification: port | adapt | reference | reject
+destination path
+reason
+required verification
+```
+
+Review the manifest before the first implementation commit.
+
+## 4. Keep the main toolchain baseline
+
+Use the current `main` versions of:
+
+- `.nvmrc`;
+- `package.json` engine/package-manager declarations;
+- `package-lock.json`;
+- GitHub verification workflow;
+- removed legacy dependency decisions.
+
+After adding only required dependencies:
+
+```bash
+node --version
+npm --version
+npm ci --no-audit --prefer-offline
+```
+
+Do not restore `gtts`, `request`, `har-validator`, or `uuid@3` through a branch
+merge.
+
+## 5. Align the hosted environment
+
+MVP hosted services:
+
+```text
+Supabase project: zpiwddskhduuykpxltun
+Vercel project:   atoenglish
+Node runtime:     24.x
+```
+
+Before implementation, confirm the local environment contains the public
+Supabase URL/key for that project and the required preview-only secrets. Never
+print or commit secret values.
+
+Generate types from the same project:
+
+```bash
+npm run db:types
+```
+
+The `db:types` script must point to `zpiwddskhduuykpxltun` before using it.
+Review the generated diff; never edit `src/types/supabase.ts` manually.
+
+## 6. Implement by user story
+
+Follow `tasks.md` dependency order.
+
+Recommended stopping checkpoints:
+
+1. **Shell checkpoint** — landing, auth, route protection, navigation, and focused
+   dashboard work with controlled fixtures.
+2. **Content checkpoint** — three human-reviewed lessons are published through a
+   controlled database operation and no static fallback remains.
+3. **Runtime checkpoint** — one lesson requires first listening, retrieval,
+   speak-and-confirm, and transfer.
+4. **Persistence checkpoint** — a learner returns to the correct state and another
+   user is denied by RLS.
+5. **Preview checkpoint** — the complete journey passes on desktop and mobile.
+
+Do not start the next checkpoint while the current one has unresolved critical
+failures.
+
+## 7. Database workflow
+
+Before DDL:
+
+1. inspect hosted constraints, grants, policies, and generated types;
+2. decide whether existing evidence storage can satisfy the strict attempt
+   contract;
+3. create a versioned migration only after the model is final;
+4. run contract tests against the SQL text;
+5. obtain owner authorization before applying the hosted migration;
+6. run two-user and anonymous verification;
+7. run Supabase security and performance advisors;
+8. regenerate types;
+9. record rollback and cleanup evidence.
+
+Do not apply `20260731162613_learning_attempts.sql` by default. It requires a new
+explicit adoption decision.
+
+## 8. Content-review workflow
+
+For every MVP lesson:
+
+1. identify canonical media and source context;
+2. record item-level rights/provenance;
+3. listen to the complete bounded segment;
+4. correct exact words, timestamps, and speaker turns;
+5. review Vietnamese guidance and answer evidence;
+6. review safety, age suitability, and level;
+7. review changed-context transfer;
+8. record human reviewer identity/date/decision;
+9. publish only after all required fields pass.
+
+The initial launch gate is three reviewed lessons in one environment and at least
+two speakers or contexts.
+
+## 9. Required verification commands
+
+Run focused checks during implementation and the full gate on the exact final
+head.
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run test
+npm run test:content-standard
+npm run test:integration
+npm run build
+```
+
+Run the MVP-specific Playwright suite against a production build on desktop and
+mobile. It must cover:
+
+```text
+landing
+→ signup/login
+→ dashboard
+→ reviewed catalog
+→ lesson start
+→ support/retrieval/speech/transfer
+→ completion
+→ logout/login
+→ restored dashboard state
+```
+
+## 10. Create one intentional preview
+
+Only after local/GitHub gates pass, create or update:
+
+```text
+preview/mvp-product-convergence
+```
+
+Vercel is configured to deploy `preview/**` branches. Verify:
+
+- deployment is READY;
+- expected commit SHA is deployed;
+- the same hosted Supabase project is used;
+- desktop/mobile journey passes;
+- no critical runtime error cluster appears;
+- editor-only generation is not exposed;
+- static sample lessons do not appear.
+
+## 11. Convergence and release
+
+Before requesting owner acceptance:
+
+- update every task checkbox from observed evidence only;
+- complete the requirement checklist;
+- update `analysis.md` with final requirement-to-evidence results;
+- record the reviewed corpus IDs and publication state;
+- record hosted migration and advisor results;
+- record Vercel deployment ID and tested commit;
+- list unresolved risks honestly.
+
+Only after owner acceptance:
+
+1. prepare a clean PR targeting `main`;
+2. run exact-head checks again if the head changes;
+3. request explicit merge authorization;
+4. request separate explicit production-deployment authorization;
+5. smoke-test production and preserve rollback information.
+
+A successful preview does not authorize merge or deployment.

--- a/specs/002-mvp-product-convergence/quickstart.md
+++ b/specs/002-mvp-product-convergence/quickstart.md
@@ -1,12 +1,9 @@
-# Quickstart: AtoEnglish MVP Product Convergence
+# Quickstart: AtoEnglish YouTube-to-Private-Lesson MVP
 
-This guide is for the future implementation pass after the owner accepts the MVP
-specification. It does not authorize merge, migration, preview deployment, or
-production deployment by itself.
+This guide applies after implementation is explicitly authorized. It does not by
+itself authorize a hosted migration, preview, merge, or production deployment.
 
 ## 1. Read the governing artifacts
-
-Read in this order:
 
 ```text
 .specify/memory/constitution.md
@@ -20,213 +17,164 @@ specs/002-mvp-product-convergence/analysis.md
 specs/001-private-natural-lesson-compiler/
 ```
 
-Spec 001 is evidence and reusable implementation material. Spec 002 governs the
-learner-facing MVP convergence.
+Spec 001 supplies compiler/private-draft evidence. Spec 002 makes paste-URL
+generation the learner-facing product.
 
-## 2. Freeze the implementation baseline
-
-Resolve the current `main` head immediately before implementation.
+## 2. Freeze current main and create a clean branch
 
 ```bash
 git fetch origin --prune
 git switch main
 git pull --ff-only origin main
 git rev-parse HEAD
+git switch -c integration/mvp-youtube-to-lesson
 ```
 
-Create the implementation branch from that exact `main` head:
+Do not merge `agent/rebuild-learning-core` or PR #54 wholesale.
 
-```bash
-git switch -c integration/mvp-product-convergence
-```
+## 3. Create the selective-port manifest
 
-Do not merge `agent/rebuild-learning-core` or PR #54 into this branch.
+Create `specs/002-mvp-product-convergence/port-manifest.md` before copying code.
+For each candidate path record source branch/SHA/path, `port|adapt|reference|reject`,
+destination, reason, and verification.
 
-## 3. Create the port manifest before copying code
+Start with the Spec 001 application/domain/compiler/Gemini/transcript/private-draft
+paths and their focused tests. Preserve current-main package/lock/toolchain.
 
-Create:
+## 4. Align environment and generated types
+
+Required hosted targets:
 
 ```text
-specs/002-mvp-product-convergence/port-manifest.md
+Supabase: zpiwddskhduuykpxltun
+Vercel:   atoenglish
+Node:     24.x
 ```
 
-For every candidate path from Real Talk or other open branches, record:
+Fix the `db:types` script to use the same Supabase project, then regenerate types.
+Never print secrets or edit generated types manually.
+
+Required private preview variables include public Supabase values and a bounded
+server-only Gemini key. Upstash/Sentry values are used only when configured.
+
+## 5. Build in dependency order
+
+Recommended checkpoints:
+
+1. **Entry checkpoint** — truthful landing, auth, server bootstrap, protected URL-first dashboard.
+2. **Source checkpoint** — valid/invalid YouTube URL, official playback, supported/unsupported transcript behavior, stable failure codes.
+3. **Compiler checkpoint** — bounded segment, live Gemini structured output, evidence validation, atomic owner-private draft.
+4. **Runtime checkpoint** — first listen, support, retrieval, speak-and-confirm, transfer gate.
+5. **Return checkpoint** — private library, reload, logout/login, cross-user denial.
+6. **Preview checkpoint** — exact hosted desktop/mobile URL-to-lesson journey.
+
+## 6. Transcript adapter gate
+
+Before release, record the private-production transcript decision:
+
+- adapter ID and implementation path;
+- acquisition mode;
+- supported YouTube conditions;
+- language/timing limits;
+- known reliability/terms/rights risks;
+- retry and failure codes;
+- visible learner warnings;
+- replacement/rollback path.
+
+Do not call the adapter production-ready merely because mocks or controlled
+fixtures pass.
+
+## 7. Live provider verification
+
+A mock is insufficient for the final gate.
+
+Run a bounded controlled source through:
 
 ```text
-source branch
-source SHA
-source path
-classification: port | adapt | reference | reject
-destination path
-reason
-required verification
+authentication
+→ transcript acquisition
+→ segment selection
+→ live Gemini generation
+→ schema/evidence validation
+→ atomic private persistence
+→ reload
 ```
 
-Review the manifest before the first implementation commit.
+Also verify one live Gemini failure path and one unsupported-video/transcript path.
+Do not log the API key, provider payload secrets, Auth tokens, or service-role key.
 
-## 4. Keep the main toolchain baseline
+## 8. Database workflow
 
-Use the current `main` versions of:
+Before new DDL:
 
-- `.nvmrc`;
-- `package.json` engine/package-manager declarations;
-- `package-lock.json`;
-- GitHub verification workflow;
-- removed legacy dependency decisions.
-
-After adding only required dependencies:
-
-```bash
-node --version
-npm --version
-npm ci --no-audit --prefer-offline
-```
-
-Do not restore `gtts`, `request`, `har-validator`, or `uuid@3` through a branch
-merge.
-
-## 5. Align the hosted environment
-
-MVP hosted services:
-
-```text
-Supabase project: zpiwddskhduuykpxltun
-Vercel project:   atoenglish
-Node runtime:     24.x
-```
-
-Before implementation, confirm the local environment contains the public
-Supabase URL/key for that project and the required preview-only secrets. Never
-print or commit secret values.
-
-Generate types from the same project:
-
-```bash
-npm run db:types
-```
-
-The `db:types` script must point to `zpiwddskhduuykpxltun` before using it.
-Review the generated diff; never edit `src/types/supabase.ts` manually.
-
-## 6. Implement by user story
-
-Follow `tasks.md` dependency order.
-
-Recommended stopping checkpoints:
-
-1. **Shell checkpoint** — landing, auth, route protection, navigation, and focused
-   dashboard work with controlled fixtures.
-2. **Content checkpoint** — three human-reviewed lessons are published through a
-   controlled database operation and no static fallback remains.
-3. **Runtime checkpoint** — one lesson requires first listening, retrieval,
-   speak-and-confirm, and transfer.
-4. **Persistence checkpoint** — a learner returns to the correct state and another
-   user is denied by RLS.
-5. **Preview checkpoint** — the complete journey passes on desktop and mobile.
-
-Do not start the next checkpoint while the current one has unresolved critical
-failures.
-
-## 7. Database workflow
-
-Before DDL:
-
-1. inspect hosted constraints, grants, policies, and generated types;
-2. decide whether existing evidence storage can satisfy the strict attempt
-   contract;
-3. create a versioned migration only after the model is final;
-4. run contract tests against the SQL text;
-5. obtain owner authorization before applying the hosted migration;
-6. run two-user and anonymous verification;
-7. run Supabase security and performance advisors;
+1. compare hosted schema/migrations/types to repo expectations;
+2. verify existing atomic private-draft RPC and RLS;
+3. decide whether existing evidence storage can model learner progress;
+4. create only versioned migrations if necessary;
+5. obtain owner authorization before applying;
+6. test anonymous/ownerA/ownerB behavior;
+7. run Supabase security/performance advisors;
 8. regenerate types;
-9. record rollback and cleanup evidence.
+9. record rollback/cleanup.
 
-Do not apply `20260731162613_learning_attempts.sql` by default. It requires a new
-explicit adoption decision.
+Do not adopt the old unapplied `20260731162613_learning_attempts.sql` by default.
 
-## 8. Content-review workflow
-
-For every MVP lesson:
-
-1. identify canonical media and source context;
-2. record item-level rights/provenance;
-3. listen to the complete bounded segment;
-4. correct exact words, timestamps, and speaker turns;
-5. review Vietnamese guidance and answer evidence;
-6. review safety, age suitability, and level;
-7. review changed-context transfer;
-8. record human reviewer identity/date/decision;
-9. publish only after all required fields pass.
-
-The initial launch gate is three reviewed lessons in one environment and at least
-two speakers or contexts.
-
-## 9. Required verification commands
-
-Run focused checks during implementation and the full gate on the exact final
-head.
+## 9. Required technical checks
 
 ```bash
 npm run lint
 npx tsc --noEmit
+npm run test:real-talk
 npm run test
 npm run test:content-standard
 npm run test:integration
 npm run build
 ```
 
-Run the MVP-specific Playwright suite against a production build on desktop and
-mobile. It must cover:
+Run production-server Playwright on desktop and mobile for:
 
 ```text
 landing
 → signup/login
-→ dashboard
-→ reviewed catalog
-→ lesson start
-→ support/retrieval/speech/transfer
+→ paste supported YouTube URL
+→ generation status
+→ private lesson
+→ first listen/support/retrieval/speech/transfer
 → completion
+→ dashboard/private library
 → logout/login
-→ restored dashboard state
+→ restored state
 ```
+
+Also cover malformed URL, transcript unavailable, provider failure, persistence
+failure, and another user's private lesson.
 
 ## 10. Create one intentional preview
 
-Only after local/GitHub gates pass, create or update:
+After all prerequisite gates and explicit authorization, deploy only an intentional
+`preview/mvp-youtube-to-lesson` branch.
 
-```text
-preview/mvp-product-convergence
-```
+Verify:
 
-Vercel is configured to deploy `preview/**` branches. Verify:
-
-- deployment is READY;
-- expected commit SHA is deployed;
-- the same hosted Supabase project is used;
-- desktop/mobile journey passes;
-- no critical runtime error cluster appears;
-- editor-only generation is not exposed;
-- static sample lessons do not appear.
+- READY deployment matches exact commit;
+- correct Supabase project and server-only Gemini key are configured;
+- supported video generates a private lesson;
+- unsupported video fails honestly;
+- no static fixture masquerades as generated content;
+- no cross-user access;
+- no critical runtime errors;
+- desktop/mobile journey passes.
 
 ## 11. Convergence and release
 
-Before requesting owner acceptance:
+Before owner acceptance:
 
-- update every task checkbox from observed evidence only;
-- complete the requirement checklist;
-- update `analysis.md` with final requirement-to-evidence results;
-- record the reviewed corpus IDs and publication state;
-- record hosted migration and advisor results;
-- record Vercel deployment ID and tested commit;
-- list unresolved risks honestly.
+- update tasks from observed evidence only;
+- complete the requirements checklist;
+- update requirement-to-evidence analysis;
+- record adapter decision, live Gemini run, hosted IDs/migrations, preview ID/SHA,
+  browser evidence, cleanup, risks, and rollback;
+- state explicitly that generated lessons are private AI drafts.
 
-Only after owner acceptance:
-
-1. prepare a clean PR targeting `main`;
-2. run exact-head checks again if the head changes;
-3. request explicit merge authorization;
-4. request separate explicit production-deployment authorization;
-5. smoke-test production and preserve rollback information.
-
-A successful preview does not authorize merge or deployment.
+Only after owner acceptance prepare a clean main-targeted PR. Merge and production
+deployment require separate explicit authorization.

--- a/specs/002-mvp-product-convergence/research.md
+++ b/specs/002-mvp-product-convergence/research.md
@@ -1,382 +1,258 @@
-# Research: AtoEnglish MVP Product Convergence
+# Research: AtoEnglish MVP — YouTube to Private Lesson
 
 **Observed:** 2026-08-03  
-**Research mode:** repository, open-PR, hosted Supabase, Vercel, CI, and product-governance audit
+**Revised after owner correction:** 2026-08-03  
+**Research mode:** repository, open-PR, hosted Supabase, Vercel, CI, product-governance, and existing Real Talk compiler audit
 
-## Research Scope and Method
+## Corrected Product Thesis
 
-The audit used the following evidence classes:
-
-1. governing repository documents and Spec Kit artifacts;
-2. current `main` and `agent/rebuild-learning-core` files;
-3. commit comparison between `main` and the Real Talk branch;
-4. exact-head GitHub Actions logs and Next.js route output;
-5. open PR descriptions and branch topology;
-6. hosted Supabase schema, migration history, Edge Functions, RLS status, and aggregate row counts;
-7. connected Vercel project, deployment history, and grouped runtime errors.
-
-“Read the whole repository” is interpreted as reading every governing artifact,
-runtime surface category, data/infrastructure boundary, test family, and active PR
-workstream needed to make an MVP decision. It does not claim manual line-by-line
-inspection of every generated asset or every one of hundreds of implementation
-files.
-
-## Repository Baseline
-
-### Current main
+The owner clarified that AtoEnglish is not primarily a curated lesson catalog.
+Its core idea remains:
 
 ```text
-branch: main
-head:   961e779886ff95b1b5f67d5e6997520d1facdb1a
+learner chooses a YouTube video
+→ pastes the URL
+→ AtoEnglish turns a supported interaction into a private English lesson
 ```
 
-Main contains the merged product shell, landing, auth, dashboard, legacy lesson
-system, six-mission learning core, Gold Day 1, analytics, database hardening,
-tests, and deployment controls.
+The earlier planning conclusion that arbitrary learner-facing generation should be
+removed was incorrect. The product must instead make this workflow reliable,
+honest, private, and usable.
 
-### Current Real Talk branch
+## Audit Scope
+
+The audit covered governing documents, product routes, landing/auth/dashboard,
+Real Talk generation/runtime, Supabase schema/migrations/RLS/functions, Vercel,
+CI, open PRs, package/toolchain state, and the branch comparison needed to plan the
+MVP. It does not claim manual line-by-line reading of every asset or generated file.
+
+## Repository and Branch Baseline
+
+- `main` contains the current merged shell, auth, dashboard, legacy learning tools,
+  database hardening, tests, and deployment controls.
+- `agent/rebuild-learning-core` contains the most complete YouTube-to-private-
+  lesson work and Spec 001 evidence.
+- The Real Talk branch is diverged from `main`: 420 commits ahead and 7 behind at
+  audit time.
+
+**Decision:** Reuse the Real Talk vertical slice through a file-level port manifest.
+Do not merge the branch wholesale.
+
+## Existing Product Surface
+
+The exact-head build exposes more than forty routes and 89 generated pages,
+including legacy units, flashcards, speaking, writing, grammar, challenge,
+leaderboard, certificate, notifications, Real Talk, and account surfaces.
+
+**Decision:** Route count is not MVP value. The critical shell becomes:
 
 ```text
-branch: agent/rebuild-learning-core
-head:   e1642db1540046271f520f72f1b20a04e5d84f09
-PR:     #54, draft, non-main base
+landing
+login/signup
+URL generation dashboard
+private lesson
+private lesson library/return
+account/logout
 ```
 
-Comparison with main:
+## Landing Finding
 
-```text
-status:    diverged
-ahead_by:  420
-behind_by: 7
-merge_base: 1e462367d365d03e01d2b211da2499ac612a57ff
-```
+Current landing still emphasizes a 28-day program, A0 path, fixed workplace
+outcome, PPP/FSRS/shadowing, and broad course comparisons.
 
-**Decision:** No wholesale merge. Future implementation begins from current
-`main` and ports selected Real Talk work.
+**Corrected decision:** Rewrite the promise around the owner-approved value:
 
-## Governing Product Findings
+> Dán một video YouTube bạn muốn học. AtoEnglish chọn một đoạn hội thoại phù hợp và biến nó thành bài luyện nghe-nói cá nhân.
 
-The constitution and product truth require:
+The copy must say **supported videos**, not every video, and must not promise
+perfect transcripts, fluency, or pronunciation scoring.
 
-- natural communication as the learner-facing surface;
-- reviewed evidence for learner-facing source claims;
-- transfer before completion;
-- owner-private AI drafts and human publication gates;
-- no raw learner audio/free text by default;
-- one small independently testable vertical slice;
-- no claim that technical checks prove learning effectiveness.
+## Authentication and Bootstrap Finding
 
-The open product-direction branch further defines:
+The current login page combines auth with a survey that asks one visible question
+but silently supplies defaults for other personalization fields. Email and OAuth
+paths do not share one clean server-owned bootstrap.
 
-> Natural communication on the surface; an evidence-based invisible curriculum underneath.
+**Decision:** Authentication precedes transcript and Gemini work. Use one
+idempotent server bootstrap. Remove fake/defaulted personalization from the
+critical path.
 
-It recommends initial environment experiences rather than learner-facing grammar
-or CEFR chapters.
+## Dashboard Finding
 
-## Runtime Surface Inventory
+Current dashboard is organized around XP, streak, flashcards, fifty units, recent
+speaking sessions, daily missions, word-of-day, and activity charts.
 
-The exact-head Real Talk branch production build generated 89 pages and exposed
-these product categories:
+**Corrected decision:** The MVP dashboard answers:
 
-- landing and legal;
-- auth callback and login;
-- dashboard, progress, roadmap, profile/settings;
-- legacy unit learning, checkpoint, transfer;
-- Real Talk catalog/create/lesson;
-- flashcards and hard cards;
-- speaking journal/roleplay/shadowing/phoneme;
-- writing and history;
-- grammar, quiz, placement, business;
-- challenge, leaderboard, certificate, invite;
-- notifications, push, daily and weekly cron APIs.
+1. Which YouTube video do you want to learn from?
+2. Do you want to continue or review a lesson you already generated?
 
-**Decision:** Route existence is not MVP scope. Primary navigation and acceptance
-will include only landing, auth, dashboard, reviewed Real Talk, review/continue,
-and account.
+The primary UI is a URL form plus recent private lessons.
 
-## Landing Findings
+## Real Talk Generation Finding
 
-Current main landing:
+Spec 001 already implemented or verified substantial parts of the desired MVP:
 
-- promises a 28-day speaking journey and 10–15 minutes/day;
-- references an A0 starting path and workplace introduction outcome;
-- includes legacy claims around PPP, FSRS, shadowing, AI roleplay, grammar-style
-  progression, and comparison with broad learning products;
-- uses a public CTA and strong production-like copy.
+- authentication before transcript/Gemini work;
+- YouTube URL validation and source identity;
+- transcript adapter boundary and explicit source policy;
+- deterministic bounded interaction-window selection;
+- Gemini structured output;
+- Zod schema validation;
+- source-evidence validation for transcript, phrases, timestamps, answers, and
+  transfer targets;
+- stable machine-readable failure results;
+- deterministic owner-private draft identity;
+- atomic private persistence;
+- RLS and inability for ordinary users to approve/publish;
+- reloadable private lesson preview;
+- desktop/mobile persisted preview with transfer completion gate.
 
-This conflicts with the current natural-communication product truth.
+This is not merely an editor tool from the owner's perspective; it is the closest
+existing implementation of the product itself.
 
-**Decision:** Replace with one honest promise: understand one short reviewed
-interaction and respond in a comparable changed situation. Do not promise a
-28-day result, fluency, pronunciation accuracy, or personalized curriculum.
+## Remaining Generation Blockers
 
-## Authentication and Onboarding Findings
+The private-generation workflow is not production-ready because:
 
-Current main login page:
+1. the current YouTube transcript adapter remains classified experimental;
+2. production/private transcript acquisition policy has not been finally accepted;
+3. `GEMINI_API_KEY` was absent from live verification;
+4. learner shell and dashboard do not make URL generation the central action;
+5. current branch/toolchain state is not cleanly integrated with `main`;
+6. final exact-head hosted/Vercel end-to-end generation has not run;
+7. product warnings and unsupported-video behavior need user-facing verification.
 
-- combines welcome, level survey, login, and signup in one client component;
-- declares four survey questions but the current short flow asks only the first
-  and silently supplies defaults for goal, obstacle, and daily time;
-- claims personalization despite defaulted answers;
-- duplicates email and OAuth onboarding paths;
-- inserts `user_progress` and `user_onboarding_profile` from the browser;
-- redirects to legacy dashboard/lesson paths.
+## Transcript Acquisition Finding
 
-Session middleware currently leaves dashboard, learn, flashcards, and speaking
-available to guests while protecting many secondary features.
+A URL-only product requires timed transcript evidence. YouTube does not guarantee
+that every public video exposes a usable English transcript through the current
+adapter. Videos may be private, age-restricted, embed-disabled, captionless,
+auto-translated, badly timed, non-English, or temporarily unavailable.
 
-**Decisions:**
+**Decision:** MVP supports a bounded subset of YouTube videos. The exact adapter
+and acquisition mode must be documented and replaceable. Unsupported inputs fail
+honestly; the product does not fabricate a transcript or ask the learner to repair
+JSON.
 
-1. Auth is auth; remove fake personalization from the critical path.
-2. Use one server-side idempotent account bootstrap shared by email and OAuth.
-3. Protect dashboard/catalog/account routes.
-4. Any onboarding question must change immediate product behavior; otherwise
-   defer it.
+The current experimental adapter is a candidate for controlled private use, not a
+silently approved universal solution.
 
-## Dashboard Findings
+## Rights and Playback Finding
 
-Current dashboard fetches and renders data from:
+The product can preserve the core URL workflow while respecting boundaries:
 
-- user progress, total XP, streak, best streak, daily goal, streak freezes;
-- due flashcards;
-- fifty-unit completion map and current legacy unit;
-- recent speaking sessions;
-- daily missions and four mission flags;
-- word of the day;
-- weekly XP and 49-day activity calendar.
+- use official YouTube embed/watch playback;
+- do not download or re-host media;
+- do not automatically publish generated derivatives;
+- keep the lesson private to the requesting owner;
+- store source identity, selected cues, acquisition mode, and warnings;
+- require separate human review before public sharing/catalog publication.
 
-It defaults to legacy `unit-1` metadata if no user state exists.
+**Decision:** Provider-neutral catalog work is not an MVP prerequisite. The MVP is
+YouTube-specific by product design; future source providers may be added behind the
+same adapter/playback contracts.
 
-**Decision:** The MVP dashboard has one primary action, recent/continue state,
-and a small reviewed lesson list. XP, streak, flashcards, word-of-day, speaking
-feed, and fifty-unit progress are not required.
+## Static Sample Finding
 
-## Navigation Findings
+`fetchCatalogVideos()` merges static sample lessons with database rows and falls
+back to samples when the database is empty. Those samples contain extensive
+transcript, speaker, translation, pronunciation, and pedagogical claims.
 
-Main navigation exposes:
+**Corrected decision:** Static samples are not the core product and must not appear
+as if generated from the user's URL or as private-library records. They may remain
+as tests, demos, or development fixtures with explicit labels. A public catalog is
+deferred.
 
-- Learn, Flashcards, Me as primary;
-- legacy lessons, speaking, writing, progress, leaderboard, roadmap, business;
-- mobile groups for study, tracking, and other features;
-- dashboard actions for challenge, writing, pronunciation, and leaderboard.
+## Database Finding
 
-The Real Talk branch adds Real Talk as another item rather than making it the
-product surface.
+Hosted project `zpiwddskhduuykpxltun` is active and contains:
 
-**Decision:** MVP primary shell is Learn, Review/Continue, Account. Real Talk is
-not an optional content tab; it is the core learning runtime.
+- private Real Talk schema and gates;
+- transcript provenance fields;
+- atomic owner-private draft persistence and conflict fix;
+- reviewed transcript registry infrastructure;
+- RLS on observed public tables;
+- very little learner/application data.
 
-## Real Talk Catalog and Content Findings
+**Decision:** Reuse the existing private draft tables and atomic RPC where hosted
+verification proves equivalence. Do not redesign the database around a public
+catalog.
 
-`fetchCatalogVideos()` currently:
+## Progress Data Finding
 
-1. imports static sample videos/lessons;
-2. queries public database rows;
-3. returns static samples when the database is empty;
-4. always prepends static samples even when public database lessons exist.
+Existing legacy progress tables do not cleanly express Real Talk first listen,
+support level, productive retrieval, speak confirmation, and transfer. The old
+unapplied `learning_attempts` migration remains outside authorized hosted work.
 
-The static sample file contains extensive transcript, translation, speaker,
-pronunciation, L1-interference, answer, and pedagogy claims. The file header calls
-them curated real conversations, but these records did not pass the hosted
-review registry and publication gate.
+**Decision:** First test a strict wrapper over existing evidence storage. If
+insufficient, add a small owner-private `real_talk_attempts` table with bounded
+fields and no learner free text/audio.
 
-The hub also exposes a CTA to generate a lesson from an arbitrary YouTube link.
+## Toolchain Finding
 
-**Decisions:**
+- `main` pins Node 24/npm 11 and removed the old `gtts` dependency chain.
+- the Real Talk branch carries stale package state and deprecated transitive
+  dependencies through `gtts`.
+- `main` still points its `db:types` script at a different Supabase project ID.
 
-- Remove static fallback from learner catalog.
-- Fail closed with an honest empty state.
-- Hide arbitrary generation from learners.
-- Keep private generation as an editor operation only.
-- Require database-backed reviewed publication state.
+**Decision:** Keep main's package/lock/toolchain. Add only dependencies truly
+required by the selected Real Talk files. Align generated types to
+`zpiwddskhduuykpxltun`.
 
-## Real Talk Compiler and Verification Findings
+## Vercel Finding
 
-Reusable evidence from Spec 001 includes:
+The connected Vercel project `atoenglish` exists and controlled previews have
+been READY. Git deployments are intentionally limited to `preview/**` branches.
+No accepted current product deployment was promoted during planning.
 
-- authenticated generation ordering and rate limiting;
-- typed generation result and Zod contract;
-- evidence validation against bounded source cues;
-- owner-private `ai_draft` persistence and RLS;
-- atomic draft RPC;
-- transcript provenance and cue digest;
-- independent reviewer role and immutable reviewed source;
-- approved `supabase-reviewed-transcript-v1` adapter;
-- desktop/mobile persisted private-preview browser evidence;
-- exact-head lint, types, 387 tests, 50 content checks, and Next.js build.
+**Decision:** After exact-head local/GitHub/hosted/live-provider gates, create one
+`preview/mvp-youtube-to-lesson` deployment and run the full URL-to-private-lesson
+journey on desktop and mobile.
 
-Remaining Spec 001 issues include:
-
-- no live Gemini key evidence;
-- no final human lesson review;
-- public learner compiler still routes to experimental/static behavior;
-- owner acceptance remains open.
-
-**Decision:** Reuse contracts/security/evidence, not branch history or learner
-surface as-is.
-
-## Source and Playback Findings
-
-The hosted controlled reviewed source was Wikimedia/DVIDS source `1000496`, while
-`real_talk_videos.youtube_id` is currently non-null and the learner components are
-YouTube-shaped.
-
-**Decision:** MVP source/playback data becomes provider-neutral with a small
-closed set of playback modes:
-
-- `youtube_embed` for compliant official embeds;
-- `direct_video` for reviewed public-domain/owned media;
-- `external_link` only when an in-product player is not permitted.
-
-The MVP must not download or re-host media.
-
-## Database Findings
-
-Hosted project:
-
-```text
-name:   AtoEnglish
-ref:    zpiwddskhduuykpxltun
-region: ap-southeast-1
-status: ACTIVE_HEALTHY
-```
-
-Observed:
-
-- 26 public tables;
-- RLS enabled on all observed public tables;
-- 3 Auth users;
-- 16 pilot events;
-- 1 league seed;
-- zero estimated rows in learner progress, flashcard, speaking, Real Talk, and
-  most other application tables.
-
-Applied Real Talk migrations include private drafts, RLS gate/performance,
-provenance, atomic write/fix, trusted ingestion, and index cleanup.
-
-Active Edge Functions include one real reviewed-source function plus several
-retired/locked Spec 001 test-session functions.
-
-**Decisions:**
-
-- Reuse the hosted project.
-- Treat the database as low-data but not disposable.
-- Align repo types and environment references.
-- Remove or formally retire test-only Edge Functions after verification.
-- Prefer a bounded Real Talk attempt schema rather than reviving all legacy
-  progress/gamification dependencies.
-
-## Existing Progress Schema Findings
-
-- `user_lesson_progress` is XP/unit-oriented.
-- `user_v2_lesson_progress` stores quiz totals and one task boolean but does not
-  express progressive support, speaking confirmation, or transfer separately.
-- `lesson_v2_evidence` stores JSON evidence and supports anonymous IDs, but its
-  generic shape risks accepting unbounded payloads without a strict Real Talk
-  contract.
-- the Real Talk branch contains an unapplied `learning_attempts` migration that
-  was explicitly left outside the hosted Spec 001 work.
-
-**Decision:** Before DDL, test whether a strict wrapper over existing evidence
-storage can meet the MVP contract. If not, add a small `real_talk_attempts` table
-with bounded columns and no free text. Do not apply the old migration by default.
-
-## Toolchain and Environment Findings
-
-Main:
-
-- Node 24/npm 11 pinned;
-- old `gtts` chain removed;
-- clean lockfile and `npm ci` workflow;
-- `db:types` still references project `vhpfskkredizeazlyzsh`.
-
-Real Talk branch:
-
-- includes current AtoEnglish project reference `zpiwddskhduuykpxltun`;
-- still carries the old `gtts` dependency chain and older install behavior;
-- CI logs show deprecated `request`, `har-validator`, and `uuid@3` through gtts;
-- checkout cleanup still observed an invalid `.gitlab-ci-local` gitlink on its
-  non-main baseline.
-
-**Decision:** Keep main toolchain/package baseline. Port only required Real Talk
-dependencies and code. Fix the Supabase project/type reference explicitly.
-
-## Vercel Findings
-
-Connected project:
-
-```text
-project: atoenglish
-id:      prj_2lnCWZp4PvBvuTBksDjMtPPruVqL
-team:    team_1MZEcAVjG3nrOnklJxYIqGQs
-runtime: Node 24 / Next.js
-```
-
-Recent intentional preview deployments are READY. The current project metadata
-reported `live: false`; no current implementation was promoted to production.
-A seven-day grouped runtime-error query returned no errors.
-
-`vercel.json` only enables Git deployments for `preview/**`, which is appropriate
-for controlled MVP acceptance.
-
-**Decision:** Create exactly one intentional `preview/mvp-product-convergence`
-deployment after technical gates. Production promotion remains a separate owner
-action.
-
-## Open PR Findings
-
-The repo has multiple draft workstreams:
-
-- #47 product direction reset;
-- #48 curriculum contracts;
-- #49 and #51 source candidate research;
-- #50 two-lane content model;
-- #52 authorized YouTube companion experiment;
-- #53 natural communication environments;
-- #54 private natural lesson compiler.
-
-**Decision:** Treat PRs #47–#53 as research/contracts, not a stack to merge before
-MVP. Extract only decisions and code required by this spec.
-
-## MVP Scope Decision
+## Corrected MVP Scope
 
 ### Must ship
 
-- truthful landing;
-- stable auth and account bootstrap;
-- focused dashboard/navigation;
-- one environment with three human-reviewed lessons;
-- provider-neutral official playback;
-- natural lesson runtime with transfer gate;
+- truthful YouTube-to-lesson landing promise;
+- stable auth and idempotent account bootstrap;
+- URL-first dashboard;
+- validated supported YouTube input;
+- explicit transcript acquisition adapter/mode and failure behavior;
+- bounded interaction selection;
+- live Gemini structured generation;
+- source-evidence validation;
+- atomic owner-private `ai_draft` persistence;
+- AI/transcript uncertainty warnings;
+- natural lesson runtime with retrieval, speech confirmation, and transfer;
+- private lesson library and return state;
 - bounded owner-private progress;
-- privacy-safe funnel events;
-- desktop/mobile preview and owner acceptance.
+- desktop/mobile hosted preview and owner acceptance.
 
-### Reuse but do not surface as product promises
+### Reuse
 
-- existing design system and layouts;
 - Supabase Auth/RLS foundation;
-- pilot event infrastructure;
-- selected Real Talk compiler/provenance contracts;
-- existing Sentry/Vercel observability;
-- existing legacy routes during transition.
+- Spec 001 compiler/provider/domain/private-draft code;
+- existing official YouTube playback component with adaptation;
+- existing persisted private preview runtime;
+- rate limiting, Sentry, Vercel observability, and pilot event infrastructure;
+- design system/layout components that support the focused shell.
 
 ### Defer
 
-- broad curriculum and five environments;
-- delayed spaced repetition;
-- XP/streak/league/achievements;
-- flashcard, grammar, writing, broad speaking tools;
-- challenge, certificate, business, notification systems;
-- arbitrary source generation;
-- full publication/reviewer UI;
-- payments and social systems.
+- public/shared lesson catalog;
+- full human reviewer/publication UI;
+- public lesson discovery and recommendation;
+- bulk generation/crawling;
+- support for every YouTube video;
+- broad curriculum and gamification systems;
+- writing, grammar, broad speaking tools, notifications, payments, social, native apps.
 
 ## Final Research Conclusion
 
-The repository already contains enough infrastructure and verified technical work
-to build an MVP. The blocker is convergence, not missing platform capability.
-The safest and fastest path is to shrink the product surface, selectively port the
-reviewed Real Talk core onto current main, publish a tiny human-reviewed corpus,
-and prove one complete learner journey on the connected Vercel and Supabase
-environments.
+The repository already contains most of the hard technical foundation for the
+owner's actual product idea. The fastest correct path is not to replace generation
+with a curated catalog. It is to converge the verified private compiler onto
+current `main`, make paste-URL generation the product's primary action, resolve the
+transcript/live-Gemini blockers, and prove one honest private lesson journey on the
+connected Supabase and Vercel environments.

--- a/specs/002-mvp-product-convergence/research.md
+++ b/specs/002-mvp-product-convergence/research.md
@@ -1,0 +1,382 @@
+# Research: AtoEnglish MVP Product Convergence
+
+**Observed:** 2026-08-03  
+**Research mode:** repository, open-PR, hosted Supabase, Vercel, CI, and product-governance audit
+
+## Research Scope and Method
+
+The audit used the following evidence classes:
+
+1. governing repository documents and Spec Kit artifacts;
+2. current `main` and `agent/rebuild-learning-core` files;
+3. commit comparison between `main` and the Real Talk branch;
+4. exact-head GitHub Actions logs and Next.js route output;
+5. open PR descriptions and branch topology;
+6. hosted Supabase schema, migration history, Edge Functions, RLS status, and aggregate row counts;
+7. connected Vercel project, deployment history, and grouped runtime errors.
+
+“Read the whole repository” is interpreted as reading every governing artifact,
+runtime surface category, data/infrastructure boundary, test family, and active PR
+workstream needed to make an MVP decision. It does not claim manual line-by-line
+inspection of every generated asset or every one of hundreds of implementation
+files.
+
+## Repository Baseline
+
+### Current main
+
+```text
+branch: main
+head:   961e779886ff95b1b5f67d5e6997520d1facdb1a
+```
+
+Main contains the merged product shell, landing, auth, dashboard, legacy lesson
+system, six-mission learning core, Gold Day 1, analytics, database hardening,
+tests, and deployment controls.
+
+### Current Real Talk branch
+
+```text
+branch: agent/rebuild-learning-core
+head:   e1642db1540046271f520f72f1b20a04e5d84f09
+PR:     #54, draft, non-main base
+```
+
+Comparison with main:
+
+```text
+status:    diverged
+ahead_by:  420
+behind_by: 7
+merge_base: 1e462367d365d03e01d2b211da2499ac612a57ff
+```
+
+**Decision:** No wholesale merge. Future implementation begins from current
+`main` and ports selected Real Talk work.
+
+## Governing Product Findings
+
+The constitution and product truth require:
+
+- natural communication as the learner-facing surface;
+- reviewed evidence for learner-facing source claims;
+- transfer before completion;
+- owner-private AI drafts and human publication gates;
+- no raw learner audio/free text by default;
+- one small independently testable vertical slice;
+- no claim that technical checks prove learning effectiveness.
+
+The open product-direction branch further defines:
+
+> Natural communication on the surface; an evidence-based invisible curriculum underneath.
+
+It recommends initial environment experiences rather than learner-facing grammar
+or CEFR chapters.
+
+## Runtime Surface Inventory
+
+The exact-head Real Talk branch production build generated 89 pages and exposed
+these product categories:
+
+- landing and legal;
+- auth callback and login;
+- dashboard, progress, roadmap, profile/settings;
+- legacy unit learning, checkpoint, transfer;
+- Real Talk catalog/create/lesson;
+- flashcards and hard cards;
+- speaking journal/roleplay/shadowing/phoneme;
+- writing and history;
+- grammar, quiz, placement, business;
+- challenge, leaderboard, certificate, invite;
+- notifications, push, daily and weekly cron APIs.
+
+**Decision:** Route existence is not MVP scope. Primary navigation and acceptance
+will include only landing, auth, dashboard, reviewed Real Talk, review/continue,
+and account.
+
+## Landing Findings
+
+Current main landing:
+
+- promises a 28-day speaking journey and 10–15 minutes/day;
+- references an A0 starting path and workplace introduction outcome;
+- includes legacy claims around PPP, FSRS, shadowing, AI roleplay, grammar-style
+  progression, and comparison with broad learning products;
+- uses a public CTA and strong production-like copy.
+
+This conflicts with the current natural-communication product truth.
+
+**Decision:** Replace with one honest promise: understand one short reviewed
+interaction and respond in a comparable changed situation. Do not promise a
+28-day result, fluency, pronunciation accuracy, or personalized curriculum.
+
+## Authentication and Onboarding Findings
+
+Current main login page:
+
+- combines welcome, level survey, login, and signup in one client component;
+- declares four survey questions but the current short flow asks only the first
+  and silently supplies defaults for goal, obstacle, and daily time;
+- claims personalization despite defaulted answers;
+- duplicates email and OAuth onboarding paths;
+- inserts `user_progress` and `user_onboarding_profile` from the browser;
+- redirects to legacy dashboard/lesson paths.
+
+Session middleware currently leaves dashboard, learn, flashcards, and speaking
+available to guests while protecting many secondary features.
+
+**Decisions:**
+
+1. Auth is auth; remove fake personalization from the critical path.
+2. Use one server-side idempotent account bootstrap shared by email and OAuth.
+3. Protect dashboard/catalog/account routes.
+4. Any onboarding question must change immediate product behavior; otherwise
+   defer it.
+
+## Dashboard Findings
+
+Current dashboard fetches and renders data from:
+
+- user progress, total XP, streak, best streak, daily goal, streak freezes;
+- due flashcards;
+- fifty-unit completion map and current legacy unit;
+- recent speaking sessions;
+- daily missions and four mission flags;
+- word of the day;
+- weekly XP and 49-day activity calendar.
+
+It defaults to legacy `unit-1` metadata if no user state exists.
+
+**Decision:** The MVP dashboard has one primary action, recent/continue state,
+and a small reviewed lesson list. XP, streak, flashcards, word-of-day, speaking
+feed, and fifty-unit progress are not required.
+
+## Navigation Findings
+
+Main navigation exposes:
+
+- Learn, Flashcards, Me as primary;
+- legacy lessons, speaking, writing, progress, leaderboard, roadmap, business;
+- mobile groups for study, tracking, and other features;
+- dashboard actions for challenge, writing, pronunciation, and leaderboard.
+
+The Real Talk branch adds Real Talk as another item rather than making it the
+product surface.
+
+**Decision:** MVP primary shell is Learn, Review/Continue, Account. Real Talk is
+not an optional content tab; it is the core learning runtime.
+
+## Real Talk Catalog and Content Findings
+
+`fetchCatalogVideos()` currently:
+
+1. imports static sample videos/lessons;
+2. queries public database rows;
+3. returns static samples when the database is empty;
+4. always prepends static samples even when public database lessons exist.
+
+The static sample file contains extensive transcript, translation, speaker,
+pronunciation, L1-interference, answer, and pedagogy claims. The file header calls
+them curated real conversations, but these records did not pass the hosted
+review registry and publication gate.
+
+The hub also exposes a CTA to generate a lesson from an arbitrary YouTube link.
+
+**Decisions:**
+
+- Remove static fallback from learner catalog.
+- Fail closed with an honest empty state.
+- Hide arbitrary generation from learners.
+- Keep private generation as an editor operation only.
+- Require database-backed reviewed publication state.
+
+## Real Talk Compiler and Verification Findings
+
+Reusable evidence from Spec 001 includes:
+
+- authenticated generation ordering and rate limiting;
+- typed generation result and Zod contract;
+- evidence validation against bounded source cues;
+- owner-private `ai_draft` persistence and RLS;
+- atomic draft RPC;
+- transcript provenance and cue digest;
+- independent reviewer role and immutable reviewed source;
+- approved `supabase-reviewed-transcript-v1` adapter;
+- desktop/mobile persisted private-preview browser evidence;
+- exact-head lint, types, 387 tests, 50 content checks, and Next.js build.
+
+Remaining Spec 001 issues include:
+
+- no live Gemini key evidence;
+- no final human lesson review;
+- public learner compiler still routes to experimental/static behavior;
+- owner acceptance remains open.
+
+**Decision:** Reuse contracts/security/evidence, not branch history or learner
+surface as-is.
+
+## Source and Playback Findings
+
+The hosted controlled reviewed source was Wikimedia/DVIDS source `1000496`, while
+`real_talk_videos.youtube_id` is currently non-null and the learner components are
+YouTube-shaped.
+
+**Decision:** MVP source/playback data becomes provider-neutral with a small
+closed set of playback modes:
+
+- `youtube_embed` for compliant official embeds;
+- `direct_video` for reviewed public-domain/owned media;
+- `external_link` only when an in-product player is not permitted.
+
+The MVP must not download or re-host media.
+
+## Database Findings
+
+Hosted project:
+
+```text
+name:   AtoEnglish
+ref:    zpiwddskhduuykpxltun
+region: ap-southeast-1
+status: ACTIVE_HEALTHY
+```
+
+Observed:
+
+- 26 public tables;
+- RLS enabled on all observed public tables;
+- 3 Auth users;
+- 16 pilot events;
+- 1 league seed;
+- zero estimated rows in learner progress, flashcard, speaking, Real Talk, and
+  most other application tables.
+
+Applied Real Talk migrations include private drafts, RLS gate/performance,
+provenance, atomic write/fix, trusted ingestion, and index cleanup.
+
+Active Edge Functions include one real reviewed-source function plus several
+retired/locked Spec 001 test-session functions.
+
+**Decisions:**
+
+- Reuse the hosted project.
+- Treat the database as low-data but not disposable.
+- Align repo types and environment references.
+- Remove or formally retire test-only Edge Functions after verification.
+- Prefer a bounded Real Talk attempt schema rather than reviving all legacy
+  progress/gamification dependencies.
+
+## Existing Progress Schema Findings
+
+- `user_lesson_progress` is XP/unit-oriented.
+- `user_v2_lesson_progress` stores quiz totals and one task boolean but does not
+  express progressive support, speaking confirmation, or transfer separately.
+- `lesson_v2_evidence` stores JSON evidence and supports anonymous IDs, but its
+  generic shape risks accepting unbounded payloads without a strict Real Talk
+  contract.
+- the Real Talk branch contains an unapplied `learning_attempts` migration that
+  was explicitly left outside the hosted Spec 001 work.
+
+**Decision:** Before DDL, test whether a strict wrapper over existing evidence
+storage can meet the MVP contract. If not, add a small `real_talk_attempts` table
+with bounded columns and no free text. Do not apply the old migration by default.
+
+## Toolchain and Environment Findings
+
+Main:
+
+- Node 24/npm 11 pinned;
+- old `gtts` chain removed;
+- clean lockfile and `npm ci` workflow;
+- `db:types` still references project `vhpfskkredizeazlyzsh`.
+
+Real Talk branch:
+
+- includes current AtoEnglish project reference `zpiwddskhduuykpxltun`;
+- still carries the old `gtts` dependency chain and older install behavior;
+- CI logs show deprecated `request`, `har-validator`, and `uuid@3` through gtts;
+- checkout cleanup still observed an invalid `.gitlab-ci-local` gitlink on its
+  non-main baseline.
+
+**Decision:** Keep main toolchain/package baseline. Port only required Real Talk
+dependencies and code. Fix the Supabase project/type reference explicitly.
+
+## Vercel Findings
+
+Connected project:
+
+```text
+project: atoenglish
+id:      prj_2lnCWZp4PvBvuTBksDjMtPPruVqL
+team:    team_1MZEcAVjG3nrOnklJxYIqGQs
+runtime: Node 24 / Next.js
+```
+
+Recent intentional preview deployments are READY. The current project metadata
+reported `live: false`; no current implementation was promoted to production.
+A seven-day grouped runtime-error query returned no errors.
+
+`vercel.json` only enables Git deployments for `preview/**`, which is appropriate
+for controlled MVP acceptance.
+
+**Decision:** Create exactly one intentional `preview/mvp-product-convergence`
+deployment after technical gates. Production promotion remains a separate owner
+action.
+
+## Open PR Findings
+
+The repo has multiple draft workstreams:
+
+- #47 product direction reset;
+- #48 curriculum contracts;
+- #49 and #51 source candidate research;
+- #50 two-lane content model;
+- #52 authorized YouTube companion experiment;
+- #53 natural communication environments;
+- #54 private natural lesson compiler.
+
+**Decision:** Treat PRs #47–#53 as research/contracts, not a stack to merge before
+MVP. Extract only decisions and code required by this spec.
+
+## MVP Scope Decision
+
+### Must ship
+
+- truthful landing;
+- stable auth and account bootstrap;
+- focused dashboard/navigation;
+- one environment with three human-reviewed lessons;
+- provider-neutral official playback;
+- natural lesson runtime with transfer gate;
+- bounded owner-private progress;
+- privacy-safe funnel events;
+- desktop/mobile preview and owner acceptance.
+
+### Reuse but do not surface as product promises
+
+- existing design system and layouts;
+- Supabase Auth/RLS foundation;
+- pilot event infrastructure;
+- selected Real Talk compiler/provenance contracts;
+- existing Sentry/Vercel observability;
+- existing legacy routes during transition.
+
+### Defer
+
+- broad curriculum and five environments;
+- delayed spaced repetition;
+- XP/streak/league/achievements;
+- flashcard, grammar, writing, broad speaking tools;
+- challenge, certificate, business, notification systems;
+- arbitrary source generation;
+- full publication/reviewer UI;
+- payments and social systems.
+
+## Final Research Conclusion
+
+The repository already contains enough infrastructure and verified technical work
+to build an MVP. The blocker is convergence, not missing platform capability.
+The safest and fastest path is to shrink the product surface, selectively port the
+reviewed Real Talk core onto current main, publish a tiny human-reviewed corpus,
+and prove one complete learner journey on the connected Vercel and Supabase
+environments.

--- a/specs/002-mvp-product-convergence/spec.md
+++ b/specs/002-mvp-product-convergence/spec.md
@@ -1,0 +1,195 @@
+# Feature Specification: AtoEnglish MVP Product Convergence
+
+**Feature Branch**: `spec/mvp-product-convergence`  
+**Created**: 2026-08-03  
+**Status**: Planning complete; implementation requires owner acceptance  
+**Input**: Turn the existing AtoEnglish repository, hosted Supabase project, Vercel project, and verified Real Talk work into one coherent MVP that a Vietnamese beginner can actually use from landing page through lesson completion and return.
+
+## MVP Product Decision
+
+The MVP is not the current collection of more than forty routes, fifty legacy units,
+gamification systems, writing tools, pronunciation tools, notifications, and an
+experimental Real Talk compiler.
+
+The MVP is one complete learner value loop:
+
+```text
+truthful landing page
+→ sign up or log in
+→ minimal account bootstrap
+→ focused dashboard
+→ choose one reviewed natural-communication lesson
+→ first listen without answer exposure
+→ scaffolded comprehension
+→ retrieve useful source-backed language
+→ speak and self-confirm
+→ changed-context transfer attempt
+→ save bounded progress
+→ return to continue or review
+```
+
+The initial MVP corpus contains one learner-facing environment with at least three
+human-reviewed lesson variants from at least two speakers or contexts. The default
+environment is **Meet someone new**, unless source review proves another initial
+environment materially safer and more feasible.
+
+## User Scenarios & Testing
+
+### User Story 1 — Enter the product and reach a focused dashboard (Priority: P1)
+
+A Vietnamese adult can understand the product promise, create or access an
+account, and reach a dashboard with one obvious next action.
+
+**Independent Test**: A new email user and a returning user can complete the
+landing → auth → dashboard journey on desktop and mobile without manual database
+repair.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the landing page, **When** they read the hero and primary CTA, **Then** the promise describes understanding and responding in natural communication rather than a conflicting 28-day, grammar-first, or fluency claim.
+2. **Given** a new user, **When** signup succeeds, **Then** one idempotent server-side bootstrap creates the minimum profile/progress state and routes the learner to the MVP dashboard.
+3. **Given** a returning user, **When** login succeeds, **Then** they return to the requested safe path or dashboard.
+4. **Given** an unauthenticated visitor, **When** they request dashboard, catalog, progress, or account routes, **Then** they are redirected to login while the landing page remains public.
+5. **Given** an authentication or bootstrap failure, **When** it occurs, **Then** the UI shows a recoverable error and does not claim successful onboarding.
+
+---
+
+### User Story 2 — Discover only reviewed learner content (Priority: P1)
+
+The learner sees a small catalog of lessons that passed source, transcript,
+speaker, timing, rights, safety, translation, and pedagogical review.
+
+**Independent Test**: With three reviewed lessons and one unreviewed/private
+draft in the database, the learner catalog returns only the three reviewed public
+lessons and never falls back to static sample content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the public catalog query, **When** the database contains no reviewed public lesson, **Then** the product shows an honest empty state rather than fabricated or unreviewed static samples.
+2. **Given** a reviewed lesson, **When** it appears in the catalog, **Then** its situation, source, level, duration, and review state are available without exposing editor-only generation controls.
+3. **Given** an `ai_draft`, private lesson, unreviewed transcript, or uncertain source, **When** the catalog loads, **Then** it is excluded.
+4. **Given** the learner navigation, **When** the MVP shell renders, **Then** arbitrary YouTube generation, grammar, writing, leaderboard, challenge, certificate, business, and other deferred surfaces are absent from the primary navigation.
+
+---
+
+### User Story 3 — Complete one natural communication lesson (Priority: P1)
+
+The learner enters a real situation, listens, receives progressive support,
+retrieves useful language, speaks it, and attempts the same goal with changed
+data or context.
+
+**Independent Test**: A learner cannot complete the lesson by watching or choosing
+answers alone; completion requires retrieval, speak-and-confirm, and transfer
+attempt evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reviewed lesson, **When** it starts, **Then** the setting, roles, and practical goal appear before grammar or vocabulary explanation.
+2. **Given** the first encounter, **When** media plays, **Then** no transcript or answer is exposed by default.
+3. **Given** the learner needs support, **When** support is requested, **Then** it reveals progressively from replay/context to English evidence and concise Vietnamese guidance.
+4. **Given** useful source-backed language, **When** acquisition begins, **Then** the learner retrieves or reconstructs it without a permanently displayed full answer.
+5. **Given** speech practice, **When** browser speech recognition is absent or unused, **Then** the learner can speak and self-confirm without a pronunciation score.
+6. **Given** the transfer step, **When** no changed-context attempt is made, **Then** completion remains blocked.
+7. **Given** completion, **Then** the UI reports immediate practice evidence only and does not claim mastery, CEFR attainment, fluency, pronunciation accuracy, or retention.
+
+---
+
+### User Story 4 — Save progress and return (Priority: P1)
+
+An authenticated learner can leave and return without losing lesson state or
+completion evidence, while the system stores no raw audio or unrestricted learner
+text.
+
+**Independent Test**: A learner starts a lesson, reloads, completes it, logs out,
+logs back in, and sees the correct continue/review state.
+
+**Acceptance Scenarios**:
+
+1. **Given** an in-progress lesson, **When** the learner reloads or returns, **Then** the product restores a safe checkpoint rather than exposing answers or restarting silently.
+2. **Given** a completed lesson, **When** the dashboard reloads, **Then** the completion and next action are visible.
+3. **Given** another authenticated user, **When** they query the first learner's attempts, **Then** RLS prevents access.
+4. **Given** stored attempt evidence, **Then** it contains bounded booleans/counts/support state and timestamps, not raw microphone recordings, unrestricted transcripts, names, employers, or free text.
+5. **Given** duplicate completion requests, **When** retries occur, **Then** persistence remains idempotent.
+
+---
+
+### User Story 5 — Operate and verify a pilot safely (Priority: P2)
+
+The owner can deploy one preview, inspect the complete product journey, and run a
+small pilot without exposing experimental authoring or relying on repository tests
+as proof of learning effectiveness.
+
+**Independent Test**: One exact-head Vercel preview passes the complete desktop
+and mobile journey against hosted Supabase, with privacy-safe pilot events and no
+critical runtime error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the implementation branch, **When** integration begins, **Then** it starts from current `main`; it does not merge the 420-commit-diverged Real Talk branch wholesale.
+2. **Given** selected Real Talk work, **When** it is ported, **Then** each file/contract is explicitly accepted, adapted, or rejected in a port manifest.
+3. **Given** the Vercel preview, **When** browser acceptance runs, **Then** landing, signup/login, dashboard, catalog, lesson, persistence, logout, and return pass on desktop and mobile.
+4. **Given** pilot analytics, **When** events are recorded, **Then** only bounded product events and scalar outcomes are stored.
+5. **Given** all technical gates pass, **Then** merge and production deployment still require explicit owner acceptance.
+
+## Functional Requirements
+
+- **FR-001**: The MVP MUST have one truthful learner-facing promise across landing, auth, dashboard, catalog, and lesson completion.
+- **FR-002**: Dashboard, learner catalog, progress, and account routes MUST require authentication; landing and legal pages remain public.
+- **FR-003**: Signup bootstrap MUST be server-derived, idempotent, and shared by email and OAuth paths.
+- **FR-004**: The primary navigation MUST contain only the MVP loop: Learn, Review/Continue, and Account, with no editor-generation entry.
+- **FR-005**: The learner catalog MUST query database-reviewed public lessons only and MUST NOT merge static sample lessons.
+- **FR-006**: Publication eligibility MUST require reviewed lesson state, reviewed transcript state, safe provenance, and `is_public = true`.
+- **FR-007**: The MVP MUST support lawful official playback for the selected sources without media downloading or re-hosting.
+- **FR-008**: Source records MUST not be hard-wired to YouTube when the reviewed MVP source uses Wikimedia or another approved provider.
+- **FR-009**: Every learner-facing quote, answer, timestamp, speaker label, translation, and guidance line MUST be traceable to the reviewed source package.
+- **FR-010**: Lesson completion MUST require first-encounter participation, productive retrieval, speak-and-confirm, and changed-context transfer attempt.
+- **FR-011**: Speech practice MUST remain usable without microphone permission and MUST NOT claim pronunciation assessment.
+- **FR-012**: Progress persistence MUST store bounded evidence only and enforce owner RLS.
+- **FR-013**: Duplicate start, checkpoint, and completion writes MUST be idempotent.
+- **FR-014**: The dashboard MUST prioritize one next action and MUST NOT require XP, streak, league, word-of-day, challenge, writing, or notification systems.
+- **FR-015**: Deferred routes MAY remain in the codebase but MUST be removed from MVP navigation and may be guarded or redirected when they create product confusion.
+- **FR-016**: The MVP MUST reuse the hosted Supabase project `zpiwddskhduuykpxltun` and Vercel project `atoenglish`; it MUST NOT create replacement infrastructure without a measured blocker.
+- **FR-017**: Repository Supabase types and environment documentation MUST point to the same hosted project used by preview and production.
+- **FR-018**: Implementation MUST begin from current `main` and selectively port reviewed work from open branches.
+- **FR-019**: The experimental `youtube-transcript` path and arbitrary learner-facing generation MUST remain disabled from MVP production flows.
+- **FR-020**: The MVP launch corpus MUST contain at least three human-reviewed lessons in one environment, from at least two speakers or contexts.
+- **FR-021**: The product MUST record privacy-safe activation and lesson funnel events without learner free text or audio.
+- **FR-022**: Technical checks MUST include lint, TypeScript, unit/contract tests, content standards, production build, hosted RLS checks, and desktop/mobile Playwright.
+- **FR-023**: Vercel preview MUST show no critical runtime errors during acceptance.
+- **FR-024**: Owner acceptance is required before merge to `main` and before production deployment.
+
+## MVP Success Criteria
+
+- **SC-001**: A new learner reaches the dashboard and starts a reviewed lesson in one uninterrupted browser journey.
+- **SC-002**: 100% of learner-visible catalog items are database-backed and human-reviewed; zero static sample lessons appear.
+- **SC-003**: The complete lesson cannot finish without a recorded transfer attempt.
+- **SC-004**: A returning learner sees correct continue/completed state after a new authenticated session.
+- **SC-005**: A second user cannot read or mutate the first user's lesson attempts.
+- **SC-006**: Desktop and mobile acceptance produce no uncaught page error, Next.js error overlay, or horizontal overflow.
+- **SC-007**: The first pilot records landing/start/auth/lesson/transfer/completion events without audio, transcript, name, employer, or free-text payloads.
+- **SC-008**: Exact-head lint, types, tests, content standards, production build, hosted checks, and preview acceptance pass before owner review.
+- **SC-009**: The MVP primary navigation exposes no deferred feature as a core learner promise.
+- **SC-010**: The owner can identify the deployed commit, reviewed corpus, database migrations, environment configuration, blockers, and rollback path from repository evidence.
+
+## Explicitly Out of Scope
+
+- broad curriculum graph or automatic next-environment recommendation;
+- five-environment or A0–B2 catalog expansion;
+- arbitrary YouTube ingestion in the learner product;
+- automatic transcript approval or publication;
+- unrestricted AI tutor or chatbot;
+- phoneme, stress, fluency, prosody, or pronunciation scoring;
+- raw audio or unrestricted speech transcript storage;
+- XP, streak, league, achievements, challenge, certificates, social or referral systems;
+- writing assistant, grammar catalog, business track, broad speaking tools;
+- push notifications, cron engagement campaigns, subscriptions, and payments;
+- native mobile apps;
+- autonomous merge or production deployment.
+
+## Assumptions
+
+- The hosted Supabase project is healthy and mostly empty, so MVP schema alignment has low migration risk but still requires backups and rollback planning.
+- Existing Real Talk compiler, provenance, private draft, and persisted preview work are evidence and reusable code candidates, not a mergeable branch as a whole.
+- Existing landing/auth/dashboard/mission code on `main` is reusable selectively but its current product promise and information architecture are not canonical.
+- Human reviewers are available to approve the initial three-lesson corpus.
+- The first pilot is small enough that content publication can use an authorized controlled operation; a full reviewer UI is not required for MVP.

--- a/specs/002-mvp-product-convergence/spec.md
+++ b/specs/002-mvp-product-convergence/spec.md
@@ -1,195 +1,203 @@
-# Feature Specification: AtoEnglish MVP Product Convergence
+# Feature Specification: AtoEnglish MVP — YouTube to Private Lesson
 
 **Feature Branch**: `spec/mvp-product-convergence`  
 **Created**: 2026-08-03  
-**Status**: Planning complete; implementation requires owner acceptance  
-**Input**: Turn the existing AtoEnglish repository, hosted Supabase project, Vercel project, and verified Real Talk work into one coherent MVP that a Vietnamese beginner can actually use from landing page through lesson completion and return.
+**Revised**: 2026-08-03 after owner correction  
+**Status**: Planning revised; implementation still requires explicit authorization  
+**Owner product decision**: The core AtoEnglish idea remains **paste a YouTube URL and turn that video into a personal English lesson**.
 
 ## MVP Product Decision
 
-The MVP is not the current collection of more than forty routes, fifty legacy units,
-gamification systems, writing tools, pronunciation tools, notifications, and an
-experimental Real Talk compiler.
-
-The MVP is one complete learner value loop:
+The MVP is not a fixed catalog of preselected lessons. It is one complete
+user-generated learning loop:
 
 ```text
 truthful landing page
 → sign up or log in
-→ minimal account bootstrap
-→ focused dashboard
-→ choose one reviewed natural-communication lesson
-→ first listen without answer exposure
-→ scaffolded comprehension
-→ retrieve useful source-backed language
-→ speak and self-confirm
-→ changed-context transfer attempt
-→ save bounded progress
-→ return to continue or review
+→ paste a supported YouTube URL
+→ validate source and acquire timed English transcript evidence
+→ select one bounded natural interaction
+→ generate a typed, evidence-bound private AI lesson
+→ learn through listening, retrieval, speaking, and changed-context transfer
+→ save the private lesson and bounded progress
+→ return to continue, review, or generate another lesson
 ```
 
-The initial MVP corpus contains one learner-facing environment with at least three
-human-reviewed lesson variants from at least two speakers or contexts. The default
-environment is **Meet someone new**, unless source review proves another initial
-environment materially safer and more feasible.
+The generated lesson is an owner-private `ai_draft`. It is useful for personal
+study but is not automatically approved, public, or guaranteed error-free. The UI
+must show its transcript acquisition mode, unresolved warnings, and an honest AI
+draft label.
+
+Human review remains mandatory before any generated lesson is published to a
+shared catalog. Public catalog and reviewer operations are not required for the
+MVP's core private workflow.
 
 ## User Scenarios & Testing
 
-### User Story 1 — Enter the product and reach a focused dashboard (Priority: P1)
+### User Story 1 — Enter the product and paste a YouTube link (Priority: P1)
 
-A Vietnamese adult can understand the product promise, create or access an
-account, and reach a dashboard with one obvious next action.
+A Vietnamese learner understands the product promise, authenticates, and sees one
+obvious action: paste a YouTube video they want to learn from.
 
-**Independent Test**: A new email user and a returning user can complete the
-landing → auth → dashboard journey on desktop and mobile without manual database
-repair.
+**Independent Test**: A new user and returning user can complete landing → auth →
+dashboard → valid YouTube URL submission on desktop and mobile without manual
+database repair.
 
 **Acceptance Scenarios**:
 
-1. **Given** a visitor on the landing page, **When** they read the hero and primary CTA, **Then** the promise describes understanding and responding in natural communication rather than a conflicting 28-day, grammar-first, or fluency claim.
-2. **Given** a new user, **When** signup succeeds, **Then** one idempotent server-side bootstrap creates the minimum profile/progress state and routes the learner to the MVP dashboard.
-3. **Given** a returning user, **When** login succeeds, **Then** they return to the requested safe path or dashboard.
-4. **Given** an unauthenticated visitor, **When** they request dashboard, catalog, progress, or account routes, **Then** they are redirected to login while the landing page remains public.
-5. **Given** an authentication or bootstrap failure, **When** it occurs, **Then** the UI shows a recoverable error and does not claim successful onboarding.
+1. **Given** a visitor on the landing page, **When** they read the hero and CTA, **Then** the promise explicitly says AtoEnglish turns a supported YouTube video into a personal English lesson.
+2. **Given** a new user, **When** signup succeeds, **Then** one idempotent server-side bootstrap creates the minimum account state and routes to the generation dashboard.
+3. **Given** a returning user, **When** login succeeds, **Then** they see the URL form plus their recent private lessons.
+4. **Given** an unauthenticated visitor, **When** they request generation, dashboard, private lesson, or account routes, **Then** they are redirected to login before transcript or Gemini work begins.
+5. **Given** a malformed or non-YouTube URL, **When** submitted, **Then** the UI rejects it locally/server-side with an actionable message and consumes no provider quota.
 
 ---
 
-### User Story 2 — Discover only reviewed learner content (Priority: P1)
+### User Story 2 — Generate a private lesson from a supported video (Priority: P1)
 
-The learner sees a small catalog of lessons that passed source, transcript,
-speaker, timing, rights, safety, translation, and pedagogical review.
+The authenticated learner pastes a supported YouTube URL. AtoEnglish validates the
+source, obtains timed English transcript evidence through an explicit adapter,
+selects a useful bounded interaction, generates a structured lesson, validates
+all source-dependent claims, and stores it privately.
 
-**Independent Test**: With three reviewed lessons and one unreviewed/private
-draft in the database, the learner catalog returns only the three reviewed public
-lessons and never falls back to static sample content.
+**Independent Test**: A controlled supported YouTube source produces one complete
+owner-private lesson in a single request; unsupported, transcriptless, private,
+age-restricted, or invalid sources fail without partial lesson persistence.
 
 **Acceptance Scenarios**:
 
-1. **Given** the public catalog query, **When** the database contains no reviewed public lesson, **Then** the product shows an honest empty state rather than fabricated or unreviewed static samples.
-2. **Given** a reviewed lesson, **When** it appears in the catalog, **Then** its situation, source, level, duration, and review state are available without exposing editor-only generation controls.
-3. **Given** an `ai_draft`, private lesson, unreviewed transcript, or uncertain source, **When** the catalog loads, **Then** it is excluded.
-4. **Given** the learner navigation, **When** the MVP shell renders, **Then** arbitrary YouTube generation, grammar, writing, leaderboard, challenge, certificate, business, and other deferred surfaces are absent from the primary navigation.
+1. **Given** a supported public YouTube video with usable English timed transcript evidence, **When** generation succeeds, **Then** the owner receives a private `ai_draft` lesson and can open it immediately.
+2. **Given** a long video, **When** the compiler runs, **Then** it selects a bounded interaction-rich window rather than converting the entire video or always using the opening.
+3. **Given** missing/unavailable captions, unsupported language, disabled embedding, private video, age restriction, or source failure, **When** generation is requested, **Then** no partial lesson is created and the UI explains why that video is unsupported.
+4. **Given** Gemini returns malformed, invented, or unsupported content, **When** schema and source-evidence validation run, **Then** the lesson is rejected before persistence.
+5. **Given** the same owner repeats the same URL/level request, **When** the operation retries, **Then** identity and persistence are deterministic/idempotent rather than creating uncontrolled duplicates.
+6. **Given** a generated lesson, **Then** it stores the actual model, transcript adapter/mode, selected source window, warnings, owner, and `ai_draft` state.
 
 ---
 
-### User Story 3 — Complete one natural communication lesson (Priority: P1)
+### User Story 3 — Complete the generated natural-communication lesson (Priority: P1)
 
-The learner enters a real situation, listens, receives progressive support,
-retrieves useful language, speaks it, and attempts the same goal with changed
-data or context.
+The learner enters the generated situation, listens to the selected source
+segment, receives progressive support, retrieves useful source-backed language,
+speaks, and attempts the same goal with changed information or context.
 
-**Independent Test**: A learner cannot complete the lesson by watching or choosing
-answers alone; completion requires retrieval, speak-and-confirm, and transfer
-attempt evidence.
+**Independent Test**: Watching or choosing recognition answers alone cannot finish
+the lesson; retrieval, speak-and-confirm, and changed-context transfer are required.
 
 **Acceptance Scenarios**:
 
-1. **Given** a reviewed lesson, **When** it starts, **Then** the setting, roles, and practical goal appear before grammar or vocabulary explanation.
-2. **Given** the first encounter, **When** media plays, **Then** no transcript or answer is exposed by default.
-3. **Given** the learner needs support, **When** support is requested, **Then** it reveals progressively from replay/context to English evidence and concise Vietnamese guidance.
-4. **Given** useful source-backed language, **When** acquisition begins, **Then** the learner retrieves or reconstructs it without a permanently displayed full answer.
-5. **Given** speech practice, **When** browser speech recognition is absent or unused, **Then** the learner can speak and self-confirm without a pronunciation score.
-6. **Given** the transfer step, **When** no changed-context attempt is made, **Then** completion remains blocked.
-7. **Given** completion, **Then** the UI reports immediate practice evidence only and does not claim mastery, CEFR attainment, fluency, pronunciation accuracy, or retention.
+1. **Given** a generated private lesson, **When** it starts, **Then** the situation, roles, practical goal, source, AI-draft label, and unresolved warnings appear before activities.
+2. **Given** the first encounter, **When** official YouTube playback begins, **Then** transcript and answers are not exposed by default.
+3. **Given** the learner requests support, **When** it is revealed, **Then** support progresses from replay/context to English evidence and concise Vietnamese guidance.
+4. **Given** useful language, **When** retrieval begins, **Then** the learner reconstructs or recalls it without a permanently displayed full answer.
+5. **Given** microphone or browser recognition is unavailable, **When** speaking practice starts, **Then** the learner can speak and self-confirm without a pronunciation score.
+6. **Given** no changed-context attempt, **When** the learner tries to finish, **Then** completion remains blocked.
+7. **Given** completion, **Then** the UI reports immediate personal practice only and does not claim mastery, CEFR attainment, fluency, pronunciation accuracy, or transcript certainty.
 
 ---
 
-### User Story 4 — Save progress and return (Priority: P1)
+### User Story 4 — Save lessons, progress, and return (Priority: P1)
 
-An authenticated learner can leave and return without losing lesson state or
-completion evidence, while the system stores no raw audio or unrestricted learner
-text.
+The learner has a private library of generated lessons and can leave, return, and
+continue safely without exposing one user's generated content to another.
 
-**Independent Test**: A learner starts a lesson, reloads, completes it, logs out,
-logs back in, and sees the correct continue/review state.
+**Independent Test**: A user generates a lesson, reloads mid-lesson, completes it,
+logs out, logs in again, and sees the correct `continue` or `review` state; a second
+user cannot discover or access it.
 
 **Acceptance Scenarios**:
 
-1. **Given** an in-progress lesson, **When** the learner reloads or returns, **Then** the product restores a safe checkpoint rather than exposing answers or restarting silently.
-2. **Given** a completed lesson, **When** the dashboard reloads, **Then** the completion and next action are visible.
-3. **Given** another authenticated user, **When** they query the first learner's attempts, **Then** RLS prevents access.
-4. **Given** stored attempt evidence, **Then** it contains bounded booleans/counts/support state and timestamps, not raw microphone recordings, unrestricted transcripts, names, employers, or free text.
-5. **Given** duplicate completion requests, **When** retries occur, **Then** persistence remains idempotent.
+1. **Given** a successfully generated lesson, **When** the dashboard reloads, **Then** it appears in the owner's recent private lessons.
+2. **Given** an in-progress lesson, **When** the learner reloads or returns, **Then** the runtime restores a safe checkpoint without exposing hidden answers.
+3. **Given** a completed lesson, **When** the learner returns, **Then** the dashboard offers review and a new YouTube-generation action.
+4. **Given** another authenticated user, **When** they query or open the first user's lesson or attempt, **Then** RLS and route ownership checks deny access.
+5. **Given** stored progress, **Then** it contains bounded booleans/counts/support state and timestamps, not raw audio, unrestricted speech transcript, names, employers, or learner free text.
+6. **Given** duplicate generation/checkpoint/completion requests, **When** retries occur, **Then** writes remain idempotent.
 
 ---
 
-### User Story 5 — Operate and verify a pilot safely (Priority: P2)
+### User Story 5 — Operate the private-generation MVP safely (Priority: P2)
 
-The owner can deploy one preview, inspect the complete product journey, and run a
-small pilot without exposing experimental authoring or relying on repository tests
-as proof of learning effectiveness.
+The owner can verify one exact-head Vercel preview against hosted Supabase and live
+provider paths without making generated lessons public or mistaking CI for product
+or learning evidence.
 
-**Independent Test**: One exact-head Vercel preview passes the complete desktop
-and mobile journey against hosted Supabase, with privacy-safe pilot events and no
-critical runtime error.
+**Independent Test**: One authenticated desktop/mobile preview completes paste URL
+→ generation → private lesson → transfer → return against hosted services, with
+no cross-user leak or critical runtime error.
 
 **Acceptance Scenarios**:
 
-1. **Given** the implementation branch, **When** integration begins, **Then** it starts from current `main`; it does not merge the 420-commit-diverged Real Talk branch wholesale.
-2. **Given** selected Real Talk work, **When** it is ported, **Then** each file/contract is explicitly accepted, adapted, or rejected in a port manifest.
-3. **Given** the Vercel preview, **When** browser acceptance runs, **Then** landing, signup/login, dashboard, catalog, lesson, persistence, logout, and return pass on desktop and mobile.
-4. **Given** pilot analytics, **When** events are recorded, **Then** only bounded product events and scalar outcomes are stored.
-5. **Given** all technical gates pass, **Then** merge and production deployment still require explicit owner acceptance.
+1. **Given** implementation begins, **Then** it starts from current `main` and selectively ports Spec 001 work; PR #54 is not merged wholesale.
+2. **Given** a production candidate, **When** the transcript acquisition decision is reviewed, **Then** the exact adapter, mode, supported-video conditions, risks, and private-only boundary are documented.
+3. **Given** live generation, **When** Gemini succeeds or fails, **Then** both paths are verified with a bounded key and no secret is exposed.
+4. **Given** the Vercel preview, **When** browser acceptance runs, **Then** landing, auth, URL submission, generation, lesson, persistence, logout, and return pass on desktop and mobile.
+5. **Given** all technical gates pass, **Then** merge and production deployment still require separate owner authorization.
 
 ## Functional Requirements
 
-- **FR-001**: The MVP MUST have one truthful learner-facing promise across landing, auth, dashboard, catalog, and lesson completion.
-- **FR-002**: Dashboard, learner catalog, progress, and account routes MUST require authentication; landing and legal pages remain public.
-- **FR-003**: Signup bootstrap MUST be server-derived, idempotent, and shared by email and OAuth paths.
-- **FR-004**: The primary navigation MUST contain only the MVP loop: Learn, Review/Continue, and Account, with no editor-generation entry.
-- **FR-005**: The learner catalog MUST query database-reviewed public lessons only and MUST NOT merge static sample lessons.
-- **FR-006**: Publication eligibility MUST require reviewed lesson state, reviewed transcript state, safe provenance, and `is_public = true`.
-- **FR-007**: The MVP MUST support lawful official playback for the selected sources without media downloading or re-hosting.
-- **FR-008**: Source records MUST not be hard-wired to YouTube when the reviewed MVP source uses Wikimedia or another approved provider.
-- **FR-009**: Every learner-facing quote, answer, timestamp, speaker label, translation, and guidance line MUST be traceable to the reviewed source package.
-- **FR-010**: Lesson completion MUST require first-encounter participation, productive retrieval, speak-and-confirm, and changed-context transfer attempt.
-- **FR-011**: Speech practice MUST remain usable without microphone permission and MUST NOT claim pronunciation assessment.
-- **FR-012**: Progress persistence MUST store bounded evidence only and enforce owner RLS.
-- **FR-013**: Duplicate start, checkpoint, and completion writes MUST be idempotent.
-- **FR-014**: The dashboard MUST prioritize one next action and MUST NOT require XP, streak, league, word-of-day, challenge, writing, or notification systems.
-- **FR-015**: Deferred routes MAY remain in the codebase but MUST be removed from MVP navigation and may be guarded or redirected when they create product confusion.
-- **FR-016**: The MVP MUST reuse the hosted Supabase project `zpiwddskhduuykpxltun` and Vercel project `atoenglish`; it MUST NOT create replacement infrastructure without a measured blocker.
-- **FR-017**: Repository Supabase types and environment documentation MUST point to the same hosted project used by preview and production.
-- **FR-018**: Implementation MUST begin from current `main` and selectively port reviewed work from open branches.
-- **FR-019**: The experimental `youtube-transcript` path and arbitrary learner-facing generation MUST remain disabled from MVP production flows.
-- **FR-020**: The MVP launch corpus MUST contain at least three human-reviewed lessons in one environment, from at least two speakers or contexts.
-- **FR-021**: The product MUST record privacy-safe activation and lesson funnel events without learner free text or audio.
-- **FR-022**: Technical checks MUST include lint, TypeScript, unit/contract tests, content standards, production build, hosted RLS checks, and desktop/mobile Playwright.
-- **FR-023**: Vercel preview MUST show no critical runtime errors during acceptance.
-- **FR-024**: Owner acceptance is required before merge to `main` and before production deployment.
+- **FR-001**: The learner-facing promise MUST center on turning a supported YouTube video into a private personal English lesson.
+- **FR-002**: Generation, dashboard, private lessons, history, and account routes MUST require authentication; landing and legal pages remain public.
+- **FR-003**: Authentication MUST complete before transcript acquisition, metadata calls, or Gemini quota is consumed.
+- **FR-004**: Signup bootstrap MUST be server-derived, idempotent, and shared by email and OAuth.
+- **FR-005**: The dashboard MUST prioritize a YouTube URL form plus `continue`, `review`, or recent-private-lesson states.
+- **FR-006**: Input MUST accept only validated supported YouTube URLs and an approved target-level/lesson option set.
+- **FR-007**: Source playback MUST use the official YouTube embed/watch boundary; media MUST NOT be downloaded or re-hosted.
+- **FR-008**: Transcript acquisition MUST use an explicit replaceable adapter with acquisition mode, language, timing evidence, review status, and machine-readable failure codes.
+- **FR-009**: The production/private-MVP transcript adapter decision MUST document supported-video conditions and risks; unsupported videos MUST fail honestly.
+- **FR-010**: The selected interaction window MUST be bounded to at most 180 seconds and the configured cue/item limits.
+- **FR-011**: Gemini output MUST use a typed structured schema and pass runtime validation.
+- **FR-012**: Every quoted phrase, answer, timestamp, transcript reference, and transfer-language target MUST pass source-evidence validation against the selected cues.
+- **FR-013**: Unsupported or invalid output MUST be rejected before persistence.
+- **FR-014**: Generated lessons MUST be owner-private, `is_public = false`, and `review_state/generation_status = ai_draft` or the exact equivalent enforced by the schema.
+- **FR-015**: Ordinary users MUST NOT approve, publish, or read another user's generated lesson.
+- **FR-016**: Generated lessons MUST persist source URL/identity, selected window, transcript provenance/mode, model identifier, warnings, owner, and deterministic identity.
+- **FR-017**: The learner UI MUST visibly label generated content as an AI draft and preserve transcript/source uncertainty warnings.
+- **FR-018**: Static sample lessons MAY remain as test fixtures but MUST NOT be merged into production private-library results or presented as generated user content.
+- **FR-019**: Lesson completion MUST require first-encounter participation, productive retrieval, speak-and-confirm, and changed-context transfer attempt.
+- **FR-020**: Speech practice MUST work without microphone permission and MUST NOT claim pronunciation assessment.
+- **FR-021**: Private lesson progress MUST store bounded evidence only, enforce owner RLS, and remain idempotent.
+- **FR-022**: Generation MUST have rate limiting, retry-safe persistence, actionable failure states, and no partial public records.
+- **FR-023**: The MVP MUST verify a live bounded Gemini success and failure path before release; absence of `GEMINI_API_KEY` remains a release blocker.
+- **FR-024**: The MVP MUST reuse hosted Supabase project `zpiwddskhduuykpxltun` and Vercel project `atoenglish`, with repository types/environment aligned to the same project.
+- **FR-025**: Implementation MUST begin from current `main` and selectively port reviewed Spec 001 code through a file-level manifest.
+- **FR-026**: Technical gates MUST include lint, TypeScript, unit/contract tests, content standards, production build, hosted RLS/integration checks, live provider checks, and desktop/mobile Playwright.
+- **FR-027**: Vercel preview MUST show no critical runtime errors during the accepted journey.
+- **FR-028**: Owner acceptance is required before merge to `main` and before production deployment.
 
 ## MVP Success Criteria
 
-- **SC-001**: A new learner reaches the dashboard and starts a reviewed lesson in one uninterrupted browser journey.
-- **SC-002**: 100% of learner-visible catalog items are database-backed and human-reviewed; zero static sample lessons appear.
-- **SC-003**: The complete lesson cannot finish without a recorded transfer attempt.
-- **SC-004**: A returning learner sees correct continue/completed state after a new authenticated session.
-- **SC-005**: A second user cannot read or mutate the first user's lesson attempts.
-- **SC-006**: Desktop and mobile acceptance produce no uncaught page error, Next.js error overlay, or horizontal overflow.
-- **SC-007**: The first pilot records landing/start/auth/lesson/transfer/completion events without audio, transcript, name, employer, or free-text payloads.
-- **SC-008**: Exact-head lint, types, tests, content standards, production build, hosted checks, and preview acceptance pass before owner review.
-- **SC-009**: The MVP primary navigation exposes no deferred feature as a core learner promise.
-- **SC-010**: The owner can identify the deployed commit, reviewed corpus, database migrations, environment configuration, blockers, and rollback path from repository evidence.
+- **SC-001**: A new learner authenticates, pastes one supported YouTube URL, and reaches a generated private lesson in one uninterrupted browser journey.
+- **SC-002**: 100% of requests that reach transcript/Gemini work belong to an authenticated user.
+- **SC-003**: A controlled supported YouTube source generates one complete typed private lesson without manual JSON repair.
+- **SC-004**: Invalid, transcriptless, unsupported, or evidence-invalid sources create zero partial lessons.
+- **SC-005**: 100% of generated lessons remain owner-private `ai_draft` records; zero appear in a public catalog automatically.
+- **SC-006**: The lesson cannot finish without a recorded transfer attempt.
+- **SC-007**: A returning learner sees correct generated-library and continue/review state after a new authenticated session.
+- **SC-008**: A second user cannot read, update, delete, approve, publish, or attempt the first user's generated lesson.
+- **SC-009**: Desktop and mobile acceptance produce no uncaught page error, Next.js overlay, horizontal overflow, or secret exposure.
+- **SC-010**: Exact-head repository, hosted database, live Gemini, transcript-adapter, and Vercel preview evidence are recorded before owner review.
 
 ## Explicitly Out of Scope
 
-- broad curriculum graph or automatic next-environment recommendation;
-- five-environment or A0–B2 catalog expansion;
-- arbitrary YouTube ingestion in the learner product;
-- automatic transcript approval or publication;
-- unrestricted AI tutor or chatbot;
+- a public reviewed lesson catalog as the primary MVP;
+- automatic public publication or community sharing;
+- full human reviewer/publication dashboard;
+- bulk generation or source crawling;
+- support for every YouTube video, language, private/age-restricted source, or missing-caption source;
+- media download or re-hosting;
+- unrestricted chatbot;
 - phoneme, stress, fluency, prosody, or pronunciation scoring;
 - raw audio or unrestricted speech transcript storage;
-- XP, streak, league, achievements, challenge, certificates, social or referral systems;
-- writing assistant, grammar catalog, business track, broad speaking tools;
-- push notifications, cron engagement campaigns, subscriptions, and payments;
-- native mobile apps;
-- autonomous merge or production deployment.
+- broad curriculum graph or automatic progression across A0–B2;
+- XP, streak, league, achievements, challenge, certificates, social/referral systems;
+- writing, grammar, business, broad speaking tools, notifications, payments, or native apps;
+- autonomous merge or deployment.
 
 ## Assumptions
 
-- The hosted Supabase project is healthy and mostly empty, so MVP schema alignment has low migration risk but still requires backups and rollback planning.
-- Existing Real Talk compiler, provenance, private draft, and persisted preview work are evidence and reusable code candidates, not a mergeable branch as a whole.
-- Existing landing/auth/dashboard/mission code on `main` is reusable selectively but its current product promise and information architecture are not canonical.
-- Human reviewers are available to approve the initial three-lesson corpus.
-- The first pilot is small enough that content publication can use an authorized controlled operation; a full reviewer UI is not required for MVP.
+- The first MVP supports only YouTube videos that the selected transcript adapter can process with timed English evidence and official playback.
+- A video URL alone is the learner input; unsupported transcript conditions produce an honest failure rather than asking the learner to repair JSON or provide technical metadata.
+- Existing Spec 001 compiler, validation, private-draft, RLS, and persisted-preview work is reusable evidence/code but its diverged branch is not mergeable wholesale.
+- Private generated lessons may be used by their owner with visible AI/transcript warnings; any public/shared lesson still requires human review.
+- A live Gemini key and an acceptable production/private transcript acquisition decision are hard release gates.

--- a/specs/002-mvp-product-convergence/tasks.md
+++ b/specs/002-mvp-product-convergence/tasks.md
@@ -1,0 +1,228 @@
+---
+description: "Dependency-ordered implementation and verification tasks for the AtoEnglish MVP product convergence"
+---
+
+# Tasks: AtoEnglish MVP Product Convergence
+
+**Input**: `spec.md`, `plan.md`, `research.md`, `data-model.md`,
+`contracts/mvp-contract.md`, `quickstart.md`, and requirements checklist  
+**Implementation base**: then-current `main`, never a wholesale merge of
+`agent/rebuild-learning-core`  
+**Rule**: A checked task means its required evidence was observed. Code existence,
+a mock, or an earlier branch check is not sufficient unless the task explicitly
+names that evidence.
+
+## Format
+
+`[ID] [P?] [Story] Description`
+
+- **[P]**: may run in parallel after its dependencies are complete;
+- **[US1–US5]**: maps to the prioritized user stories in `spec.md`;
+- every implementation task names expected files or evidence locations;
+- owner-gated migrations, previews, merge, and deployment remain unchecked until
+  explicitly authorized.
+
+---
+
+## Phase 1 — Governance, baseline, and selective-port control
+
+**Purpose**: Make the implementation branch safe before any product code changes.
+
+- [ ] T001 Obtain explicit owner acceptance of the MVP promise, one-environment scope, deferred-feature list, and fresh-main integration strategy; record the decision in `specs/002-mvp-product-convergence/owner-decisions.md`
+- [ ] T002 Resolve and record the exact current `main` SHA, open PR/branch state, hosted Supabase project, and Vercel project in `specs/002-mvp-product-convergence/baseline.md`
+- [ ] T003 Create `integration/mvp-product-convergence` from the exact current `main` head; do not merge PR #54 or `agent/rebuild-learning-core`
+- [ ] T004 Create `specs/002-mvp-product-convergence/port-manifest.md` and classify every selected Real Talk path as `port`, `adapt`, `reference`, or `reject`, including source SHA, destination, reason, and tests
+- [ ] T005 [P] Reconcile `package.json`, `package-lock.json`, `.nvmrc`, and `.github/workflows/verify.yml` against current `main`; preserve Node 24/npm 11 and prevent restoration of `gtts`, `request`, `har-validator`, or `uuid@3`
+- [ ] T006 [P] Align `.env.example` and the `db:types` script in `package.json` with hosted project `zpiwddskhduuykpxltun` without exposing secret values
+- [ ] T007 [P] Generate a fresh hosted Supabase type baseline into `src/types/supabase.ts` and record equivalence evidence in `specs/002-mvp-product-convergence/hosted-baseline.md`; never edit generated types manually
+- [ ] T008 Update `specs/000-atoenglish-rebuild-roadmap/roadmap.md` and `docs/product/CURRENT_PRIORITY.md` to make Spec 002 the accepted active MVP convergence spec without erasing Spec 001 evidence
+- [ ] T009 Update `AGENTS.md` only after T001 so agents use Spec 002 as the active implementation ledger and retain all merge/deploy restrictions
+- [ ] T010 Run pre-implementation cross-artifact analysis and update `specs/002-mvp-product-convergence/analysis.md`; implementation is blocked by any unresolved critical contradiction
+
+**Checkpoint**: The branch starts from current main, package/database baselines agree,
+and every reused change is explicitly selected.
+
+---
+
+## Phase 2 — User Story 1: Truthful entry, authentication, and focused shell
+
+**Goal**: A new or returning learner reaches one focused dashboard reliably.
+
+**Independent test**: Landing → signup/login → idempotent bootstrap → protected
+dashboard passes on desktop and mobile without manual database repair.
+
+- [ ] T011 [US1] Replace the legacy 28-day/fluency-adjacent landing promise and metadata in `src/app/page.tsx` with the approved natural-communication MVP promise
+- [ ] T012 [P] [US1] Audit and update active landing components under `src/components/landing/` so hero, product preview, method, FAQ, testimonials, and final CTA do not promise unsupported personalization, pronunciation scoring, broad curriculum, or results
+- [ ] T013 [P] [US1] Update landing JSON-LD, Open Graph, canonical copy, and accessibility assertions in `src/app/page.tsx` and `e2e/accessibility-smoke.spec.ts`
+- [ ] T014 [US1] Separate authentication from fake/defaulted personalization in `src/app/login/page.tsx`; ask only an approved choice that changes immediate behavior or remove onboarding questions from the critical path
+- [ ] T015 [US1] Define the idempotent account bootstrap contract in `src/features/mvp/domain/account-bootstrap.ts` with typed success/failure results and no client user ID
+- [ ] T016 [US1] Implement shared server-side bootstrap in `src/features/mvp/server/bootstrap-account.ts` and a thin server action under `src/app/actions/mvp-account.ts`
+- [ ] T017 [US1] If atomic database support is required, add a versioned security-invoker migration under `supabase/migrations/` for account bootstrap, with SQL contract tests under `src/__tests__/`; do not apply hosted DDL without owner authorization
+- [ ] T018 [US1] Route both email and OAuth callback flows through the shared bootstrap by updating `src/app/login/page.tsx` and `src/app/auth/callback/route.ts` (or the exact existing callback path resolved during implementation)
+- [ ] T019 [US1] Make bootstrap/auth failures recoverable and truthful in login/callback UI; add focused tests under `src/__tests__/mvp-auth-bootstrap.test.ts`
+- [ ] T020 [US1] Update `src/lib/supabase/session.ts` so `/dashboard`, `/real-talk`, `/real-talk/[slug]`, and `/me` require authentication while landing/legal/health routes remain public
+- [ ] T021 [P] [US1] Update `e2e/protected-routes.spec.ts` for the approved MVP route matrix, safe `next` handling, authenticated login redirect, and cookie refresh
+- [ ] T022 [US1] Reduce `src/lib/constants/navigation.ts`, `src/components/layout/bottom-nav.tsx`, and active desktop/mobile shell components to the MVP navigation: Học, Ôn lại/Tiếp tục, Tôi
+- [ ] T023 [US1] Define `MvpDashboardState` in `src/features/mvp/domain/dashboard-state.ts` and add exhaustive state tests
+- [ ] T024 [US1] Implement one focused dashboard query in `src/features/mvp/server/dashboard-repository.ts` using reviewed lessons and learner attempts only
+- [ ] T025 [US1] Replace the legacy dashboard orchestration in `src/app/(main)/dashboard/page.tsx` and its client components with one primary action, a small reviewed lesson list, and honest loading/empty/error states
+- [ ] T026 [P] [US1] Simplify `/me` through `src/app/(main)/me/MeClient.tsx` and related server page to account identity, bounded history/status, settings link if retained, and logout; remove legacy product promises from the MVP path
+- [ ] T027 [US1] Add desktop/mobile Playwright coverage `e2e/mvp-entry-auth-dashboard.spec.ts` for new email user, returning user, logout, safe return path, and bootstrap retry
+
+**Checkpoint**: A learner can enter, authenticate, and see exactly one coherent next
+action without depending on XP, streak, flashcards, writing, or fifty-unit state.
+
+---
+
+## Phase 3 — User Story 2: Reviewed learner catalog and source publication boundary
+
+**Goal**: Learners see only database-backed, human-reviewed lessons.
+
+**Independent test**: Three reviewed public lessons plus private/unreviewed rows
+produce exactly three catalog items and no static fallback.
+
+- [ ] T028 [US2] Port the accepted Real Talk domain/provenance/source-policy files listed in `port-manifest.md` into `src/features/real-talk/`, preserving their focused tests and adapting imports to current main
+- [ ] T029 [US2] Port or reimplement `src/features/real-talk/server/transcript-sources/supabase-reviewed.ts` and verify cue-digest, reviewer-independence, and production-policy checks on the integration branch
+- [ ] T030 [US2] Define provider-neutral source and playback contracts in `src/features/real-talk/domain/reviewed-source.ts` for `youtube_embed`, `direct_video`, and `external_link`
+- [ ] T031 [US2] Add a versioned provider-neutral Real Talk source migration under `supabase/migrations/`, including safe HTTPS constraints, provider/external identity, playback fields, compatibility handling for `youtube_id`, indexes, grants, and rollback notes
+- [ ] T032 [P] [US2] Add migration contract tests under `src/__tests__/real-talk-provider-neutral-source-migration.test.ts`
+- [ ] T033 [US2] Implement provider-neutral playback selection in `src/features/real-talk/server/playback-policy.ts` with unit tests for each allowed mode and unsafe references
+- [ ] T034 [US2] Adapt `src/components/real-talk/YouTubePlayer.tsx` into a reviewed-source player boundary under `src/features/real-talk/components/ReviewedSourcePlayer.tsx`; keep official playback and no download/re-host behavior
+- [ ] T035 [US2] Implement a database-only reviewed catalog repository in `src/features/real-talk/server/reviewed-catalog-repository.ts` that fails closed on unknown/unreviewed/publication state
+- [ ] T036 [US2] Replace `fetchCatalogVideos()` in `src/app/actions/real-talk.ts` with the reviewed catalog repository; remove all imports/merging from `src/lib/data/real-talk/videos.ts` in learner production paths
+- [ ] T037 [US2] Remove the learner-facing arbitrary-generation CTA and filters based on unreviewed static data from `src/components/real-talk/RealTalkHub.tsx`; show a reviewed small catalog or honest empty state
+- [ ] T038 [P] [US2] Keep `/real-talk/create` editor-only or disabled by updating `src/app/(main)/real-talk/create/page.tsx`, route policy, and navigation tests; ordinary learners must not discover it
+- [ ] T039 [US2] Select the initial environment and create three source-review packets under `specs/002-mvp-product-convergence/content/`, each naming canonical source, rights, complete context, bounded window, transcript, speaker/timing uncertainty, translation, safety, level, and transfer
+- [ ] T040 [US2] Obtain actual human review/sign-off for all three source packages and record reviewer identity/date/decision; automated or controlled test identities do not satisfy this task
+- [ ] T041 [US2] Create three final reviewed lesson packages under `specs/002-mvp-product-convergence/content/` and prove every learner-facing English/answer/timestamp/speaker/translation/guidance item traces to reviewed evidence
+- [ ] T042 [US2] Implement one controlled idempotent publication/seed operation under `scripts/` or an authorized server path, with explicit reviewer authorization, no ordinary-user publication ability, and rollback/cleanup support
+- [ ] T043 [US2] Add catalog contract/integration tests proving static fixtures, private drafts, unreviewed transcripts, incomplete review identity, and unsafe playback never appear
+- [ ] T044 [US2] After explicit owner authorization, apply the provider-neutral migration and controlled reviewed corpus operation to hosted Supabase; record migration IDs, row IDs, reviewer evidence, advisors, and rollback in `specs/002-mvp-product-convergence/content-publication-verification.md`
+
+**Checkpoint**: The hosted catalog contains a tiny reviewed corpus and returns
+nothing that did not pass the human/source gate.
+
+---
+
+## Phase 4 — User Story 3: Natural communication lesson runtime
+
+**Goal**: A learner completes one full natural communication loop with transfer.
+
+**Independent test**: Watching or answering recognition items cannot complete the
+lesson; retrieval, speech confirmation, and changed-context transfer are required.
+
+- [ ] T045 [US3] Port/adapt the accepted environment-first Real Talk runtime contracts and components into `src/features/real-talk/`, excluding static sample assumptions and editor-private warnings from the learner surface
+- [ ] T046 [US3] Implement a reviewed lesson loader in `src/features/real-talk/server/reviewed-lesson-repository.ts` that requires authenticated access and publication eligibility
+- [ ] T047 [US3] Update `src/app/(main)/real-talk/[videoId]/page.tsx` to use the reviewed lesson loader, shared MVP layout, not-found boundary, and provider-neutral player
+- [ ] T048 [P] [US3] Add an environment entry component under `src/features/real-talk/components/EnvironmentBriefing.tsx` showing setting, roles, relationship, and practical goal before language explanation
+- [ ] T049 [US3] Implement first encounter in `src/features/real-talk/components/FirstEncounter.tsx` with no transcript/answer exposure by default and a source-backed gist/intention task
+- [ ] T050 [US3] Implement deterministic progressive support in `src/features/real-talk/domain/support-level.ts` and `src/features/real-talk/components/ProgressiveSupport.tsx`: replay/context → keyword → English evidence → chunking → concise Vietnamese guidance
+- [ ] T051 [US3] Implement productive retrieval/reconstruction in `src/features/real-talk/components/RetrievalPractice.tsx`, ensuring the full answer is not permanently visible and every accepted target is source-backed
+- [ ] T052 [US3] Implement `speak_and_confirm` in `src/features/real-talk/components/SpeakAndConfirm.tsx` with microphone-independent fallback, no score, and explicit non-pronunciation copy
+- [ ] T053 [US3] Implement changed-context transfer in `src/features/real-talk/components/ChangedContextTransfer.tsx` without storing unrestricted learner response text
+- [ ] T054 [US3] Define and implement the completion state machine in `src/features/real-talk/domain/lesson-runtime.ts`; completion requires first listen, retrieval attempt, speaking confirmation, and transfer attempt
+- [ ] T055 [US3] Replace mastery/CEFR/fluency/pronunciation completion copy in the runtime with immediate-practice language and a retention disclaimer
+- [ ] T056 [P] [US3] Add unit/component tests under `src/__tests__/mvp-real-talk-runtime.test.tsx` for support fading, source evidence, microphone fallback, transfer gate, and honest copy
+- [ ] T057 [US3] Add an unauthenticated/direct-link/not-found/media-unavailable/error matrix for the reviewed lesson route and components
+
+**Checkpoint**: One reviewed lesson is pedagogically and technically complete under
+the MVP contract, independent of legacy lesson and gamification systems.
+
+---
+
+## Phase 5 — User Story 4: Bounded progress, continuation, and return
+
+**Goal**: An authenticated learner can leave and return without losing safe state.
+
+**Independent test**: Start → reload → complete → logout/login → dashboard state
+works, while another user cannot access the attempt.
+
+- [ ] T058 [US4] Evaluate `user_v2_lesson_progress` and `lesson_v2_evidence` against `data-model.md`; record the accept/reject decision in `specs/002-mvp-product-convergence/attempt-storage-decision.md`
+- [ ] T059 [US4] If existing storage is insufficient, add a versioned bounded `real_talk_attempts` migration under `supabase/migrations/` with completion constraints, unique `(user_id, lesson_id)`, ownership RLS, grants, indexes, and no free-text columns
+- [ ] T060 [P] [US4] Add SQL and generated-type contract tests under `src/__tests__/mvp-real-talk-attempt-migration.test.ts`
+- [ ] T061 [US4] Define typed attempt/checkpoint results in `src/features/real-talk/domain/learner-attempt.ts`
+- [ ] T062 [US4] Implement idempotent owner-derived attempt persistence in `src/features/real-talk/server/attempt-repository.ts`; do not trust client user IDs or completion flags
+- [ ] T063 [US4] Add thin server actions under `src/app/actions/real-talk-attempt.ts` for start/checkpoint/complete and validate every payload with Zod
+- [ ] T064 [US4] Restore a safe lesson checkpoint after reload without restoring answer exposure or claiming completion prematurely
+- [ ] T065 [US4] Integrate attempt state into `src/features/mvp/server/dashboard-repository.ts` so the primary action is `start`, `continue`, or `review`
+- [ ] T066 [P] [US4] Add repository/action unit tests for retry idempotency, invalid checkpoint, forged completion, and persistence failure
+- [ ] T067 [US4] After explicit owner authorization, apply the selected attempt migration to hosted Supabase and regenerate `src/types/supabase.ts`
+- [ ] T068 [US4] Run hosted anonymous/ownerA/ownerB tests proving owner read/write, cross-user denial, forged completion rejection, and cleanup; record in `specs/002-mvp-product-convergence/hosted-attempt-verification.md`
+- [ ] T069 [US4] Add `e2e/mvp-lesson-return.spec.ts` covering reload, logout/login, continue, complete, and review state on desktop and mobile
+
+**Checkpoint**: Learner progress survives sessions, is private, bounded, and not
+coupled to XP or raw learner content.
+
+---
+
+## Phase 6 — User Story 5: Pilot instrumentation, resilience, and product pruning
+
+**Goal**: The owner can run a small, observable pilot without exposing the old
+product as the MVP.
+
+**Independent test**: The full preview journey records only allowed events and
+survives key auth/media/database failure states.
+
+- [ ] T070 [US5] Define the bounded MVP event taxonomy in `src/features/mvp/domain/pilot-events.ts` with an exhaustive allow-list and forbidden free-text fields
+- [ ] T071 [US5] Reuse/adapt existing `pilot_events` client/server recording through `src/features/mvp/server/pilot-event-repository.ts` and focused actions; do not create a second analytics platform
+- [ ] T072 [P] [US5] Instrument landing, auth, dashboard, lesson start, first listen, support, retrieval, speech confirmation, transfer, completion, and return without answer/audio/transcript payloads
+- [ ] T073 [P] [US5] Add analytics contract tests proving unknown events and forbidden/unbounded payload fields are rejected
+- [ ] T074 [US5] Add focused loading, empty, database failure, auth expiry, media unavailable, and offline/retry states to the MVP shell and lesson runtime
+- [ ] T075 [US5] Audit every primary navigation, landing CTA, dashboard action, command palette, mobile drawer, sitemap, and internal promotion so deferred routes are absent from the MVP story; record decisions in `specs/002-mvp-product-convergence/deferred-route-audit.md`
+- [ ] T076 [US5] Guard, redirect, or feature-flag deferred routes that still create a critical product contradiction; do not broadly delete or rewrite them in this spec
+- [ ] T077 [P] [US5] Review and retire test-only Supabase Edge Functions (`spec001-*`) after explicit owner authorization; preserve the real `real-talk-transcript-review` function and record final inventory
+- [ ] T078 [US5] Run Supabase security/performance advisors after all authorized DDL and resolve every new MVP-related finding
+- [ ] T079 [US5] Verify Vercel/Supabase environment equivalence without exposing values and record variable-name coverage in `specs/002-mvp-product-convergence/environment-verification.md`
+
+**Checkpoint**: The MVP is observable, fails honestly, and no deferred feature is
+presented as part of the core value proposition.
+
+---
+
+## Phase 7 — Cross-cutting verification, preview, convergence, and release gates
+
+**Purpose**: Prove the exact final state. No mock substitutes for a required
+hosted, browser, human, or owner check.
+
+- [ ] T080 Run `npm ci --no-audit --prefer-offline` on a clean exact-head checkout using the main toolchain and lockfile
+- [ ] T081 Run `npm run lint` on the exact final head
+- [ ] T082 Run `npx tsc --noEmit` on the exact final head
+- [ ] T083 Run the focused MVP auth, catalog, runtime, attempt, analytics, migration, policy, and RLS contract suites
+- [ ] T084 Run `npm run test` and record file/test counts
+- [ ] T085 Run `npm run test:content-standard`
+- [ ] T086 Run applicable hosted integration suites against `zpiwddskhduuykpxltun` with bounded test identities and mandatory cleanup
+- [ ] T087 Run `npm run build` and record the complete Next.js route output; no deferred route may be mistaken for MVP scope merely because it builds
+- [ ] T088 Run desktop and mobile accessibility smoke for landing, auth, dashboard, catalog, lesson, and account shell
+- [ ] T089 Run the full authenticated MVP Playwright journey on Desktop Chrome and Pixel/mobile-equivalent against a production build, including logout/login return
+- [ ] T090 Confirm no uncaught page error, Next.js overlay, horizontal overflow, unreviewed static lesson, editor-generation CTA, or unsupported learning claim appears
+- [ ] T091 Confirm all three human-reviewed source/lesson packages remain accessible and match the published database rows and cue digests
+- [ ] T092 Update `specs/002-mvp-product-convergence/analysis.md` with final requirement-to-implementation-to-evidence mapping and resolve all critical findings
+- [ ] T093 Update `specs/002-mvp-product-convergence/checklists/requirements.md` from observed evidence; keep owner-gated items unchecked until authorized
+- [ ] T094 Obtain explicit owner authorization for one intentional Vercel preview branch `preview/mvp-product-convergence`
+- [ ] T095 Deploy the exact verified head to the connected Vercel `atoenglish` preview and record deployment ID, URL reference, commit SHA, and environment in `specs/002-mvp-product-convergence/preview-verification.md`
+- [ ] T096 Repeat the full desktop/mobile journey on the actual Vercel preview against hosted Supabase
+- [ ] T097 Inspect Vercel runtime error clusters/logs and Supabase auth/API/Postgres logs for the acceptance window; resolve critical MVP errors
+- [ ] T098 Present the preview, reviewed corpus, deferred scope, known limitations, rollback, and evidence to the owner for product acceptance
+- [ ] T099 Record the owner's decision in `specs/002-mvp-product-convergence/owner-acceptance.md`; rejection or requested changes keep the spec unconverged
+- [ ] T100 After acceptance, prepare a clean PR targeting `main` with exact task/evidence status and no automatic merge or deployment
+- [ ] T101 Rerun exact-head gates if the main-targeted PR head changes during reconciliation
+- [ ] T102 Obtain separate explicit authorization before merging to `main`
+- [ ] T103 After merge, obtain separate explicit authorization before production deployment
+- [ ] T104 If production deployment is authorized, deploy the exact merged commit, run production smoke, inspect runtime logs, and record rollback information; otherwise leave production untouched
+
+---
+
+## MVP Convergence Rule
+
+The MVP is converged only when:
+
+1. T001–T099 required work is checked from observed evidence;
+2. three human-reviewed lessons in one environment are public and traceable;
+3. the complete learner journey passes on hosted desktop and mobile preview;
+4. database ownership/privacy and bounded persistence are verified;
+5. no static/unreviewed lesson or editor-generation control is learner-facing;
+6. cross-artifact analysis has no unresolved critical conflict;
+7. the owner explicitly accepts the exact preview state.
+
+T100–T104 are release operations, not implied by convergence. Merge and production
+deployment remain separate owner decisions.

--- a/specs/002-mvp-product-convergence/tasks.md
+++ b/specs/002-mvp-product-convergence/tasks.md
@@ -1,228 +1,148 @@
 ---
-description: "Dependency-ordered implementation and verification tasks for the AtoEnglish MVP product convergence"
+description: "Dependency-ordered tasks for the AtoEnglish YouTube-to-private-lesson MVP"
 ---
 
-# Tasks: AtoEnglish MVP Product Convergence
+# Tasks: AtoEnglish YouTube-to-Private-Lesson MVP
 
-**Input**: `spec.md`, `plan.md`, `research.md`, `data-model.md`,
-`contracts/mvp-contract.md`, `quickstart.md`, and requirements checklist  
-**Implementation base**: then-current `main`, never a wholesale merge of
+**Implementation base:** then-current `main`, never a wholesale merge of
 `agent/rebuild-learning-core`  
-**Rule**: A checked task means its required evidence was observed. Code existence,
-a mock, or an earlier branch check is not sufficient unless the task explicitly
-names that evidence.
-
-## Format
-
-`[ID] [P?] [Story] Description`
-
-- **[P]**: may run in parallel after its dependencies are complete;
-- **[US1–US5]**: maps to the prioritized user stories in `spec.md`;
-- every implementation task names expected files or evidence locations;
-- owner-gated migrations, previews, merge, and deployment remain unchecked until
-  explicitly authorized.
-
----
+**Evidence rule:** Check a task only after its named evidence is observed. Mocks,
+code existence, or checks from an earlier head do not satisfy hosted/live/browser
+or owner gates.
 
 ## Phase 1 — Governance, baseline, and selective-port control
 
-**Purpose**: Make the implementation branch safe before any product code changes.
+- [x] T001 Record the owner's corrected core-product decision in `specs/002-mvp-product-convergence/owner-decisions.md`: paste YouTube URL → private personal lesson
+- [ ] T002 Obtain explicit authorization to begin implementation and record it in `owner-decisions.md`; the product correction alone does not authorize code, migration, preview, merge, or deployment
+- [ ] T003 Resolve exact current `main` SHA, PR/branch topology, hosted Supabase project, Vercel project, and active environment references in `specs/002-mvp-product-convergence/baseline.md`
+- [ ] T004 Create `integration/mvp-youtube-to-lesson` from exact current `main`; do not merge PR #54
+- [ ] T005 Create `specs/002-mvp-product-convergence/port-manifest.md` and classify selected Real Talk paths as `port`, `adapt`, `reference`, or `reject`
+- [ ] T006 Reconcile `package.json`, `package-lock.json`, `.nvmrc`, and `.github/workflows/verify.yml` against current main; retain Node 24/npm 11 and avoid restoring the stale `gtts` chain
+- [ ] T007 Align `.env.example` and `package.json` `db:types` with Supabase project `zpiwddskhduuykpxltun` without exposing secrets
+- [ ] T008 Regenerate `src/types/supabase.ts` from the hosted project and record the baseline in `specs/002-mvp-product-convergence/hosted-baseline.md`; never edit generated types manually
+- [ ] T009 Update `AGENTS.md`, `docs/product/CURRENT_PRIORITY.md`, and the roadmap only after T002 so Spec 002 becomes the accepted implementation ledger
+- [ ] T010 Re-run cross-artifact analysis and block implementation on any critical contradiction
 
-- [ ] T001 Obtain explicit owner acceptance of the MVP promise, one-environment scope, deferred-feature list, and fresh-main integration strategy; record the decision in `specs/002-mvp-product-convergence/owner-decisions.md`
-- [ ] T002 Resolve and record the exact current `main` SHA, open PR/branch state, hosted Supabase project, and Vercel project in `specs/002-mvp-product-convergence/baseline.md`
-- [ ] T003 Create `integration/mvp-product-convergence` from the exact current `main` head; do not merge PR #54 or `agent/rebuild-learning-core`
-- [ ] T004 Create `specs/002-mvp-product-convergence/port-manifest.md` and classify every selected Real Talk path as `port`, `adapt`, `reference`, or `reject`, including source SHA, destination, reason, and tests
-- [ ] T005 [P] Reconcile `package.json`, `package-lock.json`, `.nvmrc`, and `.github/workflows/verify.yml` against current `main`; preserve Node 24/npm 11 and prevent restoration of `gtts`, `request`, `har-validator`, or `uuid@3`
-- [ ] T006 [P] Align `.env.example` and the `db:types` script in `package.json` with hosted project `zpiwddskhduuykpxltun` without exposing secret values
-- [ ] T007 [P] Generate a fresh hosted Supabase type baseline into `src/types/supabase.ts` and record equivalence evidence in `specs/002-mvp-product-convergence/hosted-baseline.md`; never edit generated types manually
-- [ ] T008 Update `specs/000-atoenglish-rebuild-roadmap/roadmap.md` and `docs/product/CURRENT_PRIORITY.md` to make Spec 002 the accepted active MVP convergence spec without erasing Spec 001 evidence
-- [ ] T009 Update `AGENTS.md` only after T001 so agents use Spec 002 as the active implementation ledger and retain all merge/deploy restrictions
-- [ ] T010 Run pre-implementation cross-artifact analysis and update `specs/002-mvp-product-convergence/analysis.md`; implementation is blocked by any unresolved critical contradiction
+**Checkpoint:** Clean fresh-main branch, one environment source of truth, exact port manifest.
 
-**Checkpoint**: The branch starts from current main, package/database baselines agree,
-and every reused change is explicitly selected.
+## Phase 2 — Truthful entry, authentication, and URL-first dashboard
 
----
+- [ ] T011 [US1] Rewrite `src/app/page.tsx` metadata, hero, JSON-LD, CTA, and primary copy around “paste a supported YouTube video and get a private English lesson”
+- [ ] T012 [P] [US1] Audit/update active files under `src/components/landing/` so they do not promise fixed 28-day outcomes, perfect transcripts, pronunciation scoring, or a broad curriculum
+- [ ] T013 [P] [US1] Add landing tests in `e2e/accessibility-smoke.spec.ts` and a focused copy/CTA test proving the YouTube-to-lesson promise
+- [ ] T014 [US1] Separate auth from fake/defaulted personalization in `src/app/login/page.tsx`; keep only inputs that change the immediate MVP behavior
+- [ ] T015 [US1] Define typed bootstrap results in `src/features/mvp/domain/account-bootstrap.ts`
+- [ ] T016 [US1] Implement shared server-owned idempotent bootstrap in `src/features/mvp/server/bootstrap-account.ts` and `src/app/actions/mvp-account.ts`
+- [ ] T017 [US1] Route email and OAuth callbacks through the shared bootstrap by updating `src/app/login/page.tsx` and `src/app/auth/callback/route.ts`
+- [ ] T018 [P] [US1] Add bootstrap/auth tests under `src/__tests__/mvp-auth-bootstrap.test.ts` for retry, partial failure, email, OAuth, and no client user ID
+- [ ] T019 [US1] Protect `/dashboard`, `/real-talk`, `/real-talk/create`, `/real-talk/[slug]`, and `/me` in `src/lib/supabase/session.ts`
+- [ ] T020 [P] [US1] Update `e2e/protected-routes.spec.ts` for generation/private-lesson ownership and safe `next` behavior
+- [ ] T021 [US1] Reduce `src/lib/constants/navigation.ts` and active shell components to `Tạo bài/Học`, `Bài của tôi`, and `Tôi`
+- [ ] T022 [US1] Define `PrivateLessonLibraryState` in `src/features/mvp/domain/dashboard-state.ts` with exhaustive state tests
+- [ ] T023 [US1] Implement recent owner-private lesson and progress read model in `src/features/mvp/server/dashboard-repository.ts`
+- [ ] T024 [US1] Replace legacy dashboard orchestration in `src/app/(main)/dashboard/page.tsx` and its client components with the URL form, generation status, continue/review, recent private lessons, and honest empty/error states
+- [ ] T025 [US1] Add `e2e/mvp-entry-generation-dashboard.spec.ts` for new user, returning user, logout, URL form visibility, and bootstrap retry on desktop/mobile
 
-## Phase 2 — User Story 1: Truthful entry, authentication, and focused shell
+**Checkpoint:** Authenticated user reaches one obvious action: paste a YouTube URL.
 
-**Goal**: A new or returning learner reaches one focused dashboard reliably.
+## Phase 3 — YouTube source, official playback, and transcript boundary
 
-**Independent test**: Landing → signup/login → idempotent bootstrap → protected
-dashboard passes on desktop and mobile without manual database repair.
+- [ ] T026 [US2] Port/adapt URL/source contracts from Spec 001 into `src/features/real-talk/domain/youtube-source.ts` and focused tests
+- [ ] T027 [US2] Validate and normalize `youtube.com`, `youtu.be`, Shorts, embed, and supported mobile URL forms; reject malformed/non-YouTube inputs before provider work
+- [ ] T028 [US2] Implement source metadata/availability resolution with stable failure codes for unavailable, private, age-restricted, embed-disabled, and malformed sources
+- [ ] T029 [US2] Adapt `src/components/real-talk/YouTubePlayer.tsx` into an official playback boundary without media downloading/re-hosting
+- [ ] T030 [US2] Port/adapt `TranscriptSourceAdapter` and explicit acquisition result contracts into `src/features/real-talk/domain/transcript-source.ts`
+- [ ] T031 [US2] Port/adapt `src/features/real-talk/server/transcript-sources/youtube-experimental.ts` behind the adapter contract; do not silently rename it production-approved
+- [ ] T032 [US2] Document the exact private-MVP transcript acquisition decision in `specs/002-mvp-product-convergence/production-transcript-decision.md`, including mode, supported-video conditions, terms/rights/reliability risks, warnings, and rollback
+- [ ] T033 [US2] Implement machine-readable transcript failures in `src/features/real-talk/domain/generation-result.ts` and mapping to Vietnamese user guidance
+- [ ] T034 [US2] Normalize/bound/delimit transcript cues as untrusted prompt data in `src/features/real-talk/server/transcript-provenance.ts` and compiler helpers
+- [ ] T035 [US2] Verify deterministic interaction-rich window selection (<=180 seconds and configured cue limit) with long/opening/low-interaction fixtures
+- [ ] T036 [P] [US2] Expand tests under `src/__tests__/real-talk-youtube-source.test.ts` and `real-talk-transcript-source-policy.test.ts` for supported/unsupported URL and transcript matrices
+- [ ] T037 [US2] Ensure `/real-talk/create` or dashboard form exposes clear `supported video` requirements and distinct validate/transcript/provider errors
+- [ ] T038 [US2] Ensure no static transcript/sample path is used when a user submits a URL; add a production-boundary test
+- [ ] T039 [US2] Run a controlled live supported-YouTube transcript acquisition check without Gemini/persistence and record source, mode, cue digest, timings, and cleanup
+- [ ] T040 [US2] Run controlled unsupported/transcriptless source checks and record exact failure codes and user-visible messages
 
-- [ ] T011 [US1] Replace the legacy 28-day/fluency-adjacent landing promise and metadata in `src/app/page.tsx` with the approved natural-communication MVP promise
-- [ ] T012 [P] [US1] Audit and update active landing components under `src/components/landing/` so hero, product preview, method, FAQ, testimonials, and final CTA do not promise unsupported personalization, pronunciation scoring, broad curriculum, or results
-- [ ] T013 [P] [US1] Update landing JSON-LD, Open Graph, canonical copy, and accessibility assertions in `src/app/page.tsx` and `e2e/accessibility-smoke.spec.ts`
-- [ ] T014 [US1] Separate authentication from fake/defaulted personalization in `src/app/login/page.tsx`; ask only an approved choice that changes immediate behavior or remove onboarding questions from the critical path
-- [ ] T015 [US1] Define the idempotent account bootstrap contract in `src/features/mvp/domain/account-bootstrap.ts` with typed success/failure results and no client user ID
-- [ ] T016 [US1] Implement shared server-side bootstrap in `src/features/mvp/server/bootstrap-account.ts` and a thin server action under `src/app/actions/mvp-account.ts`
-- [ ] T017 [US1] If atomic database support is required, add a versioned security-invoker migration under `supabase/migrations/` for account bootstrap, with SQL contract tests under `src/__tests__/`; do not apply hosted DDL without owner authorization
-- [ ] T018 [US1] Route both email and OAuth callback flows through the shared bootstrap by updating `src/app/login/page.tsx` and `src/app/auth/callback/route.ts` (or the exact existing callback path resolved during implementation)
-- [ ] T019 [US1] Make bootstrap/auth failures recoverable and truthful in login/callback UI; add focused tests under `src/__tests__/mvp-auth-bootstrap.test.ts`
-- [ ] T020 [US1] Update `src/lib/supabase/session.ts` so `/dashboard`, `/real-talk`, `/real-talk/[slug]`, and `/me` require authentication while landing/legal/health routes remain public
-- [ ] T021 [P] [US1] Update `e2e/protected-routes.spec.ts` for the approved MVP route matrix, safe `next` handling, authenticated login redirect, and cookie refresh
-- [ ] T022 [US1] Reduce `src/lib/constants/navigation.ts`, `src/components/layout/bottom-nav.tsx`, and active desktop/mobile shell components to the MVP navigation: Học, Ôn lại/Tiếp tục, Tôi
-- [ ] T023 [US1] Define `MvpDashboardState` in `src/features/mvp/domain/dashboard-state.ts` and add exhaustive state tests
-- [ ] T024 [US1] Implement one focused dashboard query in `src/features/mvp/server/dashboard-repository.ts` using reviewed lessons and learner attempts only
-- [ ] T025 [US1] Replace the legacy dashboard orchestration in `src/app/(main)/dashboard/page.tsx` and its client components with one primary action, a small reviewed lesson list, and honest loading/empty/error states
-- [ ] T026 [P] [US1] Simplify `/me` through `src/app/(main)/me/MeClient.tsx` and related server page to account identity, bounded history/status, settings link if retained, and logout; remove legacy product promises from the MVP path
-- [ ] T027 [US1] Add desktop/mobile Playwright coverage `e2e/mvp-entry-auth-dashboard.spec.ts` for new email user, returning user, logout, safe return path, and bootstrap retry
+**Checkpoint:** The app can honestly distinguish a supported URL/transcript from unsupported videos.
 
-**Checkpoint**: A learner can enter, authenticate, and see exactly one coherent next
-action without depending on XP, streak, flashcards, writing, or fifty-unit state.
+## Phase 4 — Live compiler, evidence validation, and atomic private persistence
 
----
+- [ ] T041 [US2] Port/adapt `src/features/real-talk/application/generate-private-lesson.ts`
+- [ ] T042 [US2] Port/adapt `src/features/real-talk/server/private-lesson-compiler.ts`
+- [ ] T043 [US2] Port/adapt `src/features/real-talk/server/gemini-lesson-provider.ts` and typed schema configuration
+- [ ] T044 [US2] Port/adapt lesson prompt contracts in `src/features/real-talk/domain/lesson-prompt.ts`; delimit transcript/source data and prohibit instruction override
+- [ ] T045 [US2] Port/adapt Zod generation contract/evidence validation under `src/lib/real-talk/generation-contract.ts` or its accepted destination
+- [ ] T046 [US2] Preserve stable failures for invalid JSON/schema, invented text, invalid timestamps, unsupported answers, transfer language, speaker uncertainty, provider failure, and rate limiting
+- [ ] T047 [US2] Authenticate before transcript, metadata, or Gemini work in `src/app/actions/real-talk.ts`; add ordering tests
+- [ ] T048 [US2] Preserve rate limiting in `src/app/actions/real-talk.ts` with user/IP-safe keys and actionable retry timing
+- [ ] T049 [US2] Port/adapt deterministic draft identity in `src/features/real-talk/domain/draft-identity.ts`
+- [ ] T050 [US2] Verify existing hosted atomic private-draft RPC/migrations against current generated types and `data-model.md`
+- [ ] T051 [US2] Port/adapt `src/features/real-talk/server/draft-repository.ts` and `draft-mapping.ts` for owner-private `ai_draft` persistence
+- [ ] T052 [US2] Ensure successful draft persistence stores source identity, selected window, adapter/mode/digest, actual model, warnings, owner, and private state
+- [ ] T053 [US2] Ensure failures create no partial video/lesson and repeated requests retain deterministic identity
+- [ ] T054 [P] [US2] Port/adapt focused tests: generation contract/result/action/provider/draft mapping/atomic migration/private RLS
+- [ ] T055 [US2] Add generation-progress UI states in `src/app/(main)/real-talk/create/page.tsx` or dashboard component: validating, transcript, selecting, generating, validating, saving, ready, failed
+- [ ] T056 [US2] Add visible `AI draft` and transcript uncertainty warnings to generation success and lesson entry
+- [ ] T057 [US2] After bounded secret authorization, run live Gemini success through the real compiler and record provider/model/schema/evidence result without logging the key
+- [ ] T058 [US2] Run live Gemini unavailable/rate-limit/invalid-output failure path and verify no partial persistence
 
-## Phase 3 — User Story 2: Reviewed learner catalog and source publication boundary
+**Checkpoint:** Supported URL produces one reloadable atomic owner-private lesson through live provider code.
 
-**Goal**: Learners see only database-backed, human-reviewed lessons.
+## Phase 5 — Private lesson runtime, progress, library, and return
 
-**Independent test**: Three reviewed public lessons plus private/unreviewed rows
-produce exactly three catalog items and no static fallback.
+- [ ] T059 [US3] Port/adapt the environment-first private preview components into the learner runtime without removing AI/transcript warnings
+- [ ] T060 [US3] Update `src/app/(main)/real-talk/[videoId]/page.tsx` to require owner access and load the persisted private lesson
+- [ ] T061 [US3] Render environment, roles, practical goal, source, AI-draft label, and warnings before activities
+- [ ] T062 [US3] Implement first encounter with official playback and no transcript/answer exposure by default
+- [ ] T063 [US3] Implement deterministic progressive support: replay/context → keyword → English evidence/chunking → concise Vietnamese guidance
+- [ ] T064 [US3] Implement source-backed productive retrieval/reconstruction without a permanently displayed answer
+- [ ] T065 [US3] Implement microphone-independent `speak_and_confirm` with no pronunciation score
+- [ ] T066 [US3] Implement changed-context transfer without persisting unrestricted learner response text
+- [ ] T067 [US3] Implement completion state machine requiring first listen, retrieval, speaking confirmation, and transfer
+- [ ] T068 [US3] Replace mastery/fluency/CEFR/pronunciation claims with immediate-practice language
+- [ ] T069 [P] [US3] Add component/domain tests under `src/__tests__/mvp-real-talk-runtime.test.tsx`
+- [ ] T070 [US4] Evaluate existing progress/evidence tables and record decision in `specs/002-mvp-product-convergence/attempt-storage-decision.md`
+- [ ] T071 [US4] If needed, add a versioned bounded `real_talk_attempts` migration with owner RLS, lesson-ownership constraint, completion gates, unique `(user_id, lesson_id)`, and no free-text columns
+- [ ] T072 [US4] Implement typed attempt repository/actions under `src/features/real-talk/domain/learner-attempt.ts`, `server/attempt-repository.ts`, and `src/app/actions/real-talk-attempt.ts`
+- [ ] T073 [US4] Restore safe checkpoints after reload without restoring hidden answers or forged completion
+- [ ] T074 [US4] Integrate `generate`, `continue`, `review`, and recent private lesson states into dashboard/private library
+- [ ] T075 [US4] Add hosted anonymous/ownerA/ownerB tests for draft and attempt read/write/approval/publication denial
+- [ ] T076 [US4] Add `e2e/mvp-private-lesson-return.spec.ts` for generate → reload → complete → logout/login → review and cross-user denial on desktop/mobile
 
-- [ ] T028 [US2] Port the accepted Real Talk domain/provenance/source-policy files listed in `port-manifest.md` into `src/features/real-talk/`, preserving their focused tests and adapting imports to current main
-- [ ] T029 [US2] Port or reimplement `src/features/real-talk/server/transcript-sources/supabase-reviewed.ts` and verify cue-digest, reviewer-independence, and production-policy checks on the integration branch
-- [ ] T030 [US2] Define provider-neutral source and playback contracts in `src/features/real-talk/domain/reviewed-source.ts` for `youtube_embed`, `direct_video`, and `external_link`
-- [ ] T031 [US2] Add a versioned provider-neutral Real Talk source migration under `supabase/migrations/`, including safe HTTPS constraints, provider/external identity, playback fields, compatibility handling for `youtube_id`, indexes, grants, and rollback notes
-- [ ] T032 [P] [US2] Add migration contract tests under `src/__tests__/real-talk-provider-neutral-source-migration.test.ts`
-- [ ] T033 [US2] Implement provider-neutral playback selection in `src/features/real-talk/server/playback-policy.ts` with unit tests for each allowed mode and unsafe references
-- [ ] T034 [US2] Adapt `src/components/real-talk/YouTubePlayer.tsx` into a reviewed-source player boundary under `src/features/real-talk/components/ReviewedSourcePlayer.tsx`; keep official playback and no download/re-host behavior
-- [ ] T035 [US2] Implement a database-only reviewed catalog repository in `src/features/real-talk/server/reviewed-catalog-repository.ts` that fails closed on unknown/unreviewed/publication state
-- [ ] T036 [US2] Replace `fetchCatalogVideos()` in `src/app/actions/real-talk.ts` with the reviewed catalog repository; remove all imports/merging from `src/lib/data/real-talk/videos.ts` in learner production paths
-- [ ] T037 [US2] Remove the learner-facing arbitrary-generation CTA and filters based on unreviewed static data from `src/components/real-talk/RealTalkHub.tsx`; show a reviewed small catalog or honest empty state
-- [ ] T038 [P] [US2] Keep `/real-talk/create` editor-only or disabled by updating `src/app/(main)/real-talk/create/page.tsx`, route policy, and navigation tests; ordinary learners must not discover it
-- [ ] T039 [US2] Select the initial environment and create three source-review packets under `specs/002-mvp-product-convergence/content/`, each naming canonical source, rights, complete context, bounded window, transcript, speaker/timing uncertainty, translation, safety, level, and transfer
-- [ ] T040 [US2] Obtain actual human review/sign-off for all three source packages and record reviewer identity/date/decision; automated or controlled test identities do not satisfy this task
-- [ ] T041 [US2] Create three final reviewed lesson packages under `specs/002-mvp-product-convergence/content/` and prove every learner-facing English/answer/timestamp/speaker/translation/guidance item traces to reviewed evidence
-- [ ] T042 [US2] Implement one controlled idempotent publication/seed operation under `scripts/` or an authorized server path, with explicit reviewer authorization, no ordinary-user publication ability, and rollback/cleanup support
-- [ ] T043 [US2] Add catalog contract/integration tests proving static fixtures, private drafts, unreviewed transcripts, incomplete review identity, and unsafe playback never appear
-- [ ] T044 [US2] After explicit owner authorization, apply the provider-neutral migration and controlled reviewed corpus operation to hosted Supabase; record migration IDs, row IDs, reviewer evidence, advisors, and rollback in `specs/002-mvp-product-convergence/content-publication-verification.md`
+**Checkpoint:** Owner can generate, learn, leave, return, and review; other users cannot discover the lesson.
 
-**Checkpoint**: The hosted catalog contains a tiny reviewed corpus and returns
-nothing that did not pass the human/source gate.
+## Phase 6 — Privacy-safe analytics, resilience, verification, and release gates
 
----
+- [ ] T077 [US5] Define allow-listed generation/lesson events in `src/features/mvp/domain/pilot-events.ts`
+- [ ] T078 [US5] Reuse/narrow `pilot_events` recording with bounded IDs/enums/counts only; forbid URL query data, transcript, learner text, audio, email, and secrets
+- [ ] T079 [US5] Add loading/empty/retry/offline/media-unavailable/auth-expired/transcript-failure/Gemini-failure/persistence-failure UI states
+- [ ] T080 [US5] Remove public/static catalog fallback from the MVP navigation/library path; fixtures remain test-only or explicitly demo-labelled
+- [ ] T081 [US5] Hide/defer legacy units, flashcards, grammar, writing, speaking tools, leaderboard, challenge, certificate, business, and notifications from primary navigation
+- [ ] T082 [P] [US5] Run `npm run audit` and `npm run inventory`; classify reachable legacy code without broad deletion
+- [ ] T083 [US5] Run full exact-head `npm run lint`
+- [ ] T084 [US5] Run full exact-head `npx tsc --noEmit`
+- [ ] T085 [US5] Run exact-head targeted Real Talk tests
+- [ ] T086 [US5] Run exact-head full unit suite
+- [ ] T087 [US5] Run exact-head content-standard suite
+- [ ] T088 [US5] Run exact-head hosted integration/RLS/atomic persistence tests
+- [ ] T089 [US5] Run exact-head production build
+- [ ] T090 [US5] Run controlled live transcript supported/unsupported matrix on final head
+- [ ] T091 [US5] Run controlled live Gemini success/failure matrix on final head
+- [ ] T092 [US5] Run desktop/mobile Playwright full journey on the production-built app
+- [ ] T093 [US5] Run Supabase security/performance advisors and resolve/document all MVP-relevant findings
+- [ ] T094 [US5] After explicit authorization, deploy `preview/mvp-youtube-to-lesson` to connected Vercel project
+- [ ] T095 [US5] Verify preview exact SHA, correct Supabase/Gemini environment, full supported URL journey, unsupported failure, return, and cross-user denial
+- [ ] T096 [US5] Inspect Vercel runtime errors/logs for the acceptance window and record deployment ID, routes, and result
+- [ ] T097 [US5] Update requirements checklist, `analysis.md`, PR body, evidence docs, rollback/cleanup, and unresolved blockers
+- [ ] T098 [US5] Obtain owner product acceptance of the exact preview and generated lesson experience
+- [ ] T099 [US5] Prepare a clean PR targeting `main` only after acceptance; rerun exact-head checks if the head changes
+- [ ] T100 [US5] Merge only after separate explicit owner authorization
+- [ ] T101 [US5] Deploy production only after separate explicit owner authorization
+- [ ] T102 [US5] Smoke-test production URL generation, private lesson ownership, runtime, persistence, and rollback readiness
 
-## Phase 4 — User Story 3: Natural communication lesson runtime
+## Definition of MVP Complete
 
-**Goal**: A learner completes one full natural communication loop with transfer.
-
-**Independent test**: Watching or answering recognition items cannot complete the
-lesson; retrieval, speech confirmation, and changed-context transfer are required.
-
-- [ ] T045 [US3] Port/adapt the accepted environment-first Real Talk runtime contracts and components into `src/features/real-talk/`, excluding static sample assumptions and editor-private warnings from the learner surface
-- [ ] T046 [US3] Implement a reviewed lesson loader in `src/features/real-talk/server/reviewed-lesson-repository.ts` that requires authenticated access and publication eligibility
-- [ ] T047 [US3] Update `src/app/(main)/real-talk/[videoId]/page.tsx` to use the reviewed lesson loader, shared MVP layout, not-found boundary, and provider-neutral player
-- [ ] T048 [P] [US3] Add an environment entry component under `src/features/real-talk/components/EnvironmentBriefing.tsx` showing setting, roles, relationship, and practical goal before language explanation
-- [ ] T049 [US3] Implement first encounter in `src/features/real-talk/components/FirstEncounter.tsx` with no transcript/answer exposure by default and a source-backed gist/intention task
-- [ ] T050 [US3] Implement deterministic progressive support in `src/features/real-talk/domain/support-level.ts` and `src/features/real-talk/components/ProgressiveSupport.tsx`: replay/context → keyword → English evidence → chunking → concise Vietnamese guidance
-- [ ] T051 [US3] Implement productive retrieval/reconstruction in `src/features/real-talk/components/RetrievalPractice.tsx`, ensuring the full answer is not permanently visible and every accepted target is source-backed
-- [ ] T052 [US3] Implement `speak_and_confirm` in `src/features/real-talk/components/SpeakAndConfirm.tsx` with microphone-independent fallback, no score, and explicit non-pronunciation copy
-- [ ] T053 [US3] Implement changed-context transfer in `src/features/real-talk/components/ChangedContextTransfer.tsx` without storing unrestricted learner response text
-- [ ] T054 [US3] Define and implement the completion state machine in `src/features/real-talk/domain/lesson-runtime.ts`; completion requires first listen, retrieval attempt, speaking confirmation, and transfer attempt
-- [ ] T055 [US3] Replace mastery/CEFR/fluency/pronunciation completion copy in the runtime with immediate-practice language and a retention disclaimer
-- [ ] T056 [P] [US3] Add unit/component tests under `src/__tests__/mvp-real-talk-runtime.test.tsx` for support fading, source evidence, microphone fallback, transfer gate, and honest copy
-- [ ] T057 [US3] Add an unauthenticated/direct-link/not-found/media-unavailable/error matrix for the reviewed lesson route and components
-
-**Checkpoint**: One reviewed lesson is pedagogically and technically complete under
-the MVP contract, independent of legacy lesson and gamification systems.
-
----
-
-## Phase 5 — User Story 4: Bounded progress, continuation, and return
-
-**Goal**: An authenticated learner can leave and return without losing safe state.
-
-**Independent test**: Start → reload → complete → logout/login → dashboard state
-works, while another user cannot access the attempt.
-
-- [ ] T058 [US4] Evaluate `user_v2_lesson_progress` and `lesson_v2_evidence` against `data-model.md`; record the accept/reject decision in `specs/002-mvp-product-convergence/attempt-storage-decision.md`
-- [ ] T059 [US4] If existing storage is insufficient, add a versioned bounded `real_talk_attempts` migration under `supabase/migrations/` with completion constraints, unique `(user_id, lesson_id)`, ownership RLS, grants, indexes, and no free-text columns
-- [ ] T060 [P] [US4] Add SQL and generated-type contract tests under `src/__tests__/mvp-real-talk-attempt-migration.test.ts`
-- [ ] T061 [US4] Define typed attempt/checkpoint results in `src/features/real-talk/domain/learner-attempt.ts`
-- [ ] T062 [US4] Implement idempotent owner-derived attempt persistence in `src/features/real-talk/server/attempt-repository.ts`; do not trust client user IDs or completion flags
-- [ ] T063 [US4] Add thin server actions under `src/app/actions/real-talk-attempt.ts` for start/checkpoint/complete and validate every payload with Zod
-- [ ] T064 [US4] Restore a safe lesson checkpoint after reload without restoring answer exposure or claiming completion prematurely
-- [ ] T065 [US4] Integrate attempt state into `src/features/mvp/server/dashboard-repository.ts` so the primary action is `start`, `continue`, or `review`
-- [ ] T066 [P] [US4] Add repository/action unit tests for retry idempotency, invalid checkpoint, forged completion, and persistence failure
-- [ ] T067 [US4] After explicit owner authorization, apply the selected attempt migration to hosted Supabase and regenerate `src/types/supabase.ts`
-- [ ] T068 [US4] Run hosted anonymous/ownerA/ownerB tests proving owner read/write, cross-user denial, forged completion rejection, and cleanup; record in `specs/002-mvp-product-convergence/hosted-attempt-verification.md`
-- [ ] T069 [US4] Add `e2e/mvp-lesson-return.spec.ts` covering reload, logout/login, continue, complete, and review state on desktop and mobile
-
-**Checkpoint**: Learner progress survives sessions, is private, bounded, and not
-coupled to XP or raw learner content.
-
----
-
-## Phase 6 — User Story 5: Pilot instrumentation, resilience, and product pruning
-
-**Goal**: The owner can run a small, observable pilot without exposing the old
-product as the MVP.
-
-**Independent test**: The full preview journey records only allowed events and
-survives key auth/media/database failure states.
-
-- [ ] T070 [US5] Define the bounded MVP event taxonomy in `src/features/mvp/domain/pilot-events.ts` with an exhaustive allow-list and forbidden free-text fields
-- [ ] T071 [US5] Reuse/adapt existing `pilot_events` client/server recording through `src/features/mvp/server/pilot-event-repository.ts` and focused actions; do not create a second analytics platform
-- [ ] T072 [P] [US5] Instrument landing, auth, dashboard, lesson start, first listen, support, retrieval, speech confirmation, transfer, completion, and return without answer/audio/transcript payloads
-- [ ] T073 [P] [US5] Add analytics contract tests proving unknown events and forbidden/unbounded payload fields are rejected
-- [ ] T074 [US5] Add focused loading, empty, database failure, auth expiry, media unavailable, and offline/retry states to the MVP shell and lesson runtime
-- [ ] T075 [US5] Audit every primary navigation, landing CTA, dashboard action, command palette, mobile drawer, sitemap, and internal promotion so deferred routes are absent from the MVP story; record decisions in `specs/002-mvp-product-convergence/deferred-route-audit.md`
-- [ ] T076 [US5] Guard, redirect, or feature-flag deferred routes that still create a critical product contradiction; do not broadly delete or rewrite them in this spec
-- [ ] T077 [P] [US5] Review and retire test-only Supabase Edge Functions (`spec001-*`) after explicit owner authorization; preserve the real `real-talk-transcript-review` function and record final inventory
-- [ ] T078 [US5] Run Supabase security/performance advisors after all authorized DDL and resolve every new MVP-related finding
-- [ ] T079 [US5] Verify Vercel/Supabase environment equivalence without exposing values and record variable-name coverage in `specs/002-mvp-product-convergence/environment-verification.md`
-
-**Checkpoint**: The MVP is observable, fails honestly, and no deferred feature is
-presented as part of the core value proposition.
-
----
-
-## Phase 7 — Cross-cutting verification, preview, convergence, and release gates
-
-**Purpose**: Prove the exact final state. No mock substitutes for a required
-hosted, browser, human, or owner check.
-
-- [ ] T080 Run `npm ci --no-audit --prefer-offline` on a clean exact-head checkout using the main toolchain and lockfile
-- [ ] T081 Run `npm run lint` on the exact final head
-- [ ] T082 Run `npx tsc --noEmit` on the exact final head
-- [ ] T083 Run the focused MVP auth, catalog, runtime, attempt, analytics, migration, policy, and RLS contract suites
-- [ ] T084 Run `npm run test` and record file/test counts
-- [ ] T085 Run `npm run test:content-standard`
-- [ ] T086 Run applicable hosted integration suites against `zpiwddskhduuykpxltun` with bounded test identities and mandatory cleanup
-- [ ] T087 Run `npm run build` and record the complete Next.js route output; no deferred route may be mistaken for MVP scope merely because it builds
-- [ ] T088 Run desktop and mobile accessibility smoke for landing, auth, dashboard, catalog, lesson, and account shell
-- [ ] T089 Run the full authenticated MVP Playwright journey on Desktop Chrome and Pixel/mobile-equivalent against a production build, including logout/login return
-- [ ] T090 Confirm no uncaught page error, Next.js overlay, horizontal overflow, unreviewed static lesson, editor-generation CTA, or unsupported learning claim appears
-- [ ] T091 Confirm all three human-reviewed source/lesson packages remain accessible and match the published database rows and cue digests
-- [ ] T092 Update `specs/002-mvp-product-convergence/analysis.md` with final requirement-to-implementation-to-evidence mapping and resolve all critical findings
-- [ ] T093 Update `specs/002-mvp-product-convergence/checklists/requirements.md` from observed evidence; keep owner-gated items unchecked until authorized
-- [ ] T094 Obtain explicit owner authorization for one intentional Vercel preview branch `preview/mvp-product-convergence`
-- [ ] T095 Deploy the exact verified head to the connected Vercel `atoenglish` preview and record deployment ID, URL reference, commit SHA, and environment in `specs/002-mvp-product-convergence/preview-verification.md`
-- [ ] T096 Repeat the full desktop/mobile journey on the actual Vercel preview against hosted Supabase
-- [ ] T097 Inspect Vercel runtime error clusters/logs and Supabase auth/API/Postgres logs for the acceptance window; resolve critical MVP errors
-- [ ] T098 Present the preview, reviewed corpus, deferred scope, known limitations, rollback, and evidence to the owner for product acceptance
-- [ ] T099 Record the owner's decision in `specs/002-mvp-product-convergence/owner-acceptance.md`; rejection or requested changes keep the spec unconverged
-- [ ] T100 After acceptance, prepare a clean PR targeting `main` with exact task/evidence status and no automatic merge or deployment
-- [ ] T101 Rerun exact-head gates if the main-targeted PR head changes during reconciliation
-- [ ] T102 Obtain separate explicit authorization before merging to `main`
-- [ ] T103 After merge, obtain separate explicit authorization before production deployment
-- [ ] T104 If production deployment is authorized, deploy the exact merged commit, run production smoke, inspect runtime logs, and record rollback information; otherwise leave production untouched
-
----
-
-## MVP Convergence Rule
-
-The MVP is converged only when:
-
-1. T001–T099 required work is checked from observed evidence;
-2. three human-reviewed lessons in one environment are public and traceable;
-3. the complete learner journey passes on hosted desktop and mobile preview;
-4. database ownership/privacy and bounded persistence are verified;
-5. no static/unreviewed lesson or editor-generation control is learner-facing;
-6. cross-artifact analysis has no unresolved critical conflict;
-7. the owner explicitly accepts the exact preview state.
-
-T100–T104 are release operations, not implied by convergence. Merge and production
-deployment remain separate owner decisions.
+MVP is complete only when a real authenticated user can paste a supported YouTube
+URL, generate a validated owner-private lesson through live provider code, complete
+the transfer-gated lesson, return to it later, and pass cross-user/desktop/mobile
+hosted verification. No successful test authorizes merge or production deployment.


### PR DESCRIPTION
## Owner correction and implementation authorization

The core AtoEnglish idea remains:

```text
Paste a supported YouTube URL
→ generate an owner-private personal English lesson
→ learn, save, and return
```

The earlier planning version incorrectly replaced this with a fixed reviewed catalog. The specification now makes URL generation the primary learner action.

On 2026-08-03, the owner explicitly instructed **“triển khai đi”**. This authorizes implementation work on a fresh branch from `main`. It does **not** authorize merging PR #54 wholesale, applying hosted migrations without a task-specific gate, merging to `main`, or deploying production.

## Corrected MVP

```text
truthful YouTube-to-lesson landing
→ signup/login
→ URL-first dashboard
→ YouTube source validation
→ timed English transcript acquisition
→ bounded interaction selection
→ live Gemini structured generation
→ source-evidence validation
→ atomic owner-private ai_draft
→ first listen / progressive support / retrieval
→ speak-and-confirm
→ changed-context transfer
→ bounded progress
→ private library and return
```

Generated lessons remain private AI drafts with visible transcript/acquisition warnings. Human review is required only before later public sharing or catalog publication.

## Implementation branch

```text
integration/mvp-youtube-to-lesson
base: main @ 961e779886ff95b1b5f67d5e6997520d1facdb1a
```

Implementation uses a file-level selective-port manifest. PR #54 remains an evidence/source branch and will not be merged wholesale.

## Current boundaries

- runtime implementation: authorized
- repository tests/CI: authorized
- hosted read-only verification: authorized
- hosted DDL/data writes: only when an explicit task gate is reached and recorded
- Vercel preview: not yet authorized
- merge to `main`: not authorized
- production deployment: not authorized

This PR remains the draft planning review. Implementation will be tracked separately from the fresh-main integration branch.