### PR TITLE
Add deterministic Session Planner V1

### DIFF
--- a/docs/nep/SESSION_PLANNER_V1.md
+++ b/docs/nep/SESSION_PLANNER_V1.md
@@ -1,0 +1,105 @@
+# Nếp Session Planner V1
+
+Status: deterministic product policy for engineering validation. **Not a validated mastery model and not an efficacy claim.**
+
+## Why this exists
+
+AtoEnglish now has immutable attempts, evidence events and rebuildable learner skill state. The next job is to stop treating a fixed lesson list as the learning policy.
+
+Session Planner V1 answers a narrower question:
+
+> Given the practice opportunities the product can actually serve and the learner state we currently have, which opportunities should be considered next?
+
+It does **not** generate lesson content, change FSRS, score pronunciation, or train a reinforcement-learning policy.
+
+## Inputs
+
+Each plannable opportunity declares:
+
+- stable candidate ID;
+- exact target ID;
+- one low-level evidence type (`recognition`, `retrieval`, `listening`, `production`, `repair`, `transfer`, `retention`);
+- prerequisite target IDs;
+- product importance weight;
+- optional transfer-value weight;
+- metadata needed by the content/lesson layer.
+
+The planner also receives:
+
+- current `LearnerSkillState` snapshots;
+- recent target/candidate history;
+- requested session size;
+- an explicit clock value for deterministic tests/replays.
+
+## Hard gates
+
+V1 refuses to schedule an opportunity when:
+
+1. a declared prerequisite has not reached the configured readiness floor;
+2. transfer is requested before the same target has prior production state above the configured floor;
+3. retention is requested for a target with zero prior evidence;
+4. the same target already reached the per-session opportunity cap.
+
+These thresholds are **product inference**. They are intentionally centralized in `SessionPlannerConfig` so pilot data can change them without pretending they are research constants.
+
+Database evidence invariants remain authoritative. Planner eligibility cannot manufacture evidence that the Attempt → Evidence layer would reject.
+
+## Ranking policy
+
+Eligible candidates receive an explainable score composed from:
+
+- current skill gap for the requested evidence type;
+- cold-start bonus that favors lower-support entry modes before harder productive/transfer modes;
+- staleness of the target's last evidence;
+- product importance;
+- transfer value;
+- recent-target penalty;
+- recent-candidate penalty;
+- in-session repetition penalty.
+
+The score is a **ranking score only**. It must never be displayed or described as a probability that the learner has mastered the skill.
+
+Ties are deterministic: evidence-type order, then stable candidate ID.
+
+## Anti-repetition behavior
+
+Repeated lessons cannot be solved only by text deduplication. Planner V1 penalizes recent target/candidate exposure and caps repeated target selection inside one session.
+
+This works at the semantic target level, so newly generated exercise objects cannot bypass repetition control merely by having different IDs or wording.
+
+The current V1 implementation still needs richer persisted recent-history queries before this policy is connected to the production session route.
+
+## Nếp catalog compilation
+
+`src/lib/nep/session-catalog.v1.ts` compiles only evidence-bearing actions from the explicit Nếp lesson contract.
+
+For the first-meeting slice:
+
+- comprehension → `recognition / CAP-002`;
+- retrieval → `retrieval / CAP-002`;
+- independent response → `production / CAP-002`;
+- repair → `repair / CAP-003`;
+- changed-context task → `transfer / CAP-002`.
+
+The supported retry is omitted because its contract says `evidenceType: null`. Feedback/reveal steps are also omitted: they belong inside the pedagogical flow, not in mastery scheduling.
+
+## What V1 deliberately does not do
+
+- no contextual bandit or reinforcement learning;
+- no learned weights;
+- no claim that learner-state values are calibrated probabilities;
+- no direct production database query yet;
+- no replacement of the internal ordered flow of a lesson mission;
+- no automatic unlock of capabilities for which the product has no servable lesson/task catalog;
+- no acoustic pronunciation assessment.
+
+## Next integration boundary
+
+Before Session Planner controls the learner-facing route, add a server read boundary that returns only the planner inputs needed for the authenticated learner:
+
+1. learner skill states for servable targets;
+2. recent semantic target/candidate history;
+3. due FSRS review pressure where vocabulary items participate in the same session;
+4. catalog availability.
+
+Then the server can call the pure planner and return an auditable session plan. The pure function should remain deterministic so a bad recommendation can be reproduced from stored inputs.

--- a/src/__tests__/nep-session-catalog.test.ts
+++ b/src/__tests__/nep-session-catalog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
+
+describe("Nếp session catalog v1", () => {
+  it("compiles only evidence-bearing evaluated actions", () => {
+    expect(nepSessionCatalogV1.map((candidate) => candidate.metadata?.actionKind)).toEqual([
+      "comprehend",
+      "retrieve",
+      "produce",
+      "repair",
+      "transfer",
+    ]);
+  });
+
+  it("keeps repair on CAP-003 and production/transfer on CAP-002", () => {
+    const repair = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "repair");
+    const production = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "produce");
+    const transfer = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "transfer");
+
+    expect(repair).toMatchObject({ targetId: "CAP-003", evidenceType: "repair" });
+    expect(production).toMatchObject({ targetId: "CAP-002", evidenceType: "production" });
+    expect(transfer).toMatchObject({ targetId: "CAP-002", evidenceType: "transfer" });
+  });
+
+  it("maps comprehension to persisted recognition evidence", () => {
+    const comprehension = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "comprehend");
+    expect(comprehension).toMatchObject({ targetId: "CAP-002", evidenceType: "recognition" });
+  });
+
+  it("does not schedule the supported retry as mastery evidence", () => {
+    expect(nepSessionCatalogV1.some((candidate) => candidate.metadata?.actionKind === "retry")).toBe(false);
+  });
+
+  it("preserves declared lesson prerequisites and stable evaluation context", () => {
+    for (const candidate of nepSessionCatalogV1) {
+      expect(candidate.prerequisiteTargetIds).toEqual(["CAP-001"]);
+      expect(candidate.metadata?.contextId).toBeTypeOf("string");
+      expect(candidate.metadata?.evaluator).toBeTypeOf("string");
+    }
+  });
+});

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import type { LearnerSkillState } from "@/lib/learning/evidence";
+import {
+  planSession,
+  type PlannerCandidate,
+  type SessionPlannerInput,
+} from "@/lib/learning/session-planner";
+
+function state(targetId: string, overrides: Partial<LearnerSkillState> = {}): LearnerSkillState {
+  return {
+    targetId,
+    recognition: 0,
+    retrieval: 0,
+    listening: 0,
+    production: 0,
+    repair: 0,
+    transfer: 0,
+    retention: 0,
+    evidenceCount: 0,
+    lastEvidenceAt: null,
+    ...overrides,
+  };
+}
+
+function candidate(overrides: Partial<PlannerCandidate> & Pick<PlannerCandidate, "id" | "targetId" | "evidenceType">): PlannerCandidate {
+  return {
+    importance: 0.5,
+    transferValue: 0,
+    prerequisiteTargetIds: [],
+    ...overrides,
+  };
+}
+
+const fixedNow = "2026-09-03T00:00:00.000Z";
+
+function plan(input: Omit<SessionPlannerInput, "now">) {
+  return planSession({ ...input, now: fixedNow });
+}
+
+describe("session planner v1", () => {
+  it("is deterministic for identical input", () => {
+    const input = {
+      candidates: [
+        candidate({ id: "cap-a:recognition", targetId: "cap-a", evidenceType: "recognition" }),
+        candidate({ id: "cap-b:retrieval", targetId: "cap-b", evidenceType: "retrieval" }),
+      ],
+      states: [],
+      sessionSize: 2,
+    };
+
+    const first = plan(input);
+    const second = plan(input);
+
+    expect(first).toEqual(second);
+    expect(first.policy).toBe("session-planner-v1");
+  });
+
+  it("blocks candidates whose declared prerequisite is not ready", () => {
+    const result = plan({
+      candidates: [
+        candidate({
+          id: "cap-2:production",
+          targetId: "cap-2",
+          evidenceType: "production",
+          prerequisiteTargetIds: ["cap-1"],
+        }),
+      ],
+      states: [state("cap-1")],
+      sessionSize: 1,
+    });
+
+    expect(result.opportunities).toEqual([]);
+    expect(result.blocked[0]?.reasons).toContain("prerequisite-not-ready:cap-1");
+  });
+
+  it("allows the next capability after enough prerequisite evidence exists", () => {
+    const result = plan({
+      candidates: [
+        candidate({
+          id: "cap-2:production",
+          targetId: "cap-2",
+          evidenceType: "production",
+          prerequisiteTargetIds: ["cap-1"],
+        }),
+      ],
+      states: [state("cap-1", { retrieval: 0.3, evidenceCount: 2 })],
+      sessionSize: 1,
+    });
+
+    expect(result.opportunities[0]?.candidate.id).toBe("cap-2:production");
+  });
+
+  it("blocks transfer until the same target has prior production evidence", () => {
+    const transfer = candidate({
+      id: "cap-a:transfer",
+      targetId: "cap-a",
+      evidenceType: "transfer",
+      transferValue: 1,
+    });
+
+    const blocked = plan({ candidates: [transfer], states: [state("cap-a")], sessionSize: 1 });
+    expect(blocked.opportunities).toEqual([]);
+    expect(blocked.blocked[0]?.reasons).toContain("transfer-needs-prior-production");
+
+    const allowed = plan({
+      candidates: [transfer],
+      states: [state("cap-a", { production: 0.35, evidenceCount: 2 })],
+      sessionSize: 1,
+    });
+    expect(allowed.opportunities[0]?.candidate.id).toBe("cap-a:transfer");
+  });
+
+  it("blocks retention for a target with no prior evidence", () => {
+    const result = plan({
+      candidates: [candidate({ id: "cap-a:retention", targetId: "cap-a", evidenceType: "retention" })],
+      states: [state("cap-a")],
+      sessionSize: 1,
+    });
+
+    expect(result.blocked[0]?.reasons).toContain("retention-needs-prior-evidence");
+  });
+
+  it("prefers recognition over production for an otherwise equal cold-start target", () => {
+    const result = plan({
+      candidates: [
+        candidate({ id: "cap-a:production", targetId: "cap-a", evidenceType: "production" }),
+        candidate({ id: "cap-a:recognition", targetId: "cap-a", evidenceType: "recognition" }),
+      ],
+      states: [],
+      sessionSize: 1,
+    });
+
+    expect(result.opportunities[0]?.candidate.id).toBe("cap-a:recognition");
+  });
+
+  it("uses recent and in-session penalties to avoid hammering one target", () => {
+    const result = plan({
+      candidates: [
+        candidate({ id: "cap-a:recognition", targetId: "cap-a", evidenceType: "recognition", importance: 1 }),
+        candidate({ id: "cap-a:retrieval", targetId: "cap-a", evidenceType: "retrieval", importance: 1 }),
+        candidate({ id: "cap-b:recognition", targetId: "cap-b", evidenceType: "recognition", importance: 0.9 }),
+      ],
+      states: [],
+      sessionSize: 2,
+      recentTargetIds: ["cap-a"],
+    });
+
+    expect(result.opportunities.map((item) => item.candidate.targetId)).toEqual(["cap-b", "cap-a"]);
+  });
+
+  it("caps the number of opportunities for one target inside a session", () => {
+    const result = plan({
+      candidates: [
+        candidate({ id: "a:recognition", targetId: "a", evidenceType: "recognition" }),
+        candidate({ id: "a:retrieval", targetId: "a", evidenceType: "retrieval" }),
+        candidate({ id: "a:listening", targetId: "a", evidenceType: "listening" }),
+      ],
+      states: [],
+      sessionSize: 3,
+      config: { maxPerTarget: 2 },
+    });
+
+    expect(result.opportunities).toHaveLength(2);
+    expect(result.blocked.some((item) => item.reasons.includes("target-session-cap"))).toBe(true);
+  });
+
+  it("gives a stale weak target more urgency than an equally weak fresh target", () => {
+    const result = plan({
+      candidates: [
+        candidate({ id: "old:retrieval", targetId: "old", evidenceType: "retrieval" }),
+        candidate({ id: "fresh:retrieval", targetId: "fresh", evidenceType: "retrieval" }),
+      ],
+      states: [
+        state("old", { retrieval: 0.2, evidenceCount: 3, lastEvidenceAt: "2026-08-01T00:00:00.000Z" }),
+        state("fresh", { retrieval: 0.2, evidenceCount: 3, lastEvidenceAt: "2026-09-02T23:30:00.000Z" }),
+      ],
+      sessionSize: 1,
+    });
+
+    expect(result.opportunities[0]?.candidate.targetId).toBe("old");
+    expect(result.opportunities[0]?.reasons.some((reason) => reason.startsWith("staleness:"))).toBe(true);
+  });
+});

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,0 +1,277 @@
+import type { EvidenceType, LearnerSkillState } from "./evidence";
+import { createEmptyLearnerSkillState } from "./evidence";
+
+export type PlannerCandidate = {
+  id: string;
+  targetId: string;
+  evidenceType: EvidenceType;
+  prerequisiteTargetIds?: string[];
+  importance?: number;
+  transferValue?: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type SessionPlannerConfig = {
+  prerequisiteReadinessFloor: number;
+  transferProductionFloor: number;
+  maxPerTarget: number;
+  recentTargetPenalty: number;
+  recentCandidatePenalty: number;
+  inSessionRepeatPenalty: number;
+};
+
+export type SessionPlannerInput = {
+  candidates: PlannerCandidate[];
+  states: LearnerSkillState[];
+  sessionSize: number;
+  now?: string;
+  recentTargetIds?: string[];
+  recentCandidateIds?: string[];
+  config?: Partial<SessionPlannerConfig>;
+};
+
+export type PlannerScoreBreakdown = {
+  skillGap: number;
+  coldStart: number;
+  staleness: number;
+  importance: number;
+  transferValue: number;
+  recentTargetPenalty: number;
+  recentCandidatePenalty: number;
+  inSessionRepeatPenalty: number;
+  total: number;
+};
+
+export type PlannedOpportunity = {
+  candidate: PlannerCandidate;
+  score: number;
+  breakdown: PlannerScoreBreakdown;
+  reasons: string[];
+};
+
+export type BlockedOpportunity = {
+  candidate: PlannerCandidate;
+  reasons: string[];
+};
+
+export type SessionPlan = {
+  opportunities: PlannedOpportunity[];
+  blocked: BlockedOpportunity[];
+  policy: "session-planner-v1";
+};
+
+export const DEFAULT_SESSION_PLANNER_CONFIG: SessionPlannerConfig = {
+  prerequisiteReadinessFloor: 0.2,
+  transferProductionFloor: 0.2,
+  maxPerTarget: 2,
+  recentTargetPenalty: 0.55,
+  recentCandidatePenalty: 0.75,
+  inSessionRepeatPenalty: 0.8,
+};
+
+const COLD_START_BONUS: Record<EvidenceType, number> = {
+  recognition: 0.4,
+  retrieval: 0.32,
+  listening: 0.26,
+  production: 0.18,
+  repair: 0.12,
+  transfer: 0,
+  retention: 0,
+};
+
+const EVIDENCE_TIE_ORDER: Record<EvidenceType, number> = {
+  recognition: 0,
+  retrieval: 1,
+  listening: 2,
+  production: 3,
+  repair: 4,
+  transfer: 5,
+  retention: 6,
+};
+
+export function planSession(input: SessionPlannerInput): SessionPlan {
+  const config = { ...DEFAULT_SESSION_PLANNER_CONFIG, ...input.config };
+  const states = new Map(input.states.map((state) => [state.targetId, state]));
+  const now = parseTime(input.now) ?? Date.now();
+  const recentTargetIds = input.recentTargetIds ?? [];
+  const recentCandidateIds = input.recentCandidateIds ?? [];
+  const selected: PlannedOpportunity[] = [];
+  const selectedIds = new Set<string>();
+  const targetCounts = new Map<string, number>();
+  const blocked = new Map<string, BlockedOpportunity>();
+  const limit = Math.max(0, Math.floor(input.sessionSize));
+
+  while (selected.length < limit) {
+    const ranked: PlannedOpportunity[] = [];
+
+    for (const candidate of input.candidates) {
+      if (selectedIds.has(candidate.id)) continue;
+
+      const selectedForTarget = targetCounts.get(candidate.targetId) ?? 0;
+      if (selectedForTarget >= config.maxPerTarget) {
+        blocked.set(candidate.id, { candidate, reasons: ["target-session-cap"] });
+        continue;
+      }
+
+      const eligibility = checkEligibility(candidate, states, config);
+      if (!eligibility.eligible) {
+        blocked.set(candidate.id, { candidate, reasons: eligibility.reasons });
+        continue;
+      }
+
+      ranked.push(scoreCandidate({
+        candidate,
+        state: states.get(candidate.targetId) ?? createEmptyLearnerSkillState(candidate.targetId),
+        now,
+        recentTargetIds,
+        recentCandidateIds,
+        selectedForTarget,
+        config,
+      }));
+    }
+
+    ranked.sort(comparePlannedOpportunities);
+    const next = ranked[0];
+    if (!next) break;
+
+    selected.push(next);
+    selectedIds.add(next.candidate.id);
+    targetCounts.set(next.candidate.targetId, (targetCounts.get(next.candidate.targetId) ?? 0) + 1);
+    blocked.delete(next.candidate.id);
+  }
+
+  return {
+    opportunities: selected,
+    blocked: [...blocked.values()].sort((a, b) => a.candidate.id.localeCompare(b.candidate.id)),
+    policy: "session-planner-v1",
+  };
+}
+
+function checkEligibility(
+  candidate: PlannerCandidate,
+  states: Map<string, LearnerSkillState>,
+  config: SessionPlannerConfig,
+): { eligible: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+
+  for (const prerequisiteTargetId of candidate.prerequisiteTargetIds ?? []) {
+    const state = states.get(prerequisiteTargetId) ?? createEmptyLearnerSkillState(prerequisiteTargetId);
+    if (readiness(state) < config.prerequisiteReadinessFloor) {
+      reasons.push(`prerequisite-not-ready:${prerequisiteTargetId}`);
+    }
+  }
+
+  const targetState = states.get(candidate.targetId) ?? createEmptyLearnerSkillState(candidate.targetId);
+  if (candidate.evidenceType === "transfer" && targetState.production < config.transferProductionFloor) {
+    reasons.push("transfer-needs-prior-production");
+  }
+  if (candidate.evidenceType === "retention" && targetState.evidenceCount === 0) {
+    reasons.push("retention-needs-prior-evidence");
+  }
+
+  return { eligible: reasons.length === 0, reasons };
+}
+
+function scoreCandidate(input: {
+  candidate: PlannerCandidate;
+  state: LearnerSkillState;
+  now: number;
+  recentTargetIds: string[];
+  recentCandidateIds: string[];
+  selectedForTarget: number;
+  config: SessionPlannerConfig;
+}): PlannedOpportunity {
+  const { candidate, state, now, recentTargetIds, recentCandidateIds, selectedForTarget, config } = input;
+  const skillGap = 1 - clamp01(state[candidate.evidenceType]);
+  const coldStart = state.evidenceCount === 0 ? COLD_START_BONUS[candidate.evidenceType] : 0;
+  const staleness = calculateStaleness(state.lastEvidenceAt, now);
+  const importance = clamp01(candidate.importance ?? 0.5);
+  const transferValue = clamp01(candidate.transferValue ?? 0);
+  const recentTargetPenalty = countMatches(recentTargetIds, candidate.targetId) * config.recentTargetPenalty;
+  const recentCandidatePenalty = countMatches(recentCandidateIds, candidate.id) * config.recentCandidatePenalty;
+  const inSessionRepeatPenalty = selectedForTarget * config.inSessionRepeatPenalty;
+
+  const total =
+    skillGap * 1.35
+    + coldStart
+    + staleness * 0.35
+    + importance * 0.45
+    + transferValue * 0.25
+    - recentTargetPenalty
+    - recentCandidatePenalty
+    - inSessionRepeatPenalty;
+
+  const reasons = [
+    `skill-gap:${round(skillGap)}`,
+    `importance:${round(importance)}`,
+  ];
+  if (coldStart > 0) reasons.push(`cold-start:${candidate.evidenceType}`);
+  if (staleness > 0) reasons.push(`staleness:${round(staleness)}`);
+  if (transferValue > 0) reasons.push(`transfer-value:${round(transferValue)}`);
+  if (recentTargetPenalty > 0 || recentCandidatePenalty > 0) reasons.push("recent-practice-penalty");
+  if (inSessionRepeatPenalty > 0) reasons.push("in-session-diversity-penalty");
+
+  return {
+    candidate,
+    score: total,
+    breakdown: {
+      skillGap,
+      coldStart,
+      staleness,
+      importance,
+      transferValue,
+      recentTargetPenalty,
+      recentCandidatePenalty,
+      inSessionRepeatPenalty,
+      total,
+    },
+    reasons,
+  };
+}
+
+function readiness(state: LearnerSkillState) {
+  return Math.max(
+    state.retrieval,
+    state.production,
+    state.transfer,
+    state.retention,
+    state.recognition * 0.5,
+    state.listening * 0.5,
+  );
+}
+
+function calculateStaleness(lastEvidenceAt: string | null, now: number) {
+  if (!lastEvidenceAt) return 0;
+  const last = parseTime(lastEvidenceAt);
+  if (last === null || last >= now) return 0;
+  const ageDays = (now - last) / 86_400_000;
+  return clamp01(ageDays / 14);
+}
+
+function parseTime(value?: string | null) {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function countMatches(values: string[], needle: string) {
+  return values.reduce((count, value) => count + (value === needle ? 1 : 0), 0);
+}
+
+function comparePlannedOpportunities(a: PlannedOpportunity, b: PlannedOpportunity) {
+  const scoreDifference = b.score - a.score;
+  if (Math.abs(scoreDifference) > 1e-9) return scoreDifference;
+
+  const evidenceDifference = EVIDENCE_TIE_ORDER[a.candidate.evidenceType] - EVIDENCE_TIE_ORDER[b.candidate.evidenceType];
+  if (evidenceDifference !== 0) return evidenceDifference;
+
+  return a.candidate.id.localeCompare(b.candidate.id);
+}
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function round(value: number) {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/lib/nep/session-catalog.v1.ts
+++ b/src/lib/nep/session-catalog.v1.ts
@@ -1,0 +1,49 @@
+import type { PlannerCandidate } from "../learning/session-planner";
+import { firstMeetingLessonV1, type LessonActionKind, type LessonContract } from "./lesson-contract";
+
+const IMPORTANCE_BY_ACTION: Partial<Record<LessonActionKind, number>> = {
+  comprehend: 0.8,
+  retrieve: 1,
+  produce: 1,
+  repair: 0.9,
+  transfer: 0.9,
+};
+
+const TRANSFER_VALUE_BY_ACTION: Partial<Record<LessonActionKind, number>> = {
+  retrieve: 0.35,
+  produce: 0.7,
+  repair: 0.8,
+  transfer: 1,
+};
+
+/**
+ * Compile only evaluated, evidence-bearing opportunities into the planner catalog.
+ * Supported retry is intentionally omitted because its assessment is attempt-only.
+ * Feedback/reveal steps remain inside the lesson flow and are never scheduled as mastery evidence.
+ */
+export function buildLessonPlannerCandidates(lesson: LessonContract): PlannerCandidate[] {
+  return lesson.actions.flatMap((action) => {
+    const assessment = action.assessment;
+    if (!assessment?.evidenceType) return [];
+
+    return [{
+      id: `${lesson.id}:${action.id}`,
+      targetId: assessment.targetCapabilityId,
+      evidenceType: assessment.evidenceType,
+      prerequisiteTargetIds: lesson.prerequisites,
+      importance: IMPORTANCE_BY_ACTION[action.kind] ?? 0.5,
+      transferValue: TRANSFER_VALUE_BY_ACTION[action.kind] ?? 0,
+      metadata: {
+        lessonId: lesson.id,
+        lessonVersion: lesson.version,
+        actionId: action.id,
+        actionKind: action.kind,
+        modality: action.modality,
+        contextId: assessment.contextId,
+        evaluator: assessment.evaluator,
+      },
+    }];
+  });
+}
+
+export const nepSessionCatalogV1 = buildLessonPlannerCandidates(firstMeetingLessonV1);


### PR DESCRIPTION
## Why
AtoEnglish now has durable Attempt → Evidence → LearnerState and one Nếp vertical slice wired to that foundation. The next core step is a deterministic policy that can rank what practice opportunity should come next without pretending the learner-state heuristic is a validated mastery probability.

## Stack
- Base: `agent/nep-learning-evidence-integration` / PR #61
- Head: `agent/session-planner-v1`
- This PR is pure planner/catalog/tests/docs only. No Supabase migration and no learner-facing route change.

## Session Planner V1
Adds a pure, deterministic `planSession()` policy over:
- servable practice candidates;
- `LearnerSkillState` snapshots;
- recent semantic target/candidate history;
- requested session size;
- explicit clock input for replayable tests.

Ranking uses an explainable breakdown:
- skill gap for the requested evidence type;
- cold-start bonus;
- staleness;
- product importance;
- transfer value;
- recent target/candidate penalties;
- in-session repetition penalty.

The score is a ranking score only. It is not a calibrated mastery probability.

## Hard gates
V1 blocks opportunities when:
- declared prerequisites are below the configured readiness floor;
- transfer is requested before prior production state exists for the same target;
- retention is requested before any prior evidence exists;
- one target reaches the configured per-session cap.

Database Attempt → Evidence invariants remain authoritative. Planner eligibility cannot manufacture evidence that persistence would reject.

## Anti-repetition
Repeated learning is controlled at semantic target/candidate level rather than only text-level deduplication. Recent exposure and in-session repeats are penalized, and each target has a hard per-session cap.

## Nếp catalog
Adds `session-catalog.v1.ts`, compiled from the explicit lesson assessment contract:
- comprehension → recognition / CAP-002
- retrieval → retrieval / CAP-002
- production → production / CAP-002
- repair → repair / CAP-003
- transfer → transfer / CAP-002

Supported retry is omitted because its contract is attempt-only (`evidenceType: null`). Feedback/reveal steps are not planner mastery opportunities.

## Tests
Covers:
- deterministic replay;
- prerequisite gating/unlock;
- transfer production prerequisite;
- retention prior-evidence gate;
- cold-start ordering;
- recent/in-session anti-repeat behavior;
- per-target session cap;
- stale weak-skill urgency;
- exact Nếp evidence target compilation;
- retry exclusion.

## Verification
The full stack was verified against `main` through temporary draft PR #64 because the current `Verify` workflow only triggers for PRs targeting `main`.

On head `19f8d650970b71cfb9fc36d51adbe505956dbbca`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

Temporary PR #64 has been closed without merge.

## Scope boundary
Not included yet:
- server read boundary for learner states/history;
- actual learner-facing session route integration;
- FSRS pressure mixed into one session plan;
- contextual bandit/RL;
- learned policy weights;
- acoustic pronunciation scoring.

See `docs/nep/SESSION_PLANNER_V1.md` for policy rationale and next integration boundary.