### PR TITLE
Integrate Nếp vertical slice with learning evidence

### DIFF
--- a/docs/nep/PRODUCT_CONTRACT_V1.md
+++ b/docs/nep/PRODUCT_CONTRACT_V1.md
@@ -1,0 +1,92 @@
+# Nếp Product Contract V1
+
+Status: preview contract. Evidence-backed constraints, not an efficacy claim.
+
+## Product job
+
+Nếp helps a Vietnamese false beginner build **usable communicative capability** through short guided missions. The learner-facing unit is a real communicative job, not a grammar chapter or vocabulary list.
+
+## Primary loop
+
+`context → comprehend → notice → attempt-before-reveal → produce → feedback → self-repair → retry → changed-context transfer → delayed review`
+
+## Progress model
+
+Progress is evidence collected across separate channels:
+
+- comprehension
+- retrieval
+- production
+- repair
+- transfer
+- retention
+
+Finishing a screen or unit is not mastery. Immediate supported success is not delayed retention.
+
+## V1 capability graph
+
+1. Greet and end a short interaction.
+2. Introduce yourself.
+3. Ask for repetition or clarification.
+4. Confirm what you understood.
+5. Ask for simple personal/context information.
+6. Answer simple personal/context information.
+7. Express a simple need or problem.
+8. Sustain and repair a short real interaction.
+
+The graph is compiled into product artifacts. Grammar, vocabulary and pronunciation sit beneath capabilities as constraints/resources; they are not the learner-facing course spine.
+
+## Non-goals
+
+Nếp V1 is not:
+
+- a grammar catalog;
+- an Oxford-wordlist browser;
+- a generic AI chatbot;
+- a lesson-completion game;
+- an acoustic pronunciation scorer unless the app actually analyses audio with a validated method;
+- a CEFR certification system;
+- proof that the integrated Nếp Method is effective.
+
+## Evidence governance
+
+Every buildable lesson declares:
+
+- capability ID and prerequisites;
+- evidence principle IDs and claim IDs;
+- whether a rule is `source_derived` or `product_inference`;
+- the response modality required by the capability;
+- review targets and evidence channels produced;
+- the exact capability target, persisted evidence type, evaluator and context for every evaluated action.
+
+Generated lesson content is product content, not research evidence.
+
+For this preview the key source-derived constraints are:
+
+- PRN-003 — attempt before reveal for retrieval;
+- PRN-050, PRN-054, PRN-058 — bounded speaking, response demand matched to the claim, then self-repair;
+- PRN-040, PRN-045, PRN-056 — changed-context production is required before calling evidence transfer;
+- PRN-016, PRN-018 — Vietnamese support is strategic and its use must remain distinguishable from independent English performance;
+- PRN-001, PRN-002 — capability evidence is separated from completion.
+
+## Product-inference constraints for V1
+
+These are engineering/content rules to test, not research conclusions:
+
+- a preview lesson may introduce at most 6 new chunks/items;
+- hard QA rejects a speaking lesson with no observable speech path;
+- text input may be offered as an accessibility/debug fallback, but cannot produce `production` or `transfer` speaking evidence;
+- deterministic transcript feedback may check target language coverage, but must never be labelled pronunciation scoring;
+- retry after an answer-bearing reveal is stored as an attempt but is not promoted to independent mastery evidence;
+- raw learner speech transcripts are not persisted by the Nếp adapter; only derived evaluation metadata is stored;
+- lesson content that looks textbook-like is a warning for editorial review, not an automatic evidence failure.
+
+## First vertical slice
+
+Capability: `CAP-002 Introduce yourself`, with `CAP-003 Ask for repetition` embedded as a repair move.
+
+Mission: meet a new colleague, say your name, spell it when needed, ask for repetition when you miss a turn, then perform the same capability under a changed prompt/order.
+
+The evaluated actions map explicitly to the learning core: comprehension choice → `recognition/CAP-002`; retrieval → `retrieval/CAP-002`; first independent response → `production/CAP-002`; repair move → `repair/CAP-003`; supported retry → attempt-only; changed situation → `transfer/CAP-002`.
+
+Success is not “lesson complete”. The preview records whether the learner independently attempted retrieval, produced an oral response, repaired after feedback, and handled the changed situation. Anonymous preview use remains local-only; authenticated use can persist through the canonical `recordLearningAttempt` server boundary.

--- a/src/app/data-preview/page.tsx
+++ b/src/app/data-preview/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { DataDrivenPreview } from "@/features/data-driven-preview/DataDrivenPreview";
+
+export const metadata: Metadata = {
+  title: "Nếp Capability Preview — AtoEnglish",
+  description: "Vertical slice thử nghiệm capability-first: retrieval, speaking, repair, transfer và review evidence.",
+  robots: { index: false, follow: false },
+};
+
+export default function DataPreviewPage() {
+  return <DataDrivenPreview />;
+}

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -71,11 +71,17 @@ export function DataDrivenPreview() {
   const [evidence, setEvidence] = useState<EvidenceState>(initialEvidence);
   const [persistenceState, setPersistenceState] = useState<PersistenceState>("idle");
   const attemptStartedAt = useRef(Date.now());
+  const lastSubmissionKey = useRef<string | null>(null);
 
   const action = lesson.actions[step];
   const progress = Math.round(((step + 1) / lesson.actions.length) * 100);
   const speechAvailable = typeof window !== "undefined" && recognitionCtor() !== null;
   const persistedLabel = persistenceLabel(persistenceState);
+
+  const markResponseChanged = () => {
+    lastSubmissionKey.current = null;
+    setPersistenceState("idle");
+  };
 
   const resetAttempt = () => {
     setAnswer("");
@@ -83,6 +89,7 @@ export function DataDrivenPreview() {
     setFeedback(null);
     setSupportUsed(false);
     setPersistenceState("idle");
+    lastSubmissionKey.current = null;
     attemptStartedAt.current = Date.now();
   };
 
@@ -101,7 +108,7 @@ export function DataDrivenPreview() {
       setAnswerSource("speech");
       setListening(false);
       setFeedback(null);
-      setPersistenceState("idle");
+      markResponseChanged();
     };
     recognition.onerror = () => { setListening(false); setFeedback("Không lấy được transcript. Thử lại hoặc dùng text fallback; fallback không tạo speaking evidence."); };
     recognition.onend = () => setListening(false);
@@ -110,6 +117,9 @@ export function DataDrivenPreview() {
   };
 
   const persistEvaluation = async (correct: boolean) => {
+    const submissionKey = `${action.id}|${answerSource ?? "none"}|${answer.trim()}`;
+    if (lastSubmissionKey.current === submissionKey) return;
+
     const record = toLearningAttemptRecord({
       lesson,
       action,
@@ -121,6 +131,7 @@ export function DataDrivenPreview() {
     });
     if (!record) return;
 
+    lastSubmissionKey.current = submissionKey;
     setPersistenceState("saving");
     const result = await recordLearningAttempt(record);
     if (result.success) {
@@ -128,7 +139,12 @@ export function DataDrivenPreview() {
       return;
     }
     const error = "error" in result ? result.error : "";
-    setPersistenceState(error.includes("đăng nhập") ? "local-only" : "error");
+    if (error.includes("đăng nhập")) {
+      setPersistenceState("local-only");
+      return;
+    }
+    lastSubmissionKey.current = null;
+    setPersistenceState("error");
   };
 
   const evaluate = async () => {
@@ -233,11 +249,11 @@ export function DataDrivenPreview() {
             {action.prompt && <div className="mb-5 rounded-2xl bg-[#f5f3ec] p-5"><p className="text-xs font-bold uppercase tracking-[.18em] text-black/35">Prompt</p><p className="mt-2 text-xl font-medium">{action.prompt}</p></div>}
 
             {action.kind === "comprehend" ? (
-              <div className="grid gap-3 sm:grid-cols-3">{["name", "job", "country"].map((choice) => <button key={choice} type="button" onClick={() => { setAnswer(choice); setAnswerSource("text"); setFeedback(null); setPersistenceState("idle"); }} className={`rounded-2xl border px-4 py-4 text-left font-semibold ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10"}`}>{choice}</button>)}</div>
+              <div className="grid gap-3 sm:grid-cols-3">{["name", "job", "country"].map((choice) => <button key={choice} type="button" onClick={() => { setAnswer(choice); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} className={`rounded-2xl border px-4 py-4 text-left font-semibold ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10"}`}>{choice}</button>)}</div>
             ) : action.modality === "speech" ? (
               <>
                 <div className="flex flex-wrap gap-3"><button type="button" onClick={startSpeech} disabled={listening || persistenceState === "saving"} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>{!speechAvailable && <span className="flex items-center gap-2 text-xs text-[#8a5b00]"><CircleAlert className="size-4" /> Browser không hỗ trợ speech recognition</span>}</div>
-                <textarea value={answer} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); setPersistenceState("idle"); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60" />
+                <textarea value={answer} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60" />
                 <div className="mt-3 flex flex-wrap gap-2"><button type="button" onClick={evaluate} disabled={!answer || answerSource !== "speech" || persistenceState === "saving"} className="rounded-full bg-[#2d6a4f] px-4 py-2 text-xs font-bold text-white disabled:opacity-30">Đánh giá speech transcript</button><button type="button" onClick={evaluate} disabled={!answer || persistenceState === "saving"} className="rounded-full border border-black/10 px-4 py-2 text-xs font-bold text-black/55 disabled:opacity-30">Text fallback</button></div>
               </>
             ) : null}

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -77,8 +77,10 @@ export function DataDrivenPreview() {
   const progress = Math.round(((step + 1) / lesson.actions.length) * 100);
   const speechAvailable = typeof window !== "undefined" && recognitionCtor() !== null;
   const persistedLabel = persistenceLabel(persistenceState);
+  const saving = persistenceState === "saving";
 
   const markResponseChanged = () => {
+    if (lastSubmissionKey.current !== null) attemptStartedAt.current = Date.now();
     lastSubmissionKey.current = null;
     setPersistenceState("idle");
   };
@@ -93,12 +95,24 @@ export function DataDrivenPreview() {
     attemptStartedAt.current = Date.now();
   };
 
+  const toggleSupport = () => {
+    if (saving) return;
+    if (lastSubmissionKey.current !== null) attemptStartedAt.current = Date.now();
+    lastSubmissionKey.current = null;
+    setPersistenceState("idle");
+    setSupportUsed((value) => !value);
+  };
+
   const startSpeech = () => {
     const Recognition = recognitionCtor();
     if (!Recognition) {
       setFeedback("Browser này không có speech recognition. Text fallback chỉ demo flow và không được tính speaking evidence.");
       return;
     }
+    if (lastSubmissionKey.current !== null) attemptStartedAt.current = Date.now();
+    lastSubmissionKey.current = null;
+    setPersistenceState("idle");
+
     const recognition = new Recognition();
     recognition.lang = "en-US";
     recognition.interimResults = false;
@@ -117,7 +131,7 @@ export function DataDrivenPreview() {
   };
 
   const persistEvaluation = async (correct: boolean) => {
-    const submissionKey = `${action.id}|${answerSource ?? "none"}|${answer.trim()}`;
+    const submissionKey = `${action.id}|${answerSource ?? "none"}|support:${supportUsed ? 1 : 0}|${answer.trim()}`;
     if (lastSubmissionKey.current === submissionKey) return;
 
     const record = toLearningAttemptRecord({
@@ -148,7 +162,7 @@ export function DataDrivenPreview() {
   };
 
   const evaluate = async () => {
-    if (persistenceState === "saving") return;
+    if (saving) return;
 
     const ok = evaluateNếpActionResponse(action, answer);
     if (action.kind === "comprehend") {
@@ -249,23 +263,23 @@ export function DataDrivenPreview() {
             {action.prompt && <div className="mb-5 rounded-2xl bg-[#f5f3ec] p-5"><p className="text-xs font-bold uppercase tracking-[.18em] text-black/35">Prompt</p><p className="mt-2 text-xl font-medium">{action.prompt}</p></div>}
 
             {action.kind === "comprehend" ? (
-              <div className="grid gap-3 sm:grid-cols-3">{["name", "job", "country"].map((choice) => <button key={choice} type="button" onClick={() => { setAnswer(choice); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} className={`rounded-2xl border px-4 py-4 text-left font-semibold ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10"}`}>{choice}</button>)}</div>
+              <div className="grid gap-3 sm:grid-cols-3">{["name", "job", "country"].map((choice) => <button key={choice} type="button" disabled={saving} onClick={() => { setAnswer(choice); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} className={`rounded-2xl border px-4 py-4 text-left font-semibold disabled:opacity-40 ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10"}`}>{choice}</button>)}</div>
             ) : action.modality === "speech" ? (
               <>
-                <div className="flex flex-wrap gap-3"><button type="button" onClick={startSpeech} disabled={listening || persistenceState === "saving"} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>{!speechAvailable && <span className="flex items-center gap-2 text-xs text-[#8a5b00]"><CircleAlert className="size-4" /> Browser không hỗ trợ speech recognition</span>}</div>
-                <textarea value={answer} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60" />
-                <div className="mt-3 flex flex-wrap gap-2"><button type="button" onClick={evaluate} disabled={!answer || answerSource !== "speech" || persistenceState === "saving"} className="rounded-full bg-[#2d6a4f] px-4 py-2 text-xs font-bold text-white disabled:opacity-30">Đánh giá speech transcript</button><button type="button" onClick={evaluate} disabled={!answer || persistenceState === "saving"} className="rounded-full border border-black/10 px-4 py-2 text-xs font-bold text-black/55 disabled:opacity-30">Text fallback</button></div>
+                <div className="flex flex-wrap gap-3"><button type="button" onClick={startSpeech} disabled={listening || saving} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>{!speechAvailable && <span className="flex items-center gap-2 text-xs text-[#8a5b00]"><CircleAlert className="size-4" /> Browser không hỗ trợ speech recognition</span>}</div>
+                <textarea value={answer} disabled={saving} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); markResponseChanged(); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60 disabled:opacity-50" />
+                <div className="mt-3 flex flex-wrap gap-2"><button type="button" onClick={evaluate} disabled={!answer || answerSource !== "speech" || saving} className="rounded-full bg-[#2d6a4f] px-4 py-2 text-xs font-bold text-white disabled:opacity-30">Đánh giá speech transcript</button><button type="button" onClick={evaluate} disabled={!answer || saving} className="rounded-full border border-black/10 px-4 py-2 text-xs font-bold text-black/55 disabled:opacity-30">Text fallback</button></div>
               </>
             ) : null}
 
-            {action.kind === "comprehend" && <button type="button" onClick={evaluate} disabled={!answer || persistenceState === "saving"} className="mt-4 rounded-full bg-[#171713] px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-30">Kiểm tra</button>}
-            {action.supportVi && <div className="mt-5 border-t border-black/[0.07] pt-5"><button type="button" onClick={() => setSupportUsed((value) => !value)} className="text-sm font-semibold text-black/45">{supportUsed ? "Ẩn hỗ trợ" : "Xem hỗ trợ tiếng Việt"}</button>{supportUsed && <p className="mt-2 text-sm leading-6 text-black/55">{action.supportVi}</p>}</div>}
+            {action.kind === "comprehend" && <button type="button" onClick={evaluate} disabled={!answer || saving} className="mt-4 rounded-full bg-[#171713] px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-30">Kiểm tra</button>}
+            {action.supportVi && <div className="mt-5 border-t border-black/[0.07] pt-5"><button type="button" disabled={saving} onClick={toggleSupport} className="text-sm font-semibold text-black/45 disabled:opacity-40">{supportUsed ? "Ẩn hỗ trợ" : "Xem hỗ trợ tiếng Việt"}</button>{supportUsed && <p className="mt-2 text-sm leading-6 text-black/55">{action.supportVi}</p>}</div>}
             {feedback && <div className="mt-5 flex gap-3 rounded-2xl bg-[#fff7e6] p-4 text-sm leading-6"><CircleAlert className="mt-0.5 size-4 shrink-0 text-[#8a5b00]" /><p>{feedback}</p></div>}
             {persistedLabel && <p className="mt-3 text-xs leading-5 text-black/40">{persistedLabel}</p>}
           </div>
 
           <div className="mt-6 grid grid-cols-5 gap-2">{(Object.keys(evidence) as EvidenceKey[]).map((key) => <div key={key} className={`rounded-xl border px-2 py-2 text-center text-[10px] font-bold uppercase tracking-wide ${evidence[key] ? "border-[#2d6a4f]/30 bg-[#edf5ef] text-[#24583f]" : "border-black/[0.07] text-black/25"}`}>{key}</div>)}</div>
-          <div className="mt-8 flex items-center justify-between"><button type="button" onClick={() => { setStep((value) => Math.max(0, value - 1)); resetAttempt(); }} disabled={step === 0 || persistenceState === "saving"} className="rounded-full px-4 py-3 text-sm font-semibold text-black/45 disabled:opacity-20"><RefreshCw className="mr-2 inline size-3" />Quay lại</button><button type="button" onClick={next} disabled={persistenceState === "saving"} className="flex items-center gap-2 rounded-full bg-[#2d6a4f] px-6 py-3 text-sm font-semibold text-white disabled:opacity-40">{step === lesson.actions.length - 1 ? "Kết thúc slice" : "Tiếp theo"}<ArrowRight className="size-4" /></button></div>
+          <div className="mt-8 flex items-center justify-between"><button type="button" onClick={() => { setStep((value) => Math.max(0, value - 1)); resetAttempt(); }} disabled={step === 0 || saving} className="rounded-full px-4 py-3 text-sm font-semibold text-black/45 disabled:opacity-20"><RefreshCw className="mr-2 inline size-3" />Quay lại</button><button type="button" onClick={next} disabled={saving} className="flex items-center gap-2 rounded-full bg-[#2d6a4f] px-6 py-3 text-sm font-semibold text-white disabled:opacity-40">{step === lesson.actions.length - 1 ? "Kết thúc slice" : "Tiếp theo"}<ArrowRight className="size-4" /></button></div>
         </section>
 
         <footer className="pb-4 text-center text-[11px] leading-5 text-black/35"><Headphones className="mr-1 inline size-3" /> Transcript feedback ≠ pronunciation score. Raw transcript không được persist. Text fallback ≠ speaking evidence.{supportUsed && " Vietnamese support usage is tracked separately."}</footer>

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, CircleAlert, Headphones, Mic2, RefreshCw, ShieldCheck, Sparkles, Target, Volume2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+import { recordLearningAttempt } from "@/app/actions/learning-evidence";
+import { capabilityGraphV1 } from "@/lib/nep/capabilities.v1";
+import { firstMeetingLessonV1, qaLesson } from "@/lib/nep/lesson-contract";
+import { toLearningAttemptRecord } from "@/lib/nep/learning-evidence-adapter";
+
+type EvidenceKey = "comprehension" | "retrieval" | "production" | "repair" | "transfer";
+type EvidenceState = Record<EvidenceKey, boolean>;
+type PersistenceState = "idle" | "saving" | "evidence-saved" | "attempt-saved" | "local-only" | "error";
+type RecognitionCtor = new () => {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  start: () => void;
+  onresult: ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null;
+  onerror: (() => void) | null;
+  onend: (() => void) | null;
+};
+
+const initialEvidence: EvidenceState = { comprehension: false, retrieval: false, production: false, repair: false, transfer: false };
+const clean = (value: string) => value.toLowerCase().replace(/[’']/g, "'").replace(/[^a-z0-9' -]/g, " ").replace(/\s+/g, " ").trim();
+const hasAny = (text: string, signals: string[]) => signals.some((signal) => clean(text).includes(clean(signal)));
+
+function speak(text: string) {
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+  window.speechSynthesis.cancel();
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = "en-US";
+  utterance.rate = 0.88;
+  window.speechSynthesis.speak(utterance);
+}
+
+function recognitionCtor(): RecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const browserWindow = window as unknown as { SpeechRecognition?: RecognitionCtor; webkitSpeechRecognition?: RecognitionCtor };
+  return browserWindow.SpeechRecognition ?? browserWindow.webkitSpeechRecognition ?? null;
+}
+
+function evidenceKeyForAction(kind: string): EvidenceKey | null {
+  if (kind === "comprehend") return "comprehension";
+  if (kind === "retrieve") return "retrieval";
+  if (kind === "produce") return "production";
+  if (kind === "repair") return "repair";
+  if (kind === "transfer") return "transfer";
+  return null;
+}
+
+function persistenceLabel(state: PersistenceState) {
+  if (state === "saving") return "Đang lưu learning event…";
+  if (state === "evidence-saved") return "Attempt + evidence đã được lưu vào learner model.";
+  if (state === "attempt-saved") return "Attempt đã được lưu; lần này không tạo mastery evidence.";
+  if (state === "local-only") return "Preview công khai: kết quả đang chỉ giữ trong phiên này.";
+  if (state === "error") return "Flow vẫn tiếp tục, nhưng learning event chưa lưu được.";
+  return null;
+}
+
+export function DataDrivenPreview() {
+  const lesson = firstMeetingLessonV1;
+  const capability = capabilityGraphV1.find((item) => item.id === lesson.capabilityId)!;
+  const qaErrors = useMemo(() => qaLesson(lesson).filter((issue) => issue.severity === "error"), [lesson]);
+  const [active, setActive] = useState(false);
+  const [step, setStep] = useState(0);
+  const [answer, setAnswer] = useState("");
+  const [answerSource, setAnswerSource] = useState<"speech" | "text" | null>(null);
+  const [listening, setListening] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [supportUsed, setSupportUsed] = useState(false);
+  const [evidence, setEvidence] = useState<EvidenceState>(initialEvidence);
+  const [persistenceState, setPersistenceState] = useState<PersistenceState>("idle");
+  const attemptStartedAt = useRef(Date.now());
+
+  const action = lesson.actions[step];
+  const progress = Math.round(((step + 1) / lesson.actions.length) * 100);
+  const speechAvailable = typeof window !== "undefined" && recognitionCtor() !== null;
+  const persistedLabel = persistenceLabel(persistenceState);
+
+  const resetAttempt = () => {
+    setAnswer("");
+    setAnswerSource(null);
+    setFeedback(null);
+    setSupportUsed(false);
+    setPersistenceState("idle");
+    attemptStartedAt.current = Date.now();
+  };
+
+  const startSpeech = () => {
+    const Recognition = recognitionCtor();
+    if (!Recognition) {
+      setFeedback("Browser này không có speech recognition. Text fallback chỉ demo flow và không được tính speaking evidence.");
+      return;
+    }
+    const recognition = new Recognition();
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.continuous = false;
+    recognition.onresult = (event) => {
+      setAnswer(event.results[0]?.[0]?.transcript ?? "");
+      setAnswerSource("speech");
+      setListening(false);
+      setFeedback(null);
+      setPersistenceState("idle");
+    };
+    recognition.onerror = () => { setListening(false); setFeedback("Không lấy được transcript. Thử lại hoặc dùng text fallback; fallback không tạo speaking evidence."); };
+    recognition.onend = () => setListening(false);
+    setListening(true);
+    recognition.start();
+  };
+
+  const persistEvaluation = async (correct: boolean) => {
+    const record = toLearningAttemptRecord({
+      lesson,
+      action,
+      response: answer,
+      responseSource: answerSource,
+      correct,
+      supportUsed,
+      latencyMs: Date.now() - attemptStartedAt.current,
+    });
+    if (!record) return;
+
+    setPersistenceState("saving");
+    const result = await recordLearningAttempt(record);
+    if (result.success) {
+      setPersistenceState(result.evidenceRecorded ? "evidence-saved" : "attempt-saved");
+      return;
+    }
+    const error = "error" in result ? result.error : "";
+    setPersistenceState(error.includes("đăng nhập") ? "local-only" : "error");
+  };
+
+  const evaluate = async () => {
+    if (persistenceState === "saving") return;
+
+    if (action.kind === "comprehend") {
+      const ok = clean(answer) === "name";
+      setEvidence((current) => ({ ...current, comprehension: ok }));
+      setFeedback(ok ? "Đúng: Maya đang hỏi tên." : "Chưa đúng. Câu hỏi đang cần một thông tin cá nhân cụ thể.");
+      await persistEvaluation(ok);
+      return;
+    }
+
+    const ok = hasAny(answer, action.targetSignals ?? []);
+    const channel = evidenceKeyForAction(action.kind);
+    const observedSpeech = answerSource === "speech";
+    const canShowEvidence = channel && observedSpeech && ok && (channel !== "transfer" || evidence.production);
+
+    if (canShowEvidence && channel) {
+      setEvidence((current) => ({ ...current, [channel]: true }));
+    }
+
+    if (channel && answerSource !== "speech") {
+      setFeedback(ok ? "Text có target language, nhưng không cộng speaking evidence vì không có oral response quan sát được." : "Text chưa có target language cần thiết. Đây không phải pronunciation feedback.");
+      await persistEvaluation(ok);
+      return;
+    }
+
+    if (channel === "transfer" && ok && !evidence.production) {
+      setFeedback("Transcript có target language, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
+      await persistEvaluation(ok);
+      return;
+    }
+
+    setFeedback(ok ? "Transcript có target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm." : "Transcript chưa cho thấy target language cần thiết. Tự sửa một điểm rồi thử lại.");
+    await persistEvaluation(ok);
+  };
+
+  const next = () => {
+    if (step < lesson.actions.length - 1) { setStep((value) => value + 1); resetAttempt(); return; }
+    setActive(false);
+  };
+
+  if (!active) {
+    return (
+      <main className="min-h-screen bg-[#f5f3ec] text-[#171713]">
+        <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-14">
+          <div className="mb-10 flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#2d6a4f]">Nếp · vertical slice V1</p>
+              <h1 className="mt-3 text-4xl font-semibold tracking-tight sm:text-6xl">Học một việc. Làm được việc đó.</h1>
+            </div>
+            <div className="hidden rounded-full border border-black/10 bg-white px-4 py-2 text-xs font-semibold text-black/55 sm:block">Preview · không phải efficacy claim</div>
+          </div>
+
+          <section className="grid gap-5 lg:grid-cols-[1.4fr_.8fr]">
+            <div className="rounded-[32px] bg-[#173d2e] p-6 text-white shadow-[0_30px_100px_rgba(23,61,46,.16)] sm:p-9">
+              <div className="flex items-center gap-2 text-sm font-semibold text-white/70"><Target className="size-4" /> Capability hôm nay</div>
+              <h2 className="mt-5 text-3xl font-semibold sm:text-4xl">{capability.title}</h2>
+              <p className="mt-3 max-w-xl text-base leading-7 text-white/70">{lesson.mission}</p>
+              <div className="mt-7 flex flex-wrap gap-2">{lesson.newItems.map((item) => <span key={item} className="rounded-full bg-white/10 px-3 py-1.5 text-sm">{item}</span>)}</div>
+              <button type="button" onClick={() => { setActive(true); setStep(0); setEvidence(initialEvidence); resetAttempt(); }} className="mt-8 flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-bold text-[#173d2e]">Bắt đầu mission <ArrowRight className="size-4" /></button>
+            </div>
+
+            <div className="rounded-[32px] border border-black/10 bg-white p-6 sm:p-8">
+              <div className="flex items-center gap-2 text-sm font-semibold"><ShieldCheck className="size-4 text-[#2d6a4f]" /> Lesson QA</div>
+              <p className="mt-4 text-3xl font-semibold">{qaErrors.length === 0 ? "PASS" : "BLOCKED"}</p>
+              <p className="mt-2 text-sm leading-6 text-black/55">Gate: retrieval-before-reveal, explicit evidence targets, real speech path, feedback/repair/retry, changed-context transfer, delayed review và evidence trace.</p>
+              <p className="mt-5 border-t border-black/[0.07] pt-5 text-xs leading-5 text-black/40">{lesson.sourceDerived.principleIds.slice(0, 7).join(" · ")}</p>
+            </div>
+          </section>
+
+          <section className="mt-6 rounded-[32px] border border-black/10 bg-white p-6 sm:p-8">
+            <div className="flex items-center gap-2 text-sm font-semibold"><Sparkles className="size-4" /> Capability graph V1</div>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {capabilityGraphV1.map((item) => (
+                <div key={item.id} className={`rounded-2xl border p-4 ${item.id === lesson.capabilityId ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/[0.08]"}`}>
+                  <p className="text-xs font-bold text-black/35">{item.id}</p><p className="mt-2 font-semibold">{item.title}</p><p className="mt-2 text-xs leading-5 text-black/50">{item.learnerJob}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#f7f6f2] text-[#171713]">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-5 sm:px-6 sm:py-8">
+        <header className="mb-8 flex items-center gap-4">
+          <button type="button" onClick={() => setActive(false)} className="grid size-10 place-items-center rounded-full border border-black/10 bg-white" aria-label="Thoát"><ArrowLeft className="size-4" /></button>
+          <div className="min-w-0 flex-1"><div className="mb-2 flex justify-between text-xs font-bold uppercase tracking-[0.18em] text-black/40"><span>{action.kind}</span><span>{progress}%</span></div><div className="h-1.5 overflow-hidden rounded-full bg-black/[0.07]"><div className="h-full rounded-full bg-[#2d6a4f]" style={{ width: `${progress}%` }} /></div></div>
+        </header>
+
+        <section className="flex flex-1 flex-col justify-center pb-12">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#2d6a4f]">{String(step + 1).padStart(2, "0")} · {action.kind}</p>
+          <h1 className="mt-3 text-3xl font-semibold leading-tight sm:text-5xl">{action.title}</h1>
+          <p className="mt-4 max-w-xl text-base leading-7 text-black/60">{action.instruction}</p>
+
+          <div className="mt-8 rounded-[28px] border border-black/10 bg-white p-5 shadow-[0_24px_80px_rgba(20,30,20,.07)] sm:p-8">
+            {action.model && <div className="mb-5"><button type="button" onClick={() => speak(action.model ?? "")} className="mb-4 flex items-center gap-2 rounded-full bg-[#edf5ef] px-4 py-2 text-sm font-semibold text-[#24583f]"><Volume2 className="size-4" /> Nghe</button><p className="text-2xl font-medium leading-relaxed">{action.model}</p></div>}
+            {action.prompt && <div className="mb-5 rounded-2xl bg-[#f5f3ec] p-5"><p className="text-xs font-bold uppercase tracking-[.18em] text-black/35">Prompt</p><p className="mt-2 text-xl font-medium">{action.prompt}</p></div>}
+
+            {action.kind === "comprehend" ? (
+              <div className="grid gap-3 sm:grid-cols-3">{["name", "job", "country"].map((choice) => <button key={choice} type="button" onClick={() => { setAnswer(choice); setAnswerSource("text"); setFeedback(null); setPersistenceState("idle"); }} className={`rounded-2xl border px-4 py-4 text-left font-semibold ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10"}`}>{choice}</button>)}</div>
+            ) : action.modality === "speech" ? (
+              <>
+                <div className="flex flex-wrap gap-3"><button type="button" onClick={startSpeech} disabled={listening || persistenceState === "saving"} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>{!speechAvailable && <span className="flex items-center gap-2 text-xs text-[#8a5b00]"><CircleAlert className="size-4" /> Browser không hỗ trợ speech recognition</span>}</div>
+                <textarea value={answer} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); setPersistenceState("idle"); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60" />
+                <div className="mt-3 flex flex-wrap gap-2"><button type="button" onClick={evaluate} disabled={!answer || answerSource !== "speech" || persistenceState === "saving"} className="rounded-full bg-[#2d6a4f] px-4 py-2 text-xs font-bold text-white disabled:opacity-30">Đánh giá speech transcript</button><button type="button" onClick={evaluate} disabled={!answer || persistenceState === "saving"} className="rounded-full border border-black/10 px-4 py-2 text-xs font-bold text-black/55 disabled:opacity-30">Text fallback</button></div>
+              </>
+            ) : null}
+
+            {action.kind === "comprehend" && <button type="button" onClick={evaluate} disabled={!answer || persistenceState === "saving"} className="mt-4 rounded-full bg-[#171713] px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-30">Kiểm tra</button>}
+            {action.supportVi && <div className="mt-5 border-t border-black/[0.07] pt-5"><button type="button" onClick={() => setSupportUsed((value) => !value)} className="text-sm font-semibold text-black/45">{supportUsed ? "Ẩn hỗ trợ" : "Xem hỗ trợ tiếng Việt"}</button>{supportUsed && <p className="mt-2 text-sm leading-6 text-black/55">{action.supportVi}</p>}</div>}
+            {feedback && <div className="mt-5 flex gap-3 rounded-2xl bg-[#fff7e6] p-4 text-sm leading-6"><CircleAlert className="mt-0.5 size-4 shrink-0 text-[#8a5b00]" /><p>{feedback}</p></div>}
+            {persistedLabel && <p className="mt-3 text-xs leading-5 text-black/40">{persistedLabel}</p>}
+          </div>
+
+          <div className="mt-6 grid grid-cols-5 gap-2">{(Object.keys(evidence) as EvidenceKey[]).map((key) => <div key={key} className={`rounded-xl border px-2 py-2 text-center text-[10px] font-bold uppercase tracking-wide ${evidence[key] ? "border-[#2d6a4f]/30 bg-[#edf5ef] text-[#24583f]" : "border-black/[0.07] text-black/25"}`}>{key}</div>)}</div>
+          <div className="mt-8 flex items-center justify-between"><button type="button" onClick={() => { setStep((value) => Math.max(0, value - 1)); resetAttempt(); }} disabled={step === 0 || persistenceState === "saving"} className="rounded-full px-4 py-3 text-sm font-semibold text-black/45 disabled:opacity-20"><RefreshCw className="mr-2 inline size-3" />Quay lại</button><button type="button" onClick={next} disabled={persistenceState === "saving"} className="flex items-center gap-2 rounded-full bg-[#2d6a4f] px-6 py-3 text-sm font-semibold text-white disabled:opacity-40">{step === lesson.actions.length - 1 ? "Kết thúc slice" : "Tiếp theo"}<ArrowRight className="size-4" /></button></div>
+        </section>
+
+        <footer className="pb-4 text-center text-[11px] leading-5 text-black/35"><Headphones className="mr-1 inline size-3" /> Transcript feedback ≠ pronunciation score. Raw transcript không được persist. Text fallback ≠ speaking evidence.{supportUsed && " Vietnamese support usage is tracked separately."}</footer>
+      </div>
+    </main>
+  );
+}

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -5,6 +5,7 @@ import { useMemo, useRef, useState } from "react";
 
 import { recordLearningAttempt } from "@/app/actions/learning-evidence";
 import { capabilityGraphV1 } from "@/lib/nep/capabilities.v1";
+import { evaluateNếpActionResponse } from "@/lib/nep/evaluator";
 import { firstMeetingLessonV1, qaLesson } from "@/lib/nep/lesson-contract";
 import { toLearningAttemptRecord } from "@/lib/nep/learning-evidence-adapter";
 
@@ -22,8 +23,6 @@ type RecognitionCtor = new () => {
 };
 
 const initialEvidence: EvidenceState = { comprehension: false, retrieval: false, production: false, repair: false, transfer: false };
-const clean = (value: string) => value.toLowerCase().replace(/[’']/g, "'").replace(/[^a-z0-9' -]/g, " ").replace(/\s+/g, " ").trim();
-const hasAny = (text: string, signals: string[]) => signals.some((signal) => clean(text).includes(clean(signal)));
 
 function speak(text: string) {
   if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
@@ -135,15 +134,14 @@ export function DataDrivenPreview() {
   const evaluate = async () => {
     if (persistenceState === "saving") return;
 
+    const ok = evaluateNếpActionResponse(action, answer);
     if (action.kind === "comprehend") {
-      const ok = clean(answer) === "name";
       setEvidence((current) => ({ ...current, comprehension: ok }));
       setFeedback(ok ? "Đúng: Maya đang hỏi tên." : "Chưa đúng. Câu hỏi đang cần một thông tin cá nhân cụ thể.");
       await persistEvaluation(ok);
       return;
     }
 
-    const ok = hasAny(answer, action.targetSignals ?? []);
     const channel = evidenceKeyForAction(action.kind);
     const observedSpeech = answerSource === "speech";
     const canShowEvidence = channel && observedSpeech && ok && (channel !== "transfer" || evidence.production);
@@ -153,18 +151,18 @@ export function DataDrivenPreview() {
     }
 
     if (channel && answerSource !== "speech") {
-      setFeedback(ok ? "Text có target language, nhưng không cộng speaking evidence vì không có oral response quan sát được." : "Text chưa có target language cần thiết. Đây không phải pronunciation feedback.");
+      setFeedback(ok ? "Text có target language, nhưng không cộng speaking evidence vì không có oral response quan sát được." : "Text chưa đáp ứng đủ target language của task. Đây không phải pronunciation feedback.");
       await persistEvaluation(ok);
       return;
     }
 
     if (channel === "transfer" && ok && !evidence.production) {
-      setFeedback("Transcript có target language, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
+      setFeedback("Transcript đáp ứng task, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
       await persistEvaluation(ok);
       return;
     }
 
-    setFeedback(ok ? "Transcript có target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm." : "Transcript chưa cho thấy target language cần thiết. Tự sửa một điểm rồi thử lại.");
+    setFeedback(ok ? "Transcript đáp ứng đủ target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm." : "Transcript chưa đáp ứng đủ target language của task. Tự sửa rồi thử lại.");
     await persistEvaluation(ok);
   };
 

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -154,7 +154,7 @@ export function DataDrivenPreview() {
       setPersistenceState(result.evidenceRecorded ? "evidence-saved" : "attempt-saved");
       return;
     }
-    const error = "error" in result ? result.error : "";
+    const error = "error" in result ? result.error ?? "" : "";
     if (error.includes("đăng nhập")) {
       setPersistenceState("local-only");
       return;

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -70,7 +70,7 @@ export function DataDrivenPreview() {
   const [supportUsed, setSupportUsed] = useState(false);
   const [evidence, setEvidence] = useState<EvidenceState>(initialEvidence);
   const [persistenceState, setPersistenceState] = useState<PersistenceState>("idle");
-  const attemptStartedAt = useRef(Date.now());
+  const attemptStartedAt = useRef<number | null>(null);
   const lastSubmissionKey = useRef<string | null>(null);
 
   const action = lesson.actions[step];
@@ -134,6 +134,8 @@ export function DataDrivenPreview() {
     const submissionKey = `${action.id}|${answerSource ?? "none"}|support:${supportUsed ? 1 : 0}|${answer.trim()}`;
     if (lastSubmissionKey.current === submissionKey) return;
 
+    const now = Date.now();
+    const latencyMs = attemptStartedAt.current === null ? 0 : now - attemptStartedAt.current;
     const record = toLearningAttemptRecord({
       lesson,
       action,
@@ -141,7 +143,7 @@ export function DataDrivenPreview() {
       responseSource: answerSource,
       correct,
       supportUsed,
-      latencyMs: Date.now() - attemptStartedAt.current,
+      latencyMs,
     });
     if (!record) return;
 

--- a/src/lib/nep/__tests__/evaluator.test.ts
+++ b/src/lib/nep/__tests__/evaluator.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateNếpActionResponse } from "../evaluator";
+import { firstMeetingLessonV1 } from "../lesson-contract";
+
+function action(kind: "comprehend" | "retrieve" | "produce" | "repair" | "retry" | "transfer") {
+  return firstMeetingLessonV1.actions.find((item) => item.kind === kind)!;
+}
+
+describe("Nếp deterministic evaluator", () => {
+  it("evaluates comprehension as the declared exact choice", () => {
+    expect(evaluateNếpActionResponse(action("comprehend"), "name")).toBe(true);
+    expect(evaluateNếpActionResponse(action("comprehend"), "country")).toBe(false);
+  });
+
+  it("accepts normalized introduction variants", () => {
+    expect(evaluateNếpActionResponse(action("produce"), "I'm Hoang.")).toBe(true);
+    expect(evaluateNếpActionResponse(action("produce"), "I’m Hoang!")).toBe(true);
+  });
+
+  it("does not award transfer for the repair move alone", () => {
+    expect(evaluateNếpActionResponse(action("transfer"), "Sorry, could you say that again?")).toBe(false);
+  });
+
+  it("does not award transfer for self-introduction alone", () => {
+    expect(evaluateNếpActionResponse(action("transfer"), "My name is Hoang.")).toBe(false);
+  });
+
+  it("awards transfer only when every required signal group is present", () => {
+    expect(
+      evaluateNếpActionResponse(
+        action("transfer"),
+        "Sorry, could you say that again? My name is Hoang.",
+      ),
+    ).toBe(true);
+  });
+
+  it("holds the supported retry to the same multi-demand language coverage", () => {
+    expect(evaluateNếpActionResponse(action("retry"), "Could you say that again?")).toBe(false);
+    expect(evaluateNếpActionResponse(action("retry"), "I'm Hoang.")).toBe(false);
+    expect(evaluateNếpActionResponse(action("retry"), "Could you say that again? I'm Hoang.")).toBe(true);
+  });
+});

--- a/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
+++ b/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { materializeEvidence } from "../../learning/evidence";
+import { firstMeetingLessonV1 } from "../lesson-contract";
+import { toLearningAttemptRecord } from "../learning-evidence-adapter";
+
+function action(kind: "comprehend" | "produce" | "repair" | "retry" | "transfer") {
+  return firstMeetingLessonV1.actions.find((item) => item.kind === kind)!;
+}
+
+describe("Nếp → learning-core adapter", () => {
+  it("maps repair to CAP-003 while production and transfer stay on CAP-002", () => {
+    const production = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("produce"),
+      response: "My name is Hoang",
+      responseSource: "speech",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 1200,
+    });
+    const repair = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("repair"),
+      response: "Could you say that again?",
+      responseSource: "speech",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 900,
+    });
+    const transfer = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("transfer"),
+      response: "Could you say that again? My name is Hoang.",
+      responseSource: "speech",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 1500,
+    });
+
+    expect(production?.attempt.capabilityId).toBe("CAP-002");
+    expect(production?.candidate?.type).toBe("production");
+    expect(repair?.attempt.capabilityId).toBe("CAP-003");
+    expect(repair?.candidate?.type).toBe("repair");
+    expect(transfer?.attempt.capabilityId).toBe("CAP-002");
+    expect(transfer?.candidate?.type).toBe("transfer");
+  });
+
+  it("maps product-level comprehension choice to low-level recognition evidence", () => {
+    const record = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("comprehend"),
+      response: "name",
+      responseSource: "text",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 500,
+    });
+
+    expect(record?.attempt.responseModality).toBe("choice");
+    expect(record?.candidate).toMatchObject({ type: "recognition", targetId: "CAP-002", success: true });
+  });
+
+  it("never persists the raw speech transcript", () => {
+    const record = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("produce"),
+      response: "My name is Hoang and this is raw learner speech",
+      responseSource: "speech",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 1000,
+    });
+
+    expect(record?.attempt.responseText).toBeNull();
+    expect(record?.attempt.metadata).toMatchObject({ rawResponsePersisted: false });
+    expect(JSON.stringify(record)).not.toContain("raw learner speech");
+  });
+
+  it("lets the canonical evidence policy reject typed fallback as speaking evidence", () => {
+    const record = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("produce"),
+      response: "My name is Hoang",
+      responseSource: "text",
+      correct: true,
+      supportUsed: false,
+      latencyMs: 700,
+    });
+
+    expect(record?.attempt.responseModality).toBe("text");
+    expect(record?.candidate).not.toBeNull();
+    expect(materializeEvidence({ attempt: record!.attempt, candidate: record!.candidate! })).toBeNull();
+  });
+
+  it("stores supported retry as attempt-only after reveal", () => {
+    const record = toLearningAttemptRecord({
+      lesson: firstMeetingLessonV1,
+      action: action("retry"),
+      response: "Could you say that again? My name is Hoang.",
+      responseSource: "speech",
+      correct: true,
+      supportUsed: true,
+      latencyMs: 1000,
+    });
+
+    expect(record?.attempt.supportLevel).toBe(1);
+    expect(record?.candidate).toBeNull();
+  });
+});

--- a/src/lib/nep/__tests__/lesson-contract.test.ts
+++ b/src/lib/nep/__tests__/lesson-contract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { firstMeetingLessonV1, qaLesson } from "../lesson-contract";
+
+describe("Nếp lesson contract QA", () => {
+  it("accepts the first-meeting vertical slice", () => {
+    expect(qaLesson(firstMeetingLessonV1).filter((issue) => issue.severity === "error")).toEqual([]);
+  });
+
+  it("rejects a recognition-only lesson that claims the speaking flow", () => {
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.filter((action) => action.kind !== "produce" && action.kind !== "transfer"),
+    };
+    const codes = qaLesson(broken).map((issue) => issue.code);
+    expect(codes).toContain("SPEAKING_NEEDS_SPEECH");
+    expect(codes).toContain("TRANSFER_NEEDS_CHANGED_SPEECH");
+  });
+
+  it("rejects answer reveal before retrieval", () => {
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.map((action, index) =>
+        index === 0 ? { ...action, revealsAnswer: true } : action,
+      ),
+    };
+    expect(qaLesson(broken).map((issue) => issue.code)).toContain("ATTEMPT_BEFORE_REVEAL");
+  });
+
+  it("declares the exact capability target for production, repair and transfer", () => {
+    const production = firstMeetingLessonV1.actions.find((action) => action.kind === "produce");
+    const repair = firstMeetingLessonV1.actions.find((action) => action.kind === "repair");
+    const transfer = firstMeetingLessonV1.actions.find((action) => action.kind === "transfer");
+
+    expect(production?.assessment).toMatchObject({ targetCapabilityId: "CAP-002", evidenceType: "production" });
+    expect(repair?.assessment).toMatchObject({ targetCapabilityId: "CAP-003", evidenceType: "repair" });
+    expect(transfer?.assessment).toMatchObject({ targetCapabilityId: "CAP-002", evidenceType: "transfer" });
+  });
+
+  it("rejects an assessment target outside the lesson capability graph", () => {
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.map((action) =>
+        action.kind === "repair"
+          ? { ...action, assessment: { ...action.assessment!, targetCapabilityId: "CAP-999" } }
+          : action,
+      ),
+    };
+
+    expect(qaLesson(broken).map((issue) => issue.code)).toContain("ASSESSMENT_TARGET_UNDECLARED");
+  });
+
+  it("rejects transfer that reuses the independent production context", () => {
+    const production = firstMeetingLessonV1.actions.find((action) => action.kind === "produce")!;
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.map((action) =>
+        action.kind === "transfer"
+          ? { ...action, assessment: { ...action.assessment!, contextId: production.assessment!.contextId } }
+          : action,
+      ),
+    };
+
+    expect(qaLesson(broken).map((issue) => issue.code)).toContain("TRANSFER_CONTEXT_NOT_CHANGED");
+  });
+
+  it("keeps the supported retry attempt-only after answer-bearing feedback", () => {
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.map((action) =>
+        action.kind === "retry"
+          ? { ...action, assessment: { ...action.assessment!, evidenceType: "production" as const } }
+          : action,
+      ),
+    };
+
+    expect(qaLesson(broken).map((issue) => issue.code)).toContain("SUPPORTED_RETRY_ATTEMPT_ONLY");
+  });
+});

--- a/src/lib/nep/__tests__/lesson-contract.test.ts
+++ b/src/lib/nep/__tests__/lesson-contract.test.ts
@@ -64,6 +64,19 @@ describe("Nếp lesson contract QA", () => {
     expect(qaLesson(broken).map((issue) => issue.code)).toContain("TRANSFER_CONTEXT_NOT_CHANGED");
   });
 
+  it("rejects transfer whose evaluator can satisfy only one demand", () => {
+    const broken = {
+      ...firstMeetingLessonV1,
+      actions: firstMeetingLessonV1.actions.map((action) =>
+        action.kind === "transfer"
+          ? { ...action, requiredSignalGroups: [action.requiredSignalGroups![0]] }
+          : action,
+      ),
+    };
+
+    expect(qaLesson(broken).map((issue) => issue.code)).toContain("TRANSFER_REQUIRES_MULTI_DEMAND_EVALUATION");
+  });
+
   it("keeps the supported retry attempt-only after answer-bearing feedback", () => {
     const broken = {
       ...firstMeetingLessonV1,

--- a/src/lib/nep/__tests__/lesson-contract.test.ts
+++ b/src/lib/nep/__tests__/lesson-contract.test.ts
@@ -65,11 +65,15 @@ describe("Nếp lesson contract QA", () => {
   });
 
   it("rejects transfer whose evaluator can satisfy only one demand", () => {
+    const transfer = firstMeetingLessonV1.actions.find((action) => action.kind === "transfer")!;
+    const firstDemand = transfer.requiredSignalGroups?.[0];
+    expect(firstDemand).toBeDefined();
+
     const broken = {
       ...firstMeetingLessonV1,
       actions: firstMeetingLessonV1.actions.map((action) =>
         action.kind === "transfer"
-          ? { ...action, requiredSignalGroups: [action.requiredSignalGroups![0]] }
+          ? { ...action, requiredSignalGroups: [firstDemand!] }
           : action,
       ),
     };

--- a/src/lib/nep/capabilities.v1.ts
+++ b/src/lib/nep/capabilities.v1.ts
@@ -1,0 +1,146 @@
+export type EvidenceChannel =
+  | "comprehension"
+  | "retrieval"
+  | "production"
+  | "repair"
+  | "transfer"
+  | "retention";
+
+export type Capability = {
+  id: string;
+  title: string;
+  learnerJob: string;
+  prerequisites: string[];
+  functions: string[];
+  chunks: string[];
+  vocabulary: string[];
+  grammarPatterns: string[];
+  pronunciationFocus: string[];
+  listeningDemands: string[];
+  evidencePrinciples: string[];
+  evidenceClaims: string[];
+  assessment: EvidenceChannel[];
+};
+
+export const capabilityGraphV1: Capability[] = [
+  {
+    id: "CAP-001",
+    title: "Greet and close",
+    learnerJob: "Start and end a short interaction without freezing.",
+    prerequisites: [],
+    functions: ["greet", "acknowledge", "close"],
+    chunks: ["Hi.", "Nice to meet you.", "See you."],
+    vocabulary: ["hi", "nice", "meet", "see"],
+    grammarPatterns: [],
+    pronunciationFocus: ["short greeting rhythm"],
+    listeningDemands: ["recognise a greeting and closing cue"],
+    evidencePrinciples: ["PRN-001", "PRN-002", "PRN-050"],
+    evidenceClaims: ["CLM-FND-001", "CLM-SPK-001"],
+    assessment: ["comprehension", "retrieval", "production", "retention"],
+  },
+  {
+    id: "CAP-002",
+    title: "Introduce yourself",
+    learnerJob: "Say your name and basic identity information in a first meeting.",
+    prerequisites: ["CAP-001"],
+    functions: ["introduce self", "spell name"],
+    chunks: ["I'm …", "My name is …", "That's …"],
+    vocabulary: ["name", "from"],
+    grammarPatterns: ["be in first-person identity chunks"],
+    pronunciationFocus: ["letter names", "name boundary clarity"],
+    listeningDemands: ["recognise a name question", "recognise a request to repeat/spell"],
+    evidencePrinciples: ["PRN-003", "PRN-050", "PRN-054", "PRN-058", "PRN-001", "PRN-002"],
+    evidenceClaims: ["CLM-VOC-001", "CLM-SPK-001", "CLM-SPK-002", "CLM-SPK-007", "CLM-SPK-010", "CLM-SPK-008"],
+    assessment: ["comprehension", "retrieval", "production", "repair", "retention"],
+  },
+  {
+    id: "CAP-003",
+    title: "Ask for repetition",
+    learnerJob: "Recover when you did not hear or understand a short turn.",
+    prerequisites: ["CAP-001"],
+    functions: ["request repetition", "request clarification"],
+    chunks: ["Sorry?", "Could you say that again?", "What was your name again?"],
+    vocabulary: ["sorry", "again"],
+    grammarPatterns: ["Could you …? as a repair chunk"],
+    pronunciationFocus: ["polite request rhythm"],
+    listeningDemands: ["notice an information gap before responding"],
+    evidencePrinciples: ["PRN-054", "PRN-058", "PRN-016", "PRN-018"],
+    evidenceClaims: ["CLM-SPK-002", "CLM-SPK-007", "CLM-SPK-010", "CLM-SPK-008", "CLM-SCF-001", "CLM-SCF-004"],
+    assessment: ["retrieval", "production", "repair", "retention"],
+  },
+  {
+    id: "CAP-004",
+    title: "Confirm understanding",
+    learnerJob: "Check that a short piece of information was understood correctly.",
+    prerequisites: ["CAP-003"],
+    functions: ["confirm", "check information"],
+    chunks: ["So, that's …?", "You mean …?", "Right?"],
+    vocabulary: ["mean", "right"],
+    grammarPatterns: ["confirmation frames"],
+    pronunciationFocus: ["confirmation intonation"],
+    listeningDemands: ["hold one detail long enough to confirm it"],
+    evidencePrinciples: ["PRN-054", "PRN-058", "PRN-002"],
+    evidenceClaims: ["CLM-SPK-002", "CLM-SPK-008", "CLM-VOC-005"],
+    assessment: ["comprehension", "production", "repair", "retention"],
+  },
+  {
+    id: "CAP-005",
+    title: "Ask simple information",
+    learnerJob: "Ask one clear question to get basic personal or situational information.",
+    prerequisites: ["CAP-002", "CAP-003"],
+    functions: ["ask name", "ask origin", "ask simple context detail"],
+    chunks: ["What's your name?", "Where are you from?", "What do you do?"],
+    vocabulary: ["what", "where", "from"],
+    grammarPatterns: ["high-frequency wh-question frames"],
+    pronunciationFocus: ["question rhythm"],
+    listeningDemands: ["recognise the expected information type in the answer"],
+    evidencePrinciples: ["PRN-003", "PRN-054", "PRN-001"],
+    evidenceClaims: ["CLM-VOC-001", "CLM-SPK-007", "CLM-FND-001"],
+    assessment: ["retrieval", "production", "retention"],
+  },
+  {
+    id: "CAP-006",
+    title: "Answer simple information",
+    learnerJob: "Give a short relevant answer about yourself or the immediate context.",
+    prerequisites: ["CAP-002", "CAP-005"],
+    functions: ["answer name", "answer origin", "answer role/context"],
+    chunks: ["I'm …", "I'm from …", "I work in …"],
+    vocabulary: ["from", "work", "in"],
+    grammarPatterns: ["short first-person answer frames"],
+    pronunciationFocus: ["content-word prominence"],
+    listeningDemands: ["map a question cue to the requested information"],
+    evidencePrinciples: ["PRN-003", "PRN-054", "PRN-001"],
+    evidenceClaims: ["CLM-VOC-001", "CLM-SPK-002", "CLM-FND-001"],
+    assessment: ["comprehension", "retrieval", "production", "retention"],
+  },
+  {
+    id: "CAP-007",
+    title: "Express a simple need or problem",
+    learnerJob: "State one immediate need/problem and make a simple request.",
+    prerequisites: ["CAP-003", "CAP-006"],
+    functions: ["state problem", "request help"],
+    chunks: ["I need …", "I can't …", "Can you help me?"],
+    vocabulary: ["need", "help", "can"],
+    grammarPatterns: ["I need …", "I can't …", "Can you …?"],
+    pronunciationFocus: ["clear key-word stress"],
+    listeningDemands: ["recognise a response that solves or clarifies the problem"],
+    evidencePrinciples: ["PRN-050", "PRN-054", "PRN-058"],
+    evidenceClaims: ["CLM-SPK-001", "CLM-SPK-002", "CLM-SPK-008"],
+    assessment: ["retrieval", "production", "repair", "retention"],
+  },
+  {
+    id: "CAP-008",
+    title: "Sustain and repair a short interaction",
+    learnerJob: "Handle several short turns, recover from one breakdown, and still complete the communicative job.",
+    prerequisites: ["CAP-002", "CAP-003", "CAP-004", "CAP-005", "CAP-006", "CAP-007"],
+    functions: ["respond contingently", "repair", "continue", "close"],
+    chunks: ["Sorry, could you say that again?", "So, that's …?", "Got it.", "Thanks."],
+    vocabulary: ["again", "mean", "thanks"],
+    grammarPatterns: ["recycled frames from prerequisite capabilities"],
+    pronunciationFocus: ["turn-level intelligibility"],
+    listeningDemands: ["follow multiple short contingent turns"],
+    evidencePrinciples: ["PRN-040", "PRN-045", "PRN-056", "PRN-058", "PRN-002"],
+    evidenceClaims: ["CLM-TRN-001", "CLM-TRN-006", "CLM-SPK-006", "CLM-SPK-008", "CLM-VOC-005"],
+    assessment: ["comprehension", "production", "repair", "transfer", "retention"],
+  },
+];

--- a/src/lib/nep/evaluator.ts
+++ b/src/lib/nep/evaluator.ts
@@ -1,0 +1,31 @@
+import type { LessonAction } from "./lesson-contract";
+
+export function normalizeNếpResponse(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[’']/g, "'")
+    .replace(/[^a-z0-9' -]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function includesAny(response: string, signals: string[]) {
+  return signals.some((signal) => response.includes(normalizeNếpResponse(signal)));
+}
+
+/**
+ * Deterministic language-coverage evaluator for the preview slice.
+ * It evaluates only declared target language, never pronunciation or acoustic quality.
+ */
+export function evaluateNếpActionResponse(action: LessonAction, response: string): boolean {
+  const normalized = normalizeNếpResponse(response);
+
+  if (action.kind === "comprehend") {
+    return (action.targetSignals ?? []).some((signal) => normalized === normalizeNếpResponse(signal));
+  }
+
+  const groups = action.requiredSignalGroups
+    ?? (action.targetSignals && action.targetSignals.length > 0 ? [action.targetSignals] : []);
+
+  return groups.length > 0 && groups.every((group) => group.length > 0 && includesAny(normalized, group));
+}

--- a/src/lib/nep/learning-evidence-adapter.ts
+++ b/src/lib/nep/learning-evidence-adapter.ts
@@ -1,0 +1,78 @@
+import type { RecordLearningAttemptInput } from "../learning/validation";
+import type { LessonAction, LessonContract } from "./lesson-contract";
+
+export type NếpResponseSource = "speech" | "text" | null;
+
+export type EvaluatedNếpAction = {
+  lesson: LessonContract;
+  action: LessonAction;
+  response: string;
+  responseSource: NếpResponseSource;
+  correct: boolean;
+  supportUsed: boolean;
+  latencyMs: number;
+};
+
+function responseModality(action: LessonAction, source: NếpResponseSource) {
+  if (action.modality === "choice") return "choice" as const;
+  if (source === "speech") return "speech" as const;
+  if (source === "text") return "text" as const;
+  return "none" as const;
+}
+
+/**
+ * Adapts an evaluated Nếp action to the canonical Attempt → Evidence write contract.
+ * Raw learner responses are deliberately not persisted here; the deterministic evaluator
+ * has already reduced the response to success/failure plus non-sensitive metadata.
+ */
+export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLearningAttemptInput | null {
+  const { lesson, action, response, responseSource, correct, supportUsed, latencyMs } = input;
+  const assessment = action.assessment;
+  if (!assessment) return null;
+
+  const modality = responseModality(action, responseSource);
+  const safeLatency = Math.min(60 * 60 * 1000, Math.max(0, Math.round(latencyMs)));
+  const metadata = {
+    lessonId: lesson.id,
+    lessonVersion: lesson.version,
+    actionId: action.id,
+    actionKind: action.kind,
+    responseSource,
+    responseLength: response.trim().length,
+    rawResponsePersisted: false,
+    supportUsed,
+    changedContext: action.changedContext ?? false,
+  };
+
+  return {
+    attempt: {
+      capabilityId: assessment.targetCapabilityId,
+      exerciseType: `nep:${action.kind}`,
+      responseModality: modality,
+      promptId: action.id,
+      contextId: assessment.contextId,
+      responseText: null,
+      correct,
+      latencyMs: safeLatency,
+      hintCount: 0,
+      revealUsed: false,
+      supportLevel: supportUsed ? 1 : 0,
+      metadata,
+    },
+    candidate: assessment.evidenceType
+      ? {
+          type: assessment.evidenceType,
+          targetId: assessment.targetCapabilityId,
+          success: correct,
+          contextId: assessment.contextId,
+          evaluator: assessment.evaluator,
+          metadata: {
+            lessonId: lesson.id,
+            actionId: action.id,
+            responseSource,
+            rawResponsePersisted: false,
+          },
+        }
+      : null,
+  };
+}

--- a/src/lib/nep/lesson-contract.ts
+++ b/src/lib/nep/lesson-contract.ts
@@ -1,0 +1,310 @@
+import type { EvidenceType } from "../learning/evidence";
+import type { EvidenceChannel } from "./capabilities.v1";
+
+export type ProvenanceKind = "source_derived" | "product_inference";
+export type LessonModality = "listen" | "read" | "speech" | "text" | "choice";
+export type LessonActionKind =
+  | "context"
+  | "comprehend"
+  | "notice"
+  | "retrieve"
+  | "produce"
+  | "feedback"
+  | "repair"
+  | "retry"
+  | "transfer";
+
+export type LessonAssessment = {
+  /** Capability that this exact learner response attempted to demonstrate. */
+  targetCapabilityId: string;
+  /** Null means persist the attempt only; do not promote it to mastery evidence. */
+  evidenceType: EvidenceType | null;
+  /** Stable task context used by persisted-history transfer checks. */
+  contextId: string;
+  evaluator: string;
+};
+
+export type LessonAction = {
+  id: string;
+  kind: LessonActionKind;
+  title: string;
+  instruction: string;
+  modality: LessonModality;
+  prompt?: string;
+  model?: string;
+  supportVi?: string;
+  targetSignals?: string[];
+  changedContext?: boolean;
+  revealsAnswer?: boolean;
+  assessment?: LessonAssessment;
+};
+
+export type LessonContract = {
+  id: string;
+  version: 1;
+  capabilityId: string;
+  embeddedCapabilityIds: string[];
+  prerequisites: string[];
+  mission: string;
+  learnerCanDo: string;
+  newItems: string[];
+  reviewTargets: string[];
+  evidenceChannels: EvidenceChannel[];
+  sourceDerived: {
+    principleIds: string[];
+    claimIds: string[];
+  };
+  productInference: {
+    maxNewItems: number;
+    notes: string[];
+  };
+  actions: LessonAction[];
+};
+
+export type QaIssue = {
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+  provenance: ProvenanceKind;
+};
+
+const evaluatedKinds = new Set<LessonActionKind>([
+  "comprehend",
+  "retrieve",
+  "produce",
+  "repair",
+  "retry",
+  "transfer",
+]);
+
+export function qaLesson(lesson: LessonContract): QaIssue[] {
+  const issues: QaIssue[] = [];
+  const kinds = lesson.actions.map((action) => action.kind);
+  const firstRetrieve = kinds.indexOf("retrieve");
+  const firstReveal = lesson.actions.findIndex((action) => action.revealsAnswer === true);
+  const production = lesson.actions.find((action) => action.kind === "produce");
+  const repair = lesson.actions.find((action) => action.kind === "repair");
+  const retry = lesson.actions.find((action) => action.kind === "retry");
+  const transfer = lesson.actions.find((action) => action.kind === "transfer");
+  const declaredTargets = new Set([lesson.capabilityId, ...lesson.embeddedCapabilityIds]);
+
+  if (!lesson.capabilityId) {
+    issues.push({ severity: "error", code: "CAPABILITY_REQUIRED", message: "Lesson must declare a capability ID.", provenance: "product_inference" });
+  }
+  if (!Array.isArray(lesson.prerequisites)) {
+    issues.push({ severity: "error", code: "PREREQUISITES_REQUIRED", message: "Lesson must declare prerequisite metadata.", provenance: "product_inference" });
+  }
+  if (lesson.newItems.length > lesson.productInference.maxNewItems) {
+    issues.push({ severity: "error", code: "TOO_MANY_NEW_ITEMS", message: `Lesson introduces ${lesson.newItems.length} items; V1 preview cap is ${lesson.productInference.maxNewItems}.`, provenance: "product_inference" });
+  }
+  if (firstRetrieve === -1 || (firstReveal !== -1 && firstReveal < firstRetrieve)) {
+    issues.push({ severity: "error", code: "ATTEMPT_BEFORE_REVEAL", message: "Retrieval attempt must happen before answer-bearing reveal.", provenance: "source_derived" });
+  }
+  if (!production || production.modality !== "speech") {
+    issues.push({ severity: "error", code: "SPEAKING_NEEDS_SPEECH", message: "A speaking claim requires an observable speech response path.", provenance: "source_derived" });
+  }
+  for (const required of ["feedback", "repair", "retry"] as const) {
+    if (!kinds.includes(required)) {
+      issues.push({ severity: "error", code: `MISSING_${required.toUpperCase()}`, message: `Lesson must include ${required}.`, provenance: "source_derived" });
+    }
+  }
+  if (!transfer || transfer.modality !== "speech" || !transfer.changedContext) {
+    issues.push({ severity: "error", code: "TRANSFER_NEEDS_CHANGED_SPEECH", message: "Transfer requires productive speech in a changed context.", provenance: "source_derived" });
+  }
+  if (lesson.reviewTargets.length === 0 || !lesson.evidenceChannels.includes("retention")) {
+    issues.push({ severity: "error", code: "DELAYED_REVIEW_REQUIRED", message: "Lesson must publish review targets and a retention evidence channel.", provenance: "source_derived" });
+  }
+  if (lesson.sourceDerived.principleIds.length === 0 || lesson.sourceDerived.claimIds.length === 0) {
+    issues.push({ severity: "error", code: "EVIDENCE_TRACE_REQUIRED", message: "Lesson must trace to research principle and claim IDs.", provenance: "product_inference" });
+  }
+
+  for (const action of lesson.actions) {
+    if (evaluatedKinds.has(action.kind) && !action.assessment) {
+      issues.push({ severity: "error", code: "ASSESSMENT_TARGET_REQUIRED", message: `${action.id} must declare its learning-core assessment target.`, provenance: "product_inference" });
+      continue;
+    }
+    if (action.assessment && !declaredTargets.has(action.assessment.targetCapabilityId)) {
+      issues.push({ severity: "error", code: "ASSESSMENT_TARGET_UNDECLARED", message: `${action.id} targets ${action.assessment.targetCapabilityId}, which is not the lesson capability or an embedded capability.`, provenance: "product_inference" });
+    }
+  }
+
+  const comprehension = lesson.actions.find((action) => action.kind === "comprehend");
+  const retrieval = lesson.actions.find((action) => action.kind === "retrieve");
+  if (comprehension?.assessment && comprehension.assessment.evidenceType !== "recognition") {
+    issues.push({ severity: "error", code: "COMPREHENSION_PERSISTS_MODAL_EVIDENCE", message: "Choice comprehension in this slice must persist low-level recognition evidence, not a product-level comprehension label.", provenance: "product_inference" });
+  }
+  if (retrieval?.assessment && retrieval.assessment.evidenceType !== "retrieval") {
+    issues.push({ severity: "error", code: "RETRIEVAL_EVIDENCE_MISMATCH", message: "Retrieval action must persist retrieval evidence.", provenance: "product_inference" });
+  }
+  if (production?.assessment && production.assessment.evidenceType !== "production") {
+    issues.push({ severity: "error", code: "PRODUCTION_EVIDENCE_MISMATCH", message: "Production action must persist production evidence.", provenance: "product_inference" });
+  }
+  if (repair?.assessment && repair.assessment.evidenceType !== "repair") {
+    issues.push({ severity: "error", code: "REPAIR_EVIDENCE_MISMATCH", message: "Repair action must persist repair evidence.", provenance: "product_inference" });
+  }
+  if (retry?.assessment && firstReveal !== -1 && lesson.actions.indexOf(retry) > firstReveal && retry.assessment.evidenceType !== null) {
+    issues.push({ severity: "error", code: "SUPPORTED_RETRY_ATTEMPT_ONLY", message: "Retry after answer-bearing feedback must be stored as an attempt without independent mastery evidence.", provenance: "product_inference" });
+  }
+  if (transfer?.assessment) {
+    if (transfer.assessment.evidenceType !== "transfer") {
+      issues.push({ severity: "error", code: "TRANSFER_EVIDENCE_MISMATCH", message: "Transfer action must persist transfer evidence.", provenance: "product_inference" });
+    }
+    if (production?.assessment && transfer.assessment.targetCapabilityId !== production.assessment.targetCapabilityId) {
+      issues.push({ severity: "error", code: "TRANSFER_TARGET_MISMATCH", message: "Transfer must test the same capability target as the independent production it is transferring.", provenance: "product_inference" });
+    }
+    if (production?.assessment && transfer.assessment.contextId === production.assessment.contextId) {
+      issues.push({ severity: "error", code: "TRANSFER_CONTEXT_NOT_CHANGED", message: "Transfer must declare a context different from the earlier successful production context.", provenance: "source_derived" });
+    }
+  }
+  if (lesson.actions.some((action) => /this is a pen|that is the phone/i.test(action.model ?? action.prompt ?? ""))) {
+    issues.push({ severity: "warning", code: "TEXTBOOK_LIKE_LANGUAGE", message: "Editorial review: language resembles isolated textbook examples.", provenance: "product_inference" });
+  }
+  return issues;
+}
+
+export const firstMeetingLessonV1: LessonContract = {
+  id: "LESSON-CAP002-FIRST-MEETING-V1",
+  version: 1,
+  capabilityId: "CAP-002",
+  embeddedCapabilityIds: ["CAP-003"],
+  prerequisites: ["CAP-001"],
+  mission: "Meet a new colleague, introduce yourself, recover from one missed turn, then do it again when the prompt changes.",
+  learnerCanDo: "Introduce myself and ask for repetition during a short first meeting.",
+  newItems: ["I'm …", "My name is …", "That's …", "Could you say that again?"],
+  reviewTargets: ["My name is …", "That's …", "Could you say that again?"],
+  evidenceChannels: ["comprehension", "retrieval", "production", "repair", "transfer", "retention"],
+  sourceDerived: {
+    principleIds: ["PRN-003", "PRN-050", "PRN-054", "PRN-058", "PRN-040", "PRN-045", "PRN-056", "PRN-016", "PRN-018", "PRN-001", "PRN-002"],
+    claimIds: ["CLM-VOC-001", "CLM-SPK-001", "CLM-SPK-002", "CLM-SPK-007", "CLM-SPK-010", "CLM-SPK-008", "CLM-TRN-001", "CLM-TRN-005", "CLM-TRN-006", "CLM-SPK-006", "CLM-SCF-001", "CLM-SCF-004", "CLM-FND-001", "CLM-VOC-005"],
+  },
+  productInference: {
+    maxNewItems: 6,
+    notes: [
+      "The six-item cap is a V1 editorial constraint to test, not a research conclusion.",
+      "Transcript matching is language feedback only; it is not pronunciation scoring.",
+      "Text fallback can demonstrate flow but cannot count as speaking evidence.",
+      "Retry after answer-bearing feedback is attempt-only evidence.",
+    ],
+  },
+  actions: [
+    {
+      id: "context",
+      kind: "context",
+      title: "A colleague meets you for the first time",
+      instruction: "Listen for the job of each turn, not every word.",
+      modality: "listen",
+      model: "Hi, I'm Maya. What's your name?",
+      supportVi: "Bối cảnh: gặp đồng nghiệp mới. Hỗ trợ tiếng Việt chỉ giải thích nhiệm vụ.",
+    },
+    {
+      id: "comprehend",
+      kind: "comprehend",
+      title: "What does Maya need from you?",
+      instruction: "Choose the information the question is asking for.",
+      modality: "choice",
+      prompt: "What's your name?",
+      targetSignals: ["name"],
+      assessment: {
+        targetCapabilityId: "CAP-002",
+        evidenceType: "recognition",
+        contextId: "first-meeting:name-question:v1",
+        evaluator: "nep-choice-v1",
+      },
+    },
+    {
+      id: "notice",
+      kind: "notice",
+      title: "Keep only the chunks needed for the mission",
+      instruction: "Notice the frames; do not open a grammar chapter.",
+      modality: "read",
+      model: "My name is … / That's … / Could you say that again?",
+      revealsAnswer: false,
+    },
+    {
+      id: "retrieve",
+      kind: "retrieve",
+      title: "Pull the line out before seeing a full answer",
+      instruction: "From the Vietnamese cue, say the English line from memory.",
+      modality: "speech",
+      prompt: "Chào. Tôi tên là Hoàng.",
+      supportVi: "Không hiện đáp án trước lần thử đầu.",
+      targetSignals: ["my name is", "i'm", "i am"],
+      assessment: {
+        targetCapabilityId: "CAP-002",
+        evidenceType: "retrieval",
+        contextId: "first-meeting:vi-cue-introduction:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "produce",
+      kind: "produce",
+      title: "Introduce yourself and spell your name",
+      instruction: "Say the whole response aloud. Browser transcript is used only to check target-language coverage.",
+      modality: "speech",
+      prompt: "Hi, I'm Maya. What's your name?",
+      targetSignals: ["my name is", "i'm", "i am", "that's"],
+      assessment: {
+        targetCapabilityId: "CAP-002",
+        evidenceType: "production",
+        contextId: "first-meeting:name-question:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "feedback",
+      kind: "feedback",
+      title: "Get one actionable language cue",
+      instruction: "Feedback identifies missing target language; it does not score pronunciation.",
+      modality: "read",
+      revealsAnswer: true,
+      model: "Try: My name is Hoang. That's H-O-A-N-G.",
+    },
+    {
+      id: "repair",
+      kind: "repair",
+      title: "Repair the breakdown yourself",
+      instruction: "The colleague's next turn is unclear. Ask for repetition before continuing.",
+      modality: "speech",
+      prompt: "Sorry — [you missed the question].",
+      targetSignals: ["could you say that again", "say that again", "sorry"],
+      assessment: {
+        targetCapabilityId: "CAP-003",
+        evidenceType: "repair",
+        contextId: "first-meeting:missed-turn:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "retry",
+      kind: "retry",
+      title: "Retry the first-meeting response",
+      instruction: "Use the repair move, then introduce yourself again.",
+      modality: "speech",
+      prompt: "Let's try that again. What's your name?",
+      targetSignals: ["could you say that again", "my name is", "i'm", "i am"],
+      assessment: {
+        targetCapabilityId: "CAP-002",
+        evidenceType: null,
+        contextId: "first-meeting:name-question:retry:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "transfer",
+      kind: "transfer",
+      title: "Changed situation: the order flips",
+      instruction: "This time you must ask for repetition first, then answer a differently phrased name question.",
+      modality: "speech",
+      prompt: "I didn't catch that. And what should I call you?",
+      targetSignals: ["could you say that again", "my name is", "i'm", "i am"],
+      changedContext: true,
+      assessment: {
+        targetCapabilityId: "CAP-002",
+        evidenceType: "transfer",
+        contextId: "first-meeting:changed-order-name-question:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+  ],
+};

--- a/src/lib/nep/lesson-contract.ts
+++ b/src/lib/nep/lesson-contract.ts
@@ -34,6 +34,8 @@ export type LessonAction = {
   model?: string;
   supportVi?: string;
   targetSignals?: string[];
+  /** Every group is required; one signal from each group must be observed. */
+  requiredSignalGroups?: string[][];
   changedContext?: boolean;
   revealsAnswer?: boolean;
   assessment?: LessonAssessment;
@@ -76,6 +78,10 @@ const evaluatedKinds = new Set<LessonActionKind>([
   "retry",
   "transfer",
 ]);
+
+function hasEvaluatorTargets(action: LessonAction) {
+  return (action.targetSignals?.length ?? 0) > 0 || (action.requiredSignalGroups?.some((group) => group.length > 0) ?? false);
+}
 
 export function qaLesson(lesson: LessonContract): QaIssue[] {
   const issues: QaIssue[] = [];
@@ -123,6 +129,9 @@ export function qaLesson(lesson: LessonContract): QaIssue[] {
       issues.push({ severity: "error", code: "ASSESSMENT_TARGET_REQUIRED", message: `${action.id} must declare its learning-core assessment target.`, provenance: "product_inference" });
       continue;
     }
+    if (evaluatedKinds.has(action.kind) && !hasEvaluatorTargets(action)) {
+      issues.push({ severity: "error", code: "EVALUATOR_TARGET_REQUIRED", message: `${action.id} must declare deterministic target signals for evaluation.`, provenance: "product_inference" });
+    }
     if (action.assessment && !declaredTargets.has(action.assessment.targetCapabilityId)) {
       issues.push({ severity: "error", code: "ASSESSMENT_TARGET_UNDECLARED", message: `${action.id} targets ${action.assessment.targetCapabilityId}, which is not the lesson capability or an embedded capability.`, provenance: "product_inference" });
     }
@@ -155,12 +164,18 @@ export function qaLesson(lesson: LessonContract): QaIssue[] {
     if (production?.assessment && transfer.assessment.contextId === production.assessment.contextId) {
       issues.push({ severity: "error", code: "TRANSFER_CONTEXT_NOT_CHANGED", message: "Transfer must declare a context different from the earlier successful production context.", provenance: "source_derived" });
     }
+    if ((transfer.requiredSignalGroups?.length ?? 0) < 2) {
+      issues.push({ severity: "error", code: "TRANSFER_REQUIRES_MULTI_DEMAND_EVALUATION", message: "This transfer task must require both the repair move and the transferred introduction response.", provenance: "product_inference" });
+    }
   }
   if (lesson.actions.some((action) => /this is a pen|that is the phone/i.test(action.model ?? action.prompt ?? ""))) {
     issues.push({ severity: "warning", code: "TEXTBOOK_LIKE_LANGUAGE", message: "Editorial review: language resembles isolated textbook examples.", provenance: "product_inference" });
   }
   return issues;
 }
+
+const introduceSignals = ["my name is", "i'm", "i am"];
+const repairSignals = ["could you say that again", "say that again", "sorry"];
 
 export const firstMeetingLessonV1: LessonContract = {
   id: "LESSON-CAP002-FIRST-MEETING-V1",
@@ -228,7 +243,8 @@ export const firstMeetingLessonV1: LessonContract = {
       modality: "speech",
       prompt: "Chào. Tôi tên là Hoàng.",
       supportVi: "Không hiện đáp án trước lần thử đầu.",
-      targetSignals: ["my name is", "i'm", "i am"],
+      targetSignals: introduceSignals,
+      requiredSignalGroups: [introduceSignals],
       assessment: {
         targetCapabilityId: "CAP-002",
         evidenceType: "retrieval",
@@ -239,11 +255,12 @@ export const firstMeetingLessonV1: LessonContract = {
     {
       id: "produce",
       kind: "produce",
-      title: "Introduce yourself and spell your name",
-      instruction: "Say the whole response aloud. Browser transcript is used only to check target-language coverage.",
+      title: "Introduce yourself aloud",
+      instruction: "Say the response aloud. Browser transcript is used only to check target-language coverage.",
       modality: "speech",
       prompt: "Hi, I'm Maya. What's your name?",
-      targetSignals: ["my name is", "i'm", "i am", "that's"],
+      targetSignals: introduceSignals,
+      requiredSignalGroups: [introduceSignals],
       assessment: {
         targetCapabilityId: "CAP-002",
         evidenceType: "production",
@@ -267,7 +284,8 @@ export const firstMeetingLessonV1: LessonContract = {
       instruction: "The colleague's next turn is unclear. Ask for repetition before continuing.",
       modality: "speech",
       prompt: "Sorry — [you missed the question].",
-      targetSignals: ["could you say that again", "say that again", "sorry"],
+      targetSignals: repairSignals,
+      requiredSignalGroups: [repairSignals],
       assessment: {
         targetCapabilityId: "CAP-003",
         evidenceType: "repair",
@@ -282,7 +300,8 @@ export const firstMeetingLessonV1: LessonContract = {
       instruction: "Use the repair move, then introduce yourself again.",
       modality: "speech",
       prompt: "Let's try that again. What's your name?",
-      targetSignals: ["could you say that again", "my name is", "i'm", "i am"],
+      targetSignals: [...repairSignals, ...introduceSignals],
+      requiredSignalGroups: [repairSignals, introduceSignals],
       assessment: {
         targetCapabilityId: "CAP-002",
         evidenceType: null,
@@ -297,7 +316,8 @@ export const firstMeetingLessonV1: LessonContract = {
       instruction: "This time you must ask for repetition first, then answer a differently phrased name question.",
       modality: "speech",
       prompt: "I didn't catch that. And what should I call you?",
-      targetSignals: ["could you say that again", "my name is", "i'm", "i am"],
+      targetSignals: [...repairSignals, ...introduceSignals],
+      requiredSignalGroups: [repairSignals, introduceSignals],
       changedContext: true,
       assessment: {
         targetCapabilityId: "CAP-002",


### PR DESCRIPTION
## Why
PR #59 establishes the durable Attempt → Evidence → LearnerState foundation, but the Nếp preview still lived on a separate branch with local-only evidence. This stacked PR ports that vertical slice directly onto the learning-core foundation and makes the lesson contract declare exactly what each evaluated action is allowed to prove.

## Stack
- Base: `agent/learning-core-foundation` / PR #59
- Head: `agent/nep-learning-evidence-integration`
- Current stack is ahead of #59 and behind by 0 commits.
- No merge to `main` from this PR while #59 remains unmerged.

## Contract changes
Every evaluated Nếp action now declares:
- `targetCapabilityId`
- persisted low-level `evidenceType` or `null` for attempt-only
- stable `contextId`
- deterministic `evaluator`
- target signals, including required signal groups for multi-demand tasks

First-meeting mapping:
- comprehension choice → `recognition / CAP-002`
- retrieval → `retrieval / CAP-002`
- independent first response → `production / CAP-002`
- repair move → `repair / CAP-003`
- retry after answer-bearing feedback → attempt-only
- changed situation → `transfer / CAP-002`

Lesson QA rejects undeclared targets, mismatched evidence types, same-context transfer, mastery evidence on the supported retry, and a transfer evaluator that does not require both parts of the task.

## Deterministic evaluation
Nếp evaluation is contract-driven rather than inferred from UI conditionals. `requiredSignalGroups` means every group must be satisfied by at least one declared signal.

For the first transfer task this prevents a serious false positive: saying only the repair phrase (for example `Sorry`) or only the introduction cannot create successful transfer. The response must contain both the repair move and the self-introduction target language.

This remains language/transcript coverage only. It is not pronunciation or acoustic scoring.

## Persistence integration
- The preview calls canonical `recordLearningAttempt()` after evaluated responses.
- Anonymous preview remains usable; auth-required persistence failure degrades to local-only state instead of blocking the lesson.
- Authenticated attempts go through the same server/domain/DB policy introduced by #59.
- Typed fallback can persist an Attempt but cannot become oral production/repair/transfer evidence.
- Transfer remains authoritative at the database boundary and requires persisted prior production in a genuinely changed context.
- Duplicate evaluation submissions for the same action/response/source/support state are suppressed in the preview UI.
- Inputs are frozen while persistence is in flight to avoid stale request/UI races.

## Privacy boundary
The Nếp adapter does **not** persist raw learner speech/text response content. It stores derived success/failure plus metadata such as response source, response length, lesson/action IDs and support usage.

## Tests
Adds contract, adapter and evaluator regressions for:
- CAP-003 repair vs CAP-002 production/transfer
- product-level comprehension mapped to low-level recognition evidence
- undeclared target rejection
- changed-context transfer
- transfer must evaluate both repair + introduction demands
- repair-only transfer fails
- introduction-only transfer fails
- supported retry attempt-only behavior
- raw transcript non-persistence
- typed fallback rejection by canonical evidence policy

## Verification
The full stack was verified against `main` through temporary draft PR #62 because the current `Verify` workflow only triggers for PRs targeting `main`. On head `3b33ac0d31e2dd0bd4d21f715fc01f1228bf7a00`, all repository checks passed:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

Temporary PR #62 has been closed without merge.

## Scope boundary
This is one vertical slice integration only. It does not add Session Planner, generalized curriculum compilation, acoustic pronunciation scoring, or apply Supabase migrations to production.