### PR TITLE
Add authenticated Session Planner read boundary

### DIFF
--- a/src/__tests__/session-input.test.ts
+++ b/src/__tests__/session-input.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectPlannerTargetIds,
+  deriveRecentPlannerHistory,
+  mapLearnerSkillStateRow,
+  normalizeSessionSize,
+  PLANNER_RECENT_ATTEMPT_SELECT,
+  PLANNER_SKILL_STATE_SELECT,
+  type LearnerSkillStateRow,
+  type RecentLearningAttemptRow,
+} from "@/lib/learning/session-input";
+import type { PlannerCandidate } from "@/lib/learning/session-planner";
+
+function stateRow(overrides: Partial<LearnerSkillStateRow> = {}): LearnerSkillStateRow {
+  return {
+    target_id: "CAP-002",
+    recognition: 0.2,
+    retrieval: 0.3,
+    listening: 0.4,
+    production: 0.5,
+    repair: 0.1,
+    transfer: 0.05,
+    retention: 0.25,
+    evidence_count: 3,
+    last_evidence_at: "2026-09-02T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function recentRow(overrides: Partial<RecentLearningAttemptRow> = {}): RecentLearningAttemptRow {
+  return {
+    capability_id: "CAP-002",
+    knowledge_item_id: null,
+    prompt_id: "produce",
+    lesson_id: "LESSON-CAP002-FIRST-MEETING-V1",
+    action_id: "produce",
+    created_at: "2026-09-02T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Session Planner read-model adapters", () => {
+  it("maps DB learner state to the planner shape and clamps malformed values", () => {
+    const mapped = mapLearnerSkillStateRow(stateRow({
+      recognition: 1.4,
+      retrieval: -0.2,
+      evidence_count: -3,
+    }));
+
+    expect(mapped).toMatchObject({
+      targetId: "CAP-002",
+      recognition: 1,
+      retrieval: 0,
+      evidenceCount: 0,
+      lastEvidenceAt: "2026-09-02T12:00:00.000Z",
+    });
+  });
+
+  it("collects both candidate targets and prerequisite targets exactly once", () => {
+    const candidates: PlannerCandidate[] = [
+      {
+        id: "a",
+        targetId: "CAP-002",
+        evidenceType: "production",
+        prerequisiteTargetIds: ["CAP-001"],
+      },
+      {
+        id: "b",
+        targetId: "CAP-003",
+        evidenceType: "repair",
+        prerequisiteTargetIds: ["CAP-001"],
+      },
+    ];
+
+    expect(collectPlannerTargetIds(candidates)).toEqual(["CAP-001", "CAP-002", "CAP-003"]);
+  });
+
+  it("derives anti-repetition history from attempts even though they are not mastery evidence", () => {
+    const history = deriveRecentPlannerHistory([
+      recentRow(),
+      recentRow({
+        capability_id: "CAP-003",
+        prompt_id: "repair",
+        action_id: "repair",
+      }),
+    ]);
+
+    expect(history.recentTargetIds).toEqual(["CAP-002", "CAP-003"]);
+    expect(history.recentCandidateIds).toEqual([
+      "LESSON-CAP002-FIRST-MEETING-V1:produce",
+      "LESSON-CAP002-FIRST-MEETING-V1:repair",
+    ]);
+  });
+
+  it("falls back to prompt_id when projected action_id is absent", () => {
+    const history = deriveRecentPlannerHistory([
+      recentRow({ action_id: null, prompt_id: "transfer" }),
+    ]);
+
+    expect(history.recentCandidateIds).toEqual([
+      "LESSON-CAP002-FIRST-MEETING-V1:transfer",
+    ]);
+  });
+
+  it("supports knowledge-item history without inventing a candidate id", () => {
+    const history = deriveRecentPlannerHistory([
+      recentRow({
+        capability_id: null,
+        knowledge_item_id: "word:borrow",
+        lesson_id: null,
+        action_id: null,
+      }),
+    ]);
+
+    expect(history.recentTargetIds).toEqual(["word:borrow"]);
+    expect(history.recentCandidateIds).toEqual([]);
+  });
+
+  it("clamps requested session size to a small bounded range", () => {
+    expect(normalizeSessionSize(undefined)).toBe(5);
+    expect(normalizeSessionSize(0)).toBe(1);
+    expect(normalizeSessionSize(3.9)).toBe(3);
+    expect(normalizeSessionSize(99)).toBe(12);
+    expect(normalizeSessionSize(Number.NaN, 4)).toBe(4);
+  });
+
+  it("locks the planner projections to non-sensitive fields", () => {
+    expect(PLANNER_SKILL_STATE_SELECT).not.toContain("user_id");
+    expect(PLANNER_RECENT_ATTEMPT_SELECT).not.toContain("response_text");
+    expect(PLANNER_RECENT_ATTEMPT_SELECT).not.toMatch(/(?:^|,)\s*metadata\s*(?:,|$)/);
+    expect(PLANNER_RECENT_ATTEMPT_SELECT).toContain("lesson_id:metadata->>lessonId");
+    expect(PLANNER_RECENT_ATTEMPT_SELECT).toContain("action_id:metadata->>actionId");
+  });
+});

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -69,10 +69,11 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
       .in("target_id", targetIds)
       .limit(100);
 
-    // Attempts are used only as recent exposure history. Do not select response_text.
+    // Attempts are exposure history only. Project just the semantic planner keys from JSON;
+    // do not fetch response_text or the full metadata object.
     const recentAttemptQuery = readClient
       .from<RecentLearningAttemptRow>("learning_attempts")
-      .select("capability_id, knowledge_item_id, prompt_id, metadata, created_at")
+      .select("capability_id, knowledge_item_id, prompt_id, lesson_id:metadata->>lessonId, action_id:metadata->>actionId, created_at")
       .eq("user_id", user.id)
       .in("capability_id", targetIds)
       .order("created_at", { ascending: false })
@@ -106,6 +107,7 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
         stateCount: states.length,
         recentAttemptCount: recentAttemptResult.data?.length ?? 0,
         rawResponseSelected: false,
+        fullMetadataSelected: false,
       },
     };
   } catch (error) {

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -1,0 +1,115 @@
+"use server";
+
+import { headers } from "next/headers";
+
+import {
+  collectPlannerTargetIds,
+  deriveRecentPlannerHistory,
+  mapLearnerSkillStateRow,
+  normalizeSessionSize,
+  type LearnerSkillStateRow,
+  type RecentLearningAttemptRow,
+} from "@/lib/learning/session-input";
+import { planSession } from "@/lib/learning/session-planner";
+import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
+
+const plannerReadLimiter = createRateLimiter(90, 60 * 1000, "session-planner-read");
+
+type QueryError = { message: string } | null;
+type QueryResult<T> = Promise<{ data: T[] | null; error: QueryError }>;
+
+type PlannerQuery<T> = {
+  select: (columns: string) => PlannerQuery<T>;
+  eq: (column: string, value: string) => PlannerQuery<T>;
+  in: (column: string, values: string[]) => PlannerQuery<T>;
+  order: (column: string, options: { ascending: boolean }) => PlannerQuery<T>;
+  limit: (count: number) => QueryResult<T>;
+};
+
+type PlannerReadClient = {
+  from: <T>(table: string) => PlannerQuery<T>;
+};
+
+export type GetNếpSessionPlanInput = {
+  sessionSize?: number;
+};
+
+/**
+ * Read-only authenticated boundary for Session Planner V1.
+ * It deliberately selects no raw response/transcript content and does not mutate learner state.
+ * This action is not yet wired to the learner-facing route.
+ */
+export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) {
+  try {
+    const reqHeaders = await headers();
+    const ip = reqHeaders.get("x-forwarded-for")?.split(",")[0].trim() || "127.0.0.1";
+    const rateLimitCheck = await plannerReadLimiter.check(ip);
+    if (!rateLimitCheck.success) {
+      return { success: false, error: "Yêu cầu quá thường xuyên. Vui lòng thử lại sau." };
+    }
+
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: "Bạn cần đăng nhập để tạo session học thích ứng." };
+    }
+
+    const sessionSize = normalizeSessionSize(
+      typeof input.sessionSize === "number" ? input.sessionSize : undefined,
+    );
+    const targetIds = collectPlannerTargetIds(nepSessionCatalogV1);
+    const readClient = supabase as unknown as PlannerReadClient;
+
+    const stateQuery = readClient
+      .from<LearnerSkillStateRow>("learner_skill_states")
+      .select("target_id, recognition, retrieval, listening, production, repair, transfer, retention, evidence_count, last_evidence_at")
+      .eq("user_id", user.id)
+      .in("target_id", targetIds)
+      .limit(100);
+
+    // Attempts are used only as recent exposure history. Do not select response_text.
+    const recentAttemptQuery = readClient
+      .from<RecentLearningAttemptRow>("learning_attempts")
+      .select("capability_id, knowledge_item_id, prompt_id, metadata, created_at")
+      .eq("user_id", user.id)
+      .in("capability_id", targetIds)
+      .order("created_at", { ascending: false })
+      .limit(40);
+
+    const [stateResult, recentAttemptResult] = await Promise.all([stateQuery, recentAttemptQuery]);
+    if (stateResult.error) {
+      return { success: false, error: `Không thể đọc learner state: ${stateResult.error.message}` };
+    }
+    if (recentAttemptResult.error) {
+      return { success: false, error: `Không thể đọc lịch sử practice gần đây: ${recentAttemptResult.error.message}` };
+    }
+
+    const states = (stateResult.data ?? []).map(mapLearnerSkillStateRow);
+    const recentHistory = deriveRecentPlannerHistory(recentAttemptResult.data ?? []);
+    const plan = planSession({
+      candidates: nepSessionCatalogV1,
+      states,
+      sessionSize,
+      now: new Date().toISOString(),
+      recentTargetIds: recentHistory.recentTargetIds,
+      recentCandidateIds: recentHistory.recentCandidateIds,
+    });
+
+    return {
+      success: true,
+      plan,
+      diagnostics: {
+        sessionSize,
+        catalogSize: nepSessionCatalogV1.length,
+        stateCount: states.length,
+        recentAttemptCount: recentAttemptResult.data?.length ?? 0,
+        rawResponseSelected: false,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: `Lỗi hệ thống khi tạo session plan: ${message}` };
+  }
+}

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -7,6 +7,8 @@ import {
   deriveRecentPlannerHistory,
   mapLearnerSkillStateRow,
   normalizeSessionSize,
+  PLANNER_RECENT_ATTEMPT_SELECT,
+  PLANNER_SKILL_STATE_SELECT,
   type LearnerSkillStateRow,
   type RecentLearningAttemptRow,
 } from "@/lib/learning/session-input";
@@ -64,7 +66,7 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
 
     const stateQuery = readClient
       .from<LearnerSkillStateRow>("learner_skill_states")
-      .select("target_id, recognition, retrieval, listening, production, repair, transfer, retention, evidence_count, last_evidence_at")
+      .select(PLANNER_SKILL_STATE_SELECT)
       .eq("user_id", user.id)
       .in("target_id", targetIds)
       .limit(100);
@@ -73,7 +75,7 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
     // do not fetch response_text or the full metadata object.
     const recentAttemptQuery = readClient
       .from<RecentLearningAttemptRow>("learning_attempts")
-      .select("capability_id, knowledge_item_id, prompt_id, lesson_id:metadata->>lessonId, action_id:metadata->>actionId, created_at")
+      .select(PLANNER_RECENT_ATTEMPT_SELECT)
       .eq("user_id", user.id)
       .in("capability_id", targetIds)
       .order("created_at", { ascending: false })

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -1,6 +1,12 @@
 import type { LearnerSkillState } from "./evidence";
 import type { PlannerCandidate } from "./session-planner";
 
+export const PLANNER_SKILL_STATE_SELECT =
+  "target_id, recognition, retrieval, listening, production, repair, transfer, retention, evidence_count, last_evidence_at";
+
+export const PLANNER_RECENT_ATTEMPT_SELECT =
+  "capability_id, knowledge_item_id, prompt_id, lesson_id:metadata->>lessonId, action_id:metadata->>actionId, created_at";
+
 export type LearnerSkillStateRow = {
   target_id: string;
   recognition: number;

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -1,0 +1,91 @@
+import type { LearnerSkillState } from "./evidence";
+import type { PlannerCandidate } from "./session-planner";
+
+export type LearnerSkillStateRow = {
+  target_id: string;
+  recognition: number;
+  retrieval: number;
+  listening: number;
+  production: number;
+  repair: number;
+  transfer: number;
+  retention: number;
+  evidence_count: number;
+  last_evidence_at: string | null;
+};
+
+export type RecentLearningAttemptRow = {
+  capability_id: string | null;
+  knowledge_item_id: string | null;
+  prompt_id: string | null;
+  metadata: unknown;
+  created_at: string;
+};
+
+export type RecentPlannerHistory = {
+  recentTargetIds: string[];
+  recentCandidateIds: string[];
+};
+
+export function mapLearnerSkillStateRow(row: LearnerSkillStateRow): LearnerSkillState {
+  return {
+    targetId: row.target_id,
+    recognition: clamp01(row.recognition),
+    retrieval: clamp01(row.retrieval),
+    listening: clamp01(row.listening),
+    production: clamp01(row.production),
+    repair: clamp01(row.repair),
+    transfer: clamp01(row.transfer),
+    retention: clamp01(row.retention),
+    evidenceCount: Math.max(0, Math.floor(row.evidence_count)),
+    lastEvidenceAt: row.last_evidence_at,
+  };
+}
+
+export function collectPlannerTargetIds(candidates: PlannerCandidate[]): string[] {
+  const ids = new Set<string>();
+  for (const candidate of candidates) {
+    ids.add(candidate.targetId);
+    for (const prerequisite of candidate.prerequisiteTargetIds ?? []) ids.add(prerequisite);
+  }
+  return [...ids].sort();
+}
+
+/**
+ * Recent attempts are exposure history, not mastery evidence. An attempt that failed,
+ * used support, or produced no evidence still counts for anti-repetition.
+ */
+export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): RecentPlannerHistory {
+  const recentTargetIds: string[] = [];
+  const recentCandidateIds: string[] = [];
+
+  for (const row of rows) {
+    const targetId = row.capability_id ?? row.knowledge_item_id;
+    if (targetId) recentTargetIds.push(targetId);
+
+    const metadata = asRecord(row.metadata);
+    const lessonId = asNonEmptyString(metadata?.lessonId);
+    const actionId = asNonEmptyString(metadata?.actionId) ?? asNonEmptyString(row.prompt_id);
+    if (lessonId && actionId) recentCandidateIds.push(`${lessonId}:${actionId}`);
+  }
+
+  return { recentTargetIds, recentCandidateIds };
+}
+
+export function normalizeSessionSize(value: number | undefined, fallback = 5) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(12, Math.max(1, Math.floor(value!)));
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, Number.isFinite(value) ? value : 0));
+}

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -73,8 +73,8 @@ export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): Re
 }
 
 export function normalizeSessionSize(value: number | undefined, fallback = 5) {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.min(12, Math.max(1, Math.floor(value!)));
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(12, Math.max(1, Math.floor(value)));
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -18,7 +18,8 @@ export type RecentLearningAttemptRow = {
   capability_id: string | null;
   knowledge_item_id: string | null;
   prompt_id: string | null;
-  metadata: unknown;
+  lesson_id: string | null;
+  action_id: string | null;
   created_at: string;
 };
 
@@ -63,9 +64,8 @@ export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): Re
     const targetId = row.capability_id ?? row.knowledge_item_id;
     if (targetId) recentTargetIds.push(targetId);
 
-    const metadata = asRecord(row.metadata);
-    const lessonId = asNonEmptyString(metadata?.lessonId);
-    const actionId = asNonEmptyString(metadata?.actionId) ?? asNonEmptyString(row.prompt_id);
+    const lessonId = asNonEmptyString(row.lesson_id);
+    const actionId = asNonEmptyString(row.action_id) ?? asNonEmptyString(row.prompt_id);
     if (lessonId && actionId) recentCandidateIds.push(`${lessonId}:${actionId}`);
   }
 
@@ -75,11 +75,6 @@ export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): Re
 export function normalizeSessionSize(value: number | undefined, fallback = 5) {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.min(12, Math.max(1, Math.floor(value)));
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
 }
 
 function asNonEmptyString(value: unknown) {


### PR DESCRIPTION
## Why
Session Planner V1 is intentionally pure and deterministic. This PR adds the next boundary: read the authenticated learner state and recent semantic practice history needed by the planner without yet letting the planner control the learner-facing route.

## Stack
- Base: `agent/session-planner-v1` / PR #63
- Head: `agent/session-planner-read-boundary`
- Foundation/integration updates are merge-forwarded through the stack; this branch is behind its base by 0 commits.
- No production migration is applied by this PR.

## Read boundary
Adds `getNếpSessionPlan()` as a read-only server action:
- authenticates with `auth.getUser()`;
- applies a bounded read rate limit;
- reads only the current learner's rows through existing RLS;
- fetches planner state only for targets the current Nếp catalog can serve;
- reads recent attempts only as exposure history for anti-repetition;
- calls the pure `planSession()` policy and returns the explainable plan.

This action is not wired to the learner-facing route yet.

## Data minimization
The planner does not need learner speech/text content. The SQL projections intentionally exclude:
- `response_text`;
- the full attempt `metadata` object;
- unrelated attempt fields.

Recent attempt projection is limited to semantic planner keys:
- capability/knowledge target;
- prompt id;
- projected `lessonId` and `actionId` from JSON metadata;
- timestamp.

Tests lock these projections so a later refactor cannot silently start loading raw transcripts into the planner. Current Supabase documentation confirms JSON field alias projections such as `description: metadata->>description` are supported by the JavaScript `.select()` surface.

## Exposure ≠ mastery
Recent attempts are used for anti-repetition even when they failed, used support, or produced no mastery evidence. Learner mastery continues to come from `learner_skill_states` rebuilt from evidence events.

## Input adapters
Adds pure adapters for:
- DB row → `LearnerSkillState` with defensive clamping;
- candidate + prerequisite target collection;
- recent attempt → semantic target/candidate history;
- bounded session-size normalization.

## Cross-stack oral-evidence fix
While adding this boundary, a DB/application mismatch was found and fixed in the foundation stack: Nếp deliberately persists no raw transcript, while the original DB invariant required non-empty `response_text` for successful oral evidence.

The foundation now accepts an oral observation when either:
- an explicit response text was intentionally persisted, or
- privacy-safe derived metadata says `responseSource = speech` and `responseLength > 0`.

This is application-observed speech, not cryptographic microphone attestation and not pronunciation/acoustic scoring. Empty/unobserved speech cannot create positive or negative oral mastery evidence.

## Tests
Adds read-model regressions for:
- learner-state mapping/clamping;
- prerequisite target collection;
- exposure-history derivation;
- candidate-id reconstruction;
- knowledge-item fallback behavior;
- bounded session size;
- privacy-safe SELECT projections.

The foundation also includes regression coverage for privacy-safe oral evidence and the corrective SQL migration contract.

## Verification
Temporary draft PR #66 ran the repository's full `Verify` workflow against `main` for stacked head `6382f8fa29974e74aa44532efccf8f986c2da4d8`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #66 was closed without merge after verification. PR #65 is mergeable and remains draft.

## Scope boundary
Not included:
- route/UI integration;
- production migration execution;
- a paid Supabase development branch;
- live Postgres migration execution test;
- FSRS due pressure mixed into capability planning;
- RL/bandit policy;
- acoustic pronunciation scoring.

The connected AtoEnglish Supabase project currently has only its default database branch. A live isolated Postgres/Supabase migration + RLS test therefore remains a deployment gate before applying the learning-core migrations to production.