### PR TITLE
Add Structured Error Signals V1

### DIFF
--- a/docs/nep/STRUCTURED_ERROR_SIGNALS_V1.md
+++ b/docs/nep/STRUCTURED_ERROR_SIGNALS_V1.md
@@ -1,0 +1,121 @@
+# Structured Error Signals V1
+
+## Purpose
+
+AtoEnglish needs to know more than whether one task passed or failed. Session planning and later error repair need a compact, privacy-safe description of **which declared task demand was missing**.
+
+Structured Error Signals V1 upgrades the Nếp deterministic evaluator from a boolean-only surface to a result that contains:
+
+- `success`;
+- whether any response was observed;
+- matched target-group indexes;
+- missing target-group indexes;
+- stable error tags.
+
+The original learner transcript is not part of this signal object and is not persisted by the Nếp adapter.
+
+## Contract
+
+```ts
+NếpEvaluationResult {
+  success
+  evaluator: "nep-evaluator-v2"
+  observedResponse
+  matchedTargetGroupIndexes
+  missingTargetGroupIndexes
+  errorTags
+}
+```
+
+Current error tags are deliberately narrow:
+
+- `no-response`
+- `incorrect-choice`
+- `partial-target-coverage`
+- `missing-target-group:<index>`
+
+The group index refers to the action's existing `requiredSignalGroups`. V1 does not change the lesson schema just to add labels.
+
+## Single source of truth
+
+The same `NếpEvaluationResult` drives:
+
+1. learner-facing feedback;
+2. `attempt.correct`;
+3. evidence success/failure;
+4. persisted derived error metadata.
+
+The adapter does not accept a separate `correct` boolean. This prevents a caller from accidentally persisting `success=true` alongside error signals that describe a failed evaluation.
+
+## Persistence shape
+
+Attempt/evidence metadata contains a derived `errorSignals` object:
+
+```ts
+{
+  version: 1,
+  evaluator: "nep-evaluator-v2",
+  observedResponse: true,
+  matchedTargetGroupIndexes: [0],
+  missingTargetGroupIndexes: [1],
+  errorTags: ["partial-target-coverage", "missing-target-group:1"]
+}
+```
+
+Task identity (`lessonId`, `lessonVersion`, `actionId`) is stored beside it. That is enough to resolve what group index `1` meant for the exact lesson version without duplicating target language into learner-history rows.
+
+## Privacy boundary
+
+Nếp continues to persist:
+
+- response source/modality;
+- response length;
+- derived target-coverage signals;
+- support usage;
+- task identity.
+
+It does **not** persist the raw learner transcript through this adapter.
+
+For oral evidence, `responseSource = speech` plus a positive `responseLength` remains the privacy-safe observation used by the learning-core invariant. An unobserved response cannot become either positive or negative oral mastery evidence.
+
+## Feedback behavior
+
+V1 can distinguish failures such as:
+
+- transfer response has the repair move but is missing self-introduction;
+- transfer response has self-introduction but is missing the repair move;
+- both target groups are missing;
+- no response was observed;
+- comprehension choice was incorrect.
+
+This lets feedback tell the learner what to repair instead of returning a generic failure message.
+
+## What V1 does not claim
+
+A Structured Error Signal is **not** automatically:
+
+- a grammar-error diagnosis;
+- a pronunciation score;
+- a fluency score;
+- an acoustic-quality judgment;
+- a persistent misconception;
+- a calibrated learner probability;
+- proof that the microphone was genuinely used.
+
+It means only that the deterministic evaluator did or did not find one of the lesson's declared target-language groups in the observed response representation.
+
+## Next boundary: Error Memory
+
+A later read model may aggregate repeated error tags across attempts, but it should require recurrence before treating a signal as an error pattern. One failed task is an observation, not a learner trait.
+
+A safe first aggregation policy should consider:
+
+- target/capability;
+- lesson/action version;
+- error tag;
+- independent vs supported attempt;
+- recency;
+- recurrence count;
+- whether later independent attempts repaired the same demand.
+
+Only after that aggregation exists should Session Planner receive an explicit `errorRepairPressure` term. V1 does not change planner weights yet.

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -5,7 +5,7 @@ import { useMemo, useRef, useState } from "react";
 
 import { recordLearningAttempt } from "@/app/actions/learning-evidence";
 import { capabilityGraphV1 } from "@/lib/nep/capabilities.v1";
-import { evaluateNếpActionResponse } from "@/lib/nep/evaluator";
+import { evaluateNếpAction, feedbackForNếpEvaluation, type NếpEvaluationResult } from "@/lib/nep/evaluator";
 import { firstMeetingLessonV1, qaLesson } from "@/lib/nep/lesson-contract";
 import { toLearningAttemptRecord } from "@/lib/nep/learning-evidence-adapter";
 
@@ -130,7 +130,7 @@ export function DataDrivenPreview() {
     recognition.start();
   };
 
-  const persistEvaluation = async (correct: boolean) => {
+  const persistEvaluation = async (evaluation: NếpEvaluationResult) => {
     const submissionKey = `${action.id}|${answerSource ?? "none"}|support:${supportUsed ? 1 : 0}|${answer.trim()}`;
     if (lastSubmissionKey.current === submissionKey) return;
 
@@ -141,7 +141,7 @@ export function DataDrivenPreview() {
       action,
       response: answer,
       responseSource: answerSource,
-      correct,
+      evaluation,
       supportUsed,
       latencyMs,
     });
@@ -166,11 +166,12 @@ export function DataDrivenPreview() {
   const evaluate = async () => {
     if (saving) return;
 
-    const ok = evaluateNếpActionResponse(action, answer);
+    const evaluation = evaluateNếpAction(action, answer);
+    const ok = evaluation.success;
     if (action.kind === "comprehend") {
       setEvidence((current) => ({ ...current, comprehension: ok }));
-      setFeedback(ok ? "Đúng: Maya đang hỏi tên." : "Chưa đúng. Câu hỏi đang cần một thông tin cá nhân cụ thể.");
-      await persistEvaluation(ok);
+      setFeedback(ok ? "Đúng: Maya đang hỏi tên." : feedbackForNếpEvaluation(action, evaluation));
+      await persistEvaluation(evaluation);
       return;
     }
 
@@ -183,19 +184,23 @@ export function DataDrivenPreview() {
     }
 
     if (channel && answerSource !== "speech") {
-      setFeedback(ok ? "Text có target language, nhưng không cộng speaking evidence vì không có oral response quan sát được." : "Text chưa đáp ứng đủ target language của task. Đây không phải pronunciation feedback.");
-      await persistEvaluation(ok);
+      setFeedback(
+        ok
+          ? "Text có đủ target language, nhưng không cộng speaking evidence vì không có oral response quan sát được."
+          : `${feedbackForNếpEvaluation(action, evaluation)} Text fallback không tạo speaking evidence.`,
+      );
+      await persistEvaluation(evaluation);
       return;
     }
 
     if (channel === "transfer" && ok && !evidence.production) {
       setFeedback("Transcript đáp ứng task, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
-      await persistEvaluation(ok);
+      await persistEvaluation(evaluation);
       return;
     }
 
-    setFeedback(ok ? "Transcript đáp ứng đủ target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm." : "Transcript chưa đáp ứng đủ target language của task. Tự sửa rồi thử lại.");
-    await persistEvaluation(ok);
+    setFeedback(feedbackForNếpEvaluation(action, evaluation));
+    await persistEvaluation(evaluation);
   };
 
   const next = () => {

--- a/src/lib/nep/__tests__/evaluator.test.ts
+++ b/src/lib/nep/__tests__/evaluator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluateNếpActionResponse } from "../evaluator";
+import { evaluateNếpAction, evaluateNếpActionResponse, feedbackForNếpEvaluation } from "../evaluator";
 import { firstMeetingLessonV1 } from "../lesson-contract";
 
 function action(kind: "comprehend" | "retrieve" | "produce" | "repair" | "retry" | "transfer") {
@@ -13,26 +13,76 @@ describe("Nếp deterministic evaluator", () => {
     expect(evaluateNếpActionResponse(action("comprehend"), "country")).toBe(false);
   });
 
+  it("emits structured comprehension errors", () => {
+    expect(evaluateNếpAction(action("comprehend"), "country")).toEqual({
+      success: false,
+      evaluator: "nep-evaluator-v2",
+      observedResponse: true,
+      matchedTargetGroupIndexes: [],
+      missingTargetGroupIndexes: [0],
+      errorTags: ["incorrect-choice", "missing-target-group:0"],
+    });
+  });
+
   it("accepts normalized introduction variants", () => {
     expect(evaluateNếpActionResponse(action("produce"), "I'm Hoang.")).toBe(true);
     expect(evaluateNếpActionResponse(action("produce"), "I’m Hoang!")).toBe(true);
   });
 
-  it("does not award transfer for the repair move alone", () => {
-    expect(evaluateNếpActionResponse(action("transfer"), "Sorry, could you say that again?")).toBe(false);
-  });
+  it("identifies a missing introduction separately from a missing repair move", () => {
+    const repairOnly = evaluateNếpAction(
+      action("transfer"),
+      "Sorry, could you say that again?",
+    );
+    expect(repairOnly).toMatchObject({
+      success: false,
+      matchedTargetGroupIndexes: [0],
+      missingTargetGroupIndexes: [1],
+      errorTags: ["partial-target-coverage", "missing-target-group:1"],
+    });
+    expect(feedbackForNếpEvaluation(action("transfer"), repairOnly)).toBe(
+      "Đã có repair move nhưng còn thiếu phần tự giới thiệu tên.",
+    );
 
-  it("does not award transfer for self-introduction alone", () => {
-    expect(evaluateNếpActionResponse(action("transfer"), "My name is Hoang.")).toBe(false);
+    const introductionOnly = evaluateNếpAction(action("transfer"), "My name is Hoang.");
+    expect(introductionOnly).toMatchObject({
+      success: false,
+      matchedTargetGroupIndexes: [1],
+      missingTargetGroupIndexes: [0],
+      errorTags: ["partial-target-coverage", "missing-target-group:0"],
+    });
+    expect(feedbackForNếpEvaluation(action("transfer"), introductionOnly)).toBe(
+      "Thiếu bước xin nhắc lại trước khi tiếp tục.",
+    );
   });
 
   it("awards transfer only when every required signal group is present", () => {
-    expect(
-      evaluateNếpActionResponse(
-        action("transfer"),
-        "Sorry, could you say that again? My name is Hoang.",
-      ),
-    ).toBe(true);
+    const result = evaluateNếpAction(
+      action("transfer"),
+      "Sorry, could you say that again? My name is Hoang.",
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      matchedTargetGroupIndexes: [0, 1],
+      missingTargetGroupIndexes: [],
+      errorTags: [],
+    });
+  });
+
+  it("marks no response separately from a learner language error", () => {
+    const result = evaluateNếpAction(action("produce"), "   ");
+
+    expect(result).toMatchObject({
+      success: false,
+      observedResponse: false,
+      matchedTargetGroupIndexes: [],
+      missingTargetGroupIndexes: [0],
+      errorTags: ["no-response", "missing-target-group:0"],
+    });
+    expect(feedbackForNếpEvaluation(action("produce"), result)).toContain(
+      "không nên tạo oral mastery evidence",
+    );
   });
 
   it("holds the supported retry to the same multi-demand language coverage", () => {

--- a/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
+++ b/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
@@ -97,8 +97,8 @@ describe("Nếp → learning-core adapter", () => {
     expect(materializeEvidence({ attempt: record!.attempt, candidate: record!.candidate! })).toBeNull();
   });
 
-  it("does not manufacture oral evidence when no response was observed", () => {
-    const record = recordFor("produce", "", "speech");
+  it("does not manufacture oral evidence when only non-language punctuation was observed", () => {
+    const record = recordFor("produce", "...", "speech");
 
     expect(record?.attempt.metadata).toMatchObject({
       responseLength: 0,

--- a/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
+++ b/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { materializeEvidence } from "../../learning/evidence";
+import { evaluateNếpAction } from "../evaluator";
 import { firstMeetingLessonV1 } from "../lesson-contract";
 import { toLearningAttemptRecord } from "../learning-evidence-adapter";
 
@@ -8,35 +9,29 @@ function action(kind: "comprehend" | "produce" | "repair" | "retry" | "transfer"
   return firstMeetingLessonV1.actions.find((item) => item.kind === kind)!;
 }
 
+function recordFor(
+  kind: "comprehend" | "produce" | "repair" | "retry" | "transfer",
+  response: string,
+  responseSource: "speech" | "text" | null,
+  supportUsed = false,
+) {
+  const lessonAction = action(kind);
+  return toLearningAttemptRecord({
+    lesson: firstMeetingLessonV1,
+    action: lessonAction,
+    response,
+    responseSource,
+    evaluation: evaluateNếpAction(lessonAction, response),
+    supportUsed,
+    latencyMs: 1000,
+  });
+}
+
 describe("Nếp → learning-core adapter", () => {
   it("maps repair to CAP-003 while production and transfer stay on CAP-002", () => {
-    const production = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("produce"),
-      response: "My name is Hoang",
-      responseSource: "speech",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 1200,
-    });
-    const repair = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("repair"),
-      response: "Could you say that again?",
-      responseSource: "speech",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 900,
-    });
-    const transfer = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("transfer"),
-      response: "Could you say that again? My name is Hoang.",
-      responseSource: "speech",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 1500,
-    });
+    const production = recordFor("produce", "My name is Hoang", "speech");
+    const repair = recordFor("repair", "Could you say that again?", "speech");
+    const transfer = recordFor("transfer", "Could you say that again? My name is Hoang.", "speech");
 
     expect(production?.attempt.capabilityId).toBe("CAP-002");
     expect(production?.candidate?.type).toBe("production");
@@ -47,64 +42,87 @@ describe("Nếp → learning-core adapter", () => {
   });
 
   it("maps product-level comprehension choice to low-level recognition evidence", () => {
-    const record = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("comprehend"),
-      response: "name",
-      responseSource: "text",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 500,
-    });
+    const record = recordFor("comprehend", "name", "text");
 
     expect(record?.attempt.responseModality).toBe("choice");
     expect(record?.candidate).toMatchObject({ type: "recognition", targetId: "CAP-002", success: true });
   });
 
   it("never persists the raw speech transcript", () => {
-    const record = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("produce"),
-      response: "My name is Hoang and this is raw learner speech",
-      responseSource: "speech",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 1000,
-    });
+    const record = recordFor(
+      "produce",
+      "My name is Hoang and this is raw learner speech",
+      "speech",
+    );
 
     expect(record?.attempt.responseText).toBeNull();
     expect(record?.attempt.metadata).toMatchObject({ rawResponsePersisted: false });
     expect(JSON.stringify(record)).not.toContain("raw learner speech");
   });
 
-  it("lets the canonical evidence policy reject typed fallback as speaking evidence", () => {
-    const record = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("produce"),
-      response: "My name is Hoang",
-      responseSource: "text",
-      correct: true,
-      supportUsed: false,
-      latencyMs: 700,
+  it("persists structured target-coverage errors without persisting learner text", () => {
+    const record = recordFor("transfer", "Could you say that again?", "speech");
+
+    expect(record?.attempt.correct).toBe(false);
+    expect(record?.attempt.metadata).toMatchObject({
+      errorSignals: {
+        version: 1,
+        evaluator: "nep-evaluator-v2",
+        observedResponse: true,
+        matchedTargetGroupIndexes: [0],
+        missingTargetGroupIndexes: [1],
+        errorTags: ["partial-target-coverage", "missing-target-group:1"],
+      },
     });
+    expect(record?.candidate?.metadata).toMatchObject({
+      errorSignals: {
+        missingTargetGroupIndexes: [1],
+        errorTags: ["partial-target-coverage", "missing-target-group:1"],
+      },
+    });
+  });
+
+  it("uses the evaluation result as the single source for success", () => {
+    const record = recordFor("repair", "hello there", "speech");
+
+    expect(record?.attempt.correct).toBe(false);
+    expect(record?.candidate?.success).toBe(false);
+  });
+
+  it("lets the canonical evidence policy reject typed fallback as speaking evidence", () => {
+    const record = recordFor("produce", "My name is Hoang", "text");
 
     expect(record?.attempt.responseModality).toBe("text");
     expect(record?.candidate).not.toBeNull();
     expect(materializeEvidence({ attempt: record!.attempt, candidate: record!.candidate! })).toBeNull();
   });
 
-  it("stores supported retry as attempt-only after reveal", () => {
-    const record = toLearningAttemptRecord({
-      lesson: firstMeetingLessonV1,
-      action: action("retry"),
-      response: "Could you say that again? My name is Hoang.",
-      responseSource: "speech",
-      correct: true,
-      supportUsed: true,
-      latencyMs: 1000,
+  it("does not manufacture oral evidence when no response was observed", () => {
+    const record = recordFor("produce", "", "speech");
+
+    expect(record?.attempt.metadata).toMatchObject({
+      responseLength: 0,
+      errorSignals: {
+        observedResponse: false,
+        errorTags: ["no-response", "missing-target-group:0"],
+      },
     });
+    expect(materializeEvidence({ attempt: record!.attempt, candidate: record!.candidate! })).toBeNull();
+  });
+
+  it("stores supported retry as attempt-only while retaining derived evaluation signals", () => {
+    const record = recordFor(
+      "retry",
+      "Could you say that again? My name is Hoang.",
+      "speech",
+      true,
+    );
 
     expect(record?.attempt.supportLevel).toBe(1);
+    expect(record?.attempt.correct).toBe(true);
+    expect(record?.attempt.metadata).toMatchObject({
+      errorSignals: { errorTags: [], missingTargetGroupIndexes: [] },
+    });
     expect(record?.candidate).toBeNull();
   });
 });

--- a/src/lib/nep/evaluator.ts
+++ b/src/lib/nep/evaluator.ts
@@ -1,5 +1,20 @@
 import type { LessonAction } from "./lesson-contract";
 
+export type NếpEvaluationErrorTag =
+  | "no-response"
+  | "incorrect-choice"
+  | "partial-target-coverage"
+  | `missing-target-group:${number}`;
+
+export type NếpEvaluationResult = {
+  success: boolean;
+  evaluator: "nep-evaluator-v2";
+  observedResponse: boolean;
+  matchedTargetGroupIndexes: number[];
+  missingTargetGroupIndexes: number[];
+  errorTags: NếpEvaluationErrorTag[];
+};
+
 export function normalizeNếpResponse(value: string) {
   return value
     .toLowerCase()
@@ -15,17 +30,97 @@ function includesAny(response: string, signals: string[]) {
 
 /**
  * Deterministic language-coverage evaluator for the preview slice.
- * It evaluates only declared target language, never pronunciation or acoustic quality.
+ * It emits only derived target-coverage/error signals. It never scores pronunciation,
+ * acoustic quality, fluency, grammar outside the declared targets, or learner identity.
  */
-export function evaluateNếpActionResponse(action: LessonAction, response: string): boolean {
+export function evaluateNếpAction(action: LessonAction, response: string): NếpEvaluationResult {
   const normalized = normalizeNếpResponse(response);
+  const observedResponse = normalized.length > 0;
 
   if (action.kind === "comprehend") {
-    return (action.targetSignals ?? []).some((signal) => normalized === normalizeNếpResponse(signal));
+    const success = (action.targetSignals ?? []).some(
+      (signal) => normalized === normalizeNếpResponse(signal),
+    );
+
+    return {
+      success,
+      evaluator: "nep-evaluator-v2",
+      observedResponse,
+      matchedTargetGroupIndexes: success ? [0] : [],
+      missingTargetGroupIndexes: success ? [] : [0],
+      errorTags: success
+        ? []
+        : observedResponse
+          ? ["incorrect-choice", "missing-target-group:0"]
+          : ["no-response", "missing-target-group:0"],
+    };
   }
 
   const groups = action.requiredSignalGroups
     ?? (action.targetSignals && action.targetSignals.length > 0 ? [action.targetSignals] : []);
+  const matchedTargetGroupIndexes: number[] = [];
+  const missingTargetGroupIndexes: number[] = [];
 
-  return groups.length > 0 && groups.every((group) => group.length > 0 && includesAny(normalized, group));
+  groups.forEach((group, index) => {
+    if (group.length > 0 && includesAny(normalized, group)) {
+      matchedTargetGroupIndexes.push(index);
+    } else {
+      missingTargetGroupIndexes.push(index);
+    }
+  });
+
+  const success = groups.length > 0 && missingTargetGroupIndexes.length === 0;
+  const errorTags: NếpEvaluationErrorTag[] = [];
+  if (!observedResponse) errorTags.push("no-response");
+  if (matchedTargetGroupIndexes.length > 0 && missingTargetGroupIndexes.length > 0) {
+    errorTags.push("partial-target-coverage");
+  }
+  for (const index of missingTargetGroupIndexes) {
+    errorTags.push(`missing-target-group:${index}`);
+  }
+
+  return {
+    success,
+    evaluator: "nep-evaluator-v2",
+    observedResponse,
+    matchedTargetGroupIndexes,
+    missingTargetGroupIndexes,
+    errorTags,
+  };
+}
+
+/** Backward-compatible boolean surface for existing callers/tests. */
+export function evaluateNếpActionResponse(action: LessonAction, response: string): boolean {
+  return evaluateNếpAction(action, response).success;
+}
+
+export function feedbackForNếpEvaluation(action: LessonAction, result: NếpEvaluationResult) {
+  if (result.success) {
+    return "Transcript đáp ứng đủ target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm.";
+  }
+
+  if (!result.observedResponse) {
+    return "Chưa quan sát được câu trả lời. Lần này không nên tạo oral mastery evidence.";
+  }
+
+  if (action.kind === "comprehend") {
+    return "Chưa đúng. Câu hỏi đang cần thông tin về tên.";
+  }
+
+  if (action.kind === "transfer" || action.kind === "retry") {
+    const missingRepair = result.missingTargetGroupIndexes.includes(0);
+    const missingIntroduction = result.missingTargetGroupIndexes.includes(1);
+    if (missingRepair && missingIntroduction) {
+      return "Cần đủ hai phần: xin nhắc lại và tự giới thiệu tên.";
+    }
+    if (missingRepair) return "Thiếu bước xin nhắc lại trước khi tiếp tục.";
+    if (missingIntroduction) return "Đã có repair move nhưng còn thiếu phần tự giới thiệu tên.";
+  }
+
+  if (action.kind === "repair") return "Chưa có repair move cần thiết để xin người đối thoại nhắc lại.";
+  if (action.kind === "retrieve" || action.kind === "produce") {
+    return "Chưa có cụm tự giới thiệu cần thiết cho task.";
+  }
+
+  return "Câu trả lời chưa đáp ứng đủ target language của task. Tự sửa rồi thử lại.";
 }

--- a/src/lib/nep/learning-evidence-adapter.ts
+++ b/src/lib/nep/learning-evidence-adapter.ts
@@ -1,4 +1,5 @@
 import type { RecordLearningAttemptInput } from "../learning/validation";
+import type { NếpEvaluationResult } from "./evaluator";
 import type { LessonAction, LessonContract } from "./lesson-contract";
 
 export type NếpResponseSource = "speech" | "text" | null;
@@ -8,7 +9,7 @@ export type EvaluatedNếpAction = {
   action: LessonAction;
   response: string;
   responseSource: NếpResponseSource;
-  correct: boolean;
+  evaluation: NếpEvaluationResult;
   supportUsed: boolean;
   latencyMs: number;
 };
@@ -20,18 +21,30 @@ function responseModality(action: LessonAction, source: NếpResponseSource) {
   return "none" as const;
 }
 
+function structuredErrorSignals(evaluation: NếpEvaluationResult) {
+  return {
+    version: 1,
+    evaluator: evaluation.evaluator,
+    observedResponse: evaluation.observedResponse,
+    matchedTargetGroupIndexes: evaluation.matchedTargetGroupIndexes,
+    missingTargetGroupIndexes: evaluation.missingTargetGroupIndexes,
+    errorTags: evaluation.errorTags,
+  };
+}
+
 /**
- * Adapts an evaluated Nếp action to the canonical Attempt → Evidence write contract.
- * Raw learner responses are deliberately not persisted here; the deterministic evaluator
- * has already reduced the response to success/failure plus non-sensitive metadata.
+ * Adapts one deterministic Nếp evaluation to the canonical Attempt → Evidence write contract.
+ * Raw learner responses are deliberately not persisted. Only derived target-coverage/error
+ * signals, response length, modality and task identity cross the persistence boundary.
  */
 export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLearningAttemptInput | null {
-  const { lesson, action, response, responseSource, correct, supportUsed, latencyMs } = input;
+  const { lesson, action, response, responseSource, evaluation, supportUsed, latencyMs } = input;
   const assessment = action.assessment;
   if (!assessment) return null;
 
   const modality = responseModality(action, responseSource);
   const safeLatency = Math.min(60 * 60 * 1000, Math.max(0, Math.round(latencyMs)));
+  const errorSignals = structuredErrorSignals(evaluation);
   const metadata = {
     lessonId: lesson.id,
     lessonVersion: lesson.version,
@@ -42,6 +55,7 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
     rawResponsePersisted: false,
     supportUsed,
     changedContext: action.changedContext ?? false,
+    errorSignals,
   };
 
   return {
@@ -52,7 +66,7 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
       promptId: action.id,
       contextId: assessment.contextId,
       responseText: null,
-      correct,
+      correct: evaluation.success,
       latencyMs: safeLatency,
       hintCount: 0,
       revealUsed: false,
@@ -63,14 +77,16 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
       ? {
           type: assessment.evidenceType,
           targetId: assessment.targetCapabilityId,
-          success: correct,
+          success: evaluation.success,
           contextId: assessment.contextId,
           evaluator: assessment.evaluator,
           metadata: {
             lessonId: lesson.id,
+            lessonVersion: lesson.version,
             actionId: action.id,
             responseSource,
             rawResponsePersisted: false,
+            errorSignals,
           },
         }
       : null,

--- a/src/lib/nep/learning-evidence-adapter.ts
+++ b/src/lib/nep/learning-evidence-adapter.ts
@@ -51,7 +51,7 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
     actionId: action.id,
     actionKind: action.kind,
     responseSource,
-    responseLength: response.trim().length,
+    responseLength: evaluation.observedResponse ? response.trim().length : 0,
     rawResponsePersisted: false,
     supportUsed,
     changedContext: action.changedContext ?? false,


### PR DESCRIPTION
## Why
AtoEnglish needs more than pass/fail if Session Planner is eventually going to repair recurring learner errors. This slice upgrades the existing deterministic Nếp evaluator to emit narrow, privacy-safe target-coverage signals without claiming grammar, pronunciation or calibrated mastery diagnosis.

## Stack
- Base: `agent/session-planner-read-boundary` / PR #65
- Head: `agent/structured-error-signals-v1`
- No database migration.
- No planner weight change.
- No new learner-content schema.

## Structured evaluation
`evaluateNếpAction()` now returns one `NếpEvaluationResult` containing:
- success;
- `observedResponse`;
- matched target-group indexes;
- missing target-group indexes;
- stable error tags;
- evaluator version `nep-evaluator-v2`.

Current tags are deliberately narrow:
- `no-response`
- `incorrect-choice`
- `partial-target-coverage`
- `missing-target-group:<index>`

## Single source of truth
The persistence adapter no longer accepts a separate `correct` boolean. The same evaluation result now drives:
- learner-facing feedback;
- `attempt.correct`;
- evidence success/failure;
- persisted derived error metadata.

This prevents pass/fail and structured-error metadata from disagreeing.

## Privacy boundary
Raw learner speech/text is still not persisted by the Nếp adapter. Persisted `errorSignals` contain only derived task-coverage data plus task identity.

The persistence adapter now sets the privacy-safe `responseLength` to zero whenever the evaluator says no meaningful response was observed. This closes the punctuation-only edge case (`"..."`) where a non-empty raw string could otherwise look like an observed oral response to the DB invariant.

## Feedback
The UI can now distinguish, for example:
- repair move present but self-introduction missing;
- self-introduction present but repair move missing;
- both demands missing;
- no response observed;
- incorrect comprehension choice.

Text fallback still never becomes speaking evidence. Transcript feedback is still not pronunciation scoring.

## Tests
Adds/extends regressions for:
- structured comprehension errors;
- partial multi-demand coverage;
- missing repair vs missing introduction;
- no-response separation from learner error;
- success with no error tags;
- single-source success persistence;
- structured error metadata without raw transcript;
- typed fallback rejection as oral evidence;
- punctuation-only/unobserved oral response rejection;
- supported retry remaining attempt-only.

## Verification
Temporary draft PR #68 ran the full repository `Verify` workflow against `main` for head `2fa8e2250a95faf799d45ea4adf8196a3b59ddd2`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #68 was closed without merge after verification. PR #67 is mergeable and remains draft.

## Scope boundary
V1 does **not** call one failed task a persistent misconception. It does not diagnose grammar or pronunciation. It does not alter Session Planner yet.

See `docs/nep/STRUCTURED_ERROR_SIGNALS_V1.md` for the contract and the next Error Memory boundary.