### PR TITLE
Add deterministic Error Memory V1

### DIFF
--- a/docs/nep/ERROR_MEMORY_V1.md
+++ b/docs/nep/ERROR_MEMORY_V1.md
@@ -1,0 +1,90 @@
+# Error Memory V1
+
+## Goal
+
+Structured Error Signals describe one attempt. Error Memory V1 decides when repeated observations are strong enough to call an error a **temporary recurring pattern**.
+
+The key rule is conservative:
+
+> One failed task is an observation, not a learner trait.
+
+## Identity
+
+An error memory is versioned by:
+
+- target/capability;
+- lesson id;
+- lesson version;
+- action id;
+- actionable error tag.
+
+This prevents an old content definition from silently contaminating a later lesson version with different target groups.
+
+## Actionable tags
+
+V1 aggregates only:
+
+- `incorrect-choice`;
+- `missing-target-group:<index>`.
+
+It deliberately ignores:
+
+- `no-response` — this may reflect microphone/STT/UI failure rather than learner knowledge;
+- `partial-target-coverage` — this is a broad summary already represented by the specific missing-group tag.
+
+## States
+
+Each memory entry has one of four states:
+
+- `supported-only` — observed only while support was active;
+- `observed` — one independent failure since the last repair;
+- `recurring` — at least two independent failures since the last repair;
+- `repaired` — a later independent successful response completed the same versioned action.
+
+Supported failures are counted diagnostically but do not promote a pattern to `recurring`.
+
+## Repair semantics
+
+A later independent successful attempt on the same target + lesson version + action repairs all active error tags for that action.
+
+After repair, the old recurrence is not permanent. A new independent failure becomes `observed` again, and only another independent failure promotes it back to `recurring`.
+
+This prevents the learner model from becoming a permanent collection of past mistakes.
+
+## Read boundary
+
+`getNếpErrorMemory()` is authenticated and read-only. It reads the learner's own `learning_attempts` rows through existing RLS and projects only:
+
+- target identity;
+- correctness/support level;
+- lesson/action/version identity;
+- `errorSignals.observedResponse`;
+- `errorSignals.errorTags`;
+- timestamp.
+
+It does not SELECT `response_text` or the full attempt `metadata` object.
+
+## What V1 does not do
+
+Error Memory V1 does not yet:
+
+- change Session Planner scores;
+- create a new database table;
+- claim an error is a misconception;
+- infer grammar or pronunciation problems;
+- use LLM classification;
+- use RL/bandits;
+- persist a permanent learner label.
+
+The snapshot is rebuilt deterministically from immutable attempts.
+
+## Next boundary
+
+A later planner integration can derive an explicit `errorRepairPressure` only from `recurring` entries. The planner should not receive pressure from `supported-only`, `observed`, `repaired`, or `no-response` events.
+
+Before adding that term, tests should lock:
+
+- one-off failures do not alter planning;
+- two independent recurrent failures increase priority for the relevant repair opportunity;
+- a successful independent repair removes that pressure;
+- unrelated targets/actions are unaffected.

--- a/src/__tests__/error-memory.test.ts
+++ b/src/__tests__/error-memory.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ERROR_MEMORY_ATTEMPT_SELECT,
+  actionableErrorTags,
+  buildErrorMemory,
+  type ErrorMemoryAttemptRow,
+} from "@/lib/learning/error-memory";
+
+function row(overrides: Partial<ErrorMemoryAttemptRow> = {}): ErrorMemoryAttemptRow {
+  return {
+    capability_id: "CAP-002",
+    knowledge_item_id: null,
+    correct: false,
+    support_level: 0,
+    lesson_id: "nep-first-meeting-v1",
+    lesson_version: "1.0.0",
+    action_id: "transfer",
+    observed_response: true,
+    error_tags: ["partial-target-coverage", "missing-target-group:1"],
+    created_at: "2026-09-02T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Error Memory V1", () => {
+  it("keeps one independent failure as an observation, not a recurring learner pattern", () => {
+    const memory = buildErrorMemory([row()]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.entries[0]).toMatchObject({
+      errorTag: "missing-target-group:1",
+      status: "observed",
+      independentFailureCount: 1,
+      independentFailuresSinceRepair: 1,
+    });
+  });
+
+  it("promotes the same actionable error only after a second independent failure", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(1);
+    expect(memory.recurring[0]).toMatchObject({
+      errorTag: "missing-target-group:1",
+      status: "recurring",
+      independentFailureCount: 2,
+      independentFailuresSinceRepair: 2,
+    });
+  });
+
+  it("does not let supported failures manufacture recurrence", () => {
+    const memory = buildErrorMemory([
+      row({ support_level: 1, created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ support_level: 1, created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ support_level: 0, created_at: "2026-09-02T12:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.entries[0]).toMatchObject({
+      status: "observed",
+      independentFailureCount: 1,
+      supportedFailureCount: 2,
+    });
+  });
+
+  it("ignores no-response and broad partial-coverage tags as persistent error patterns", () => {
+    const memory = buildErrorMemory([
+      row({ observed_response: false, error_tags: ["no-response", "missing-target-group:1"] }),
+      row({ error_tags: ["partial-target-coverage"] }),
+    ]);
+
+    expect(memory.entries).toEqual([]);
+    expect(actionableErrorTags(["no-response", "partial-target-coverage", "incorrect-choice"])).toEqual([
+      "incorrect-choice",
+    ]);
+  });
+
+  it("marks a recurring error repaired after a later independent success on the same action", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.repaired[0]).toMatchObject({
+      status: "repaired",
+      independentFailureCount: 2,
+      independentFailuresSinceRepair: 0,
+      repairedAt: "2026-09-02T12:00:00.000Z",
+    });
+  });
+
+  it("requires recurrence again after repair instead of making the old pattern permanent", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+      row({ created_at: "2026-09-02T13:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.entries[0]).toMatchObject({
+      status: "observed",
+      independentFailureCount: 3,
+      independentFailuresSinceRepair: 1,
+      repairedAt: null,
+    });
+  });
+
+  it("keeps different lesson versions and actions as separate error memories", () => {
+    const memory = buildErrorMemory([
+      row({ lesson_version: "1.0.0", action_id: "transfer" }),
+      row({ lesson_version: "2.0.0", action_id: "transfer", created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ lesson_version: "1.0.0", action_id: "repair", created_at: "2026-09-02T12:00:00.000Z" }),
+    ]);
+
+    expect(memory.entries).toHaveLength(3);
+    expect(memory.recurring).toHaveLength(0);
+  });
+
+  it("is deterministic even when rows arrive newest-first", () => {
+    const chronological = [
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+    ];
+
+    expect(buildErrorMemory([...chronological].reverse())).toEqual(buildErrorMemory(chronological));
+  });
+
+  it("locks the read projection to derived metadata and excludes raw learner content", () => {
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("error_tags:metadata->errorSignals->errorTags");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("observed_response:metadata->errorSignals->observedResponse");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toContain("response_text");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toMatch(/(^|,\s*)metadata($|,)/);
+  });
+});

--- a/src/app/actions/error-memory.ts
+++ b/src/app/actions/error-memory.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { headers } from "next/headers";
+
+import {
+  ERROR_MEMORY_ATTEMPT_SELECT,
+  buildErrorMemory,
+  type ErrorMemoryAttemptRow,
+} from "@/lib/learning/error-memory";
+import { collectPlannerTargetIds } from "@/lib/learning/session-input";
+import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
+
+const errorMemoryReadLimiter = createRateLimiter(60, 60 * 1000, "error-memory-read");
+
+type QueryError = { message: string } | null;
+type QueryResult<T> = Promise<{ data: T[] | null; error: QueryError }>;
+type ErrorMemoryQuery<T> = {
+  select: (columns: string) => ErrorMemoryQuery<T>;
+  eq: (column: string, value: string) => ErrorMemoryQuery<T>;
+  in: (column: string, values: string[]) => ErrorMemoryQuery<T>;
+  order: (column: string, options: { ascending: boolean }) => ErrorMemoryQuery<T>;
+  limit: (count: number) => QueryResult<T>;
+};
+type ErrorMemoryReadClient = {
+  from: <T>(table: string) => ErrorMemoryQuery<T>;
+};
+
+/**
+ * Read-only authenticated boundary for Error Memory V1.
+ * Reads derived structured error metadata only; raw response_text/full metadata are excluded.
+ */
+export async function getNếpErrorMemory() {
+  try {
+    const reqHeaders = await headers();
+    const ip = reqHeaders.get("x-forwarded-for")?.split(",")[0].trim() || "127.0.0.1";
+    const rateLimitCheck = await errorMemoryReadLimiter.check(ip);
+    if (!rateLimitCheck.success) {
+      return { success: false, error: "Yêu cầu quá thường xuyên. Vui lòng thử lại sau." };
+    }
+
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { success: false, error: "Bạn cần đăng nhập để đọc error memory." };
+    }
+
+    const targetIds = collectPlannerTargetIds(nepSessionCatalogV1);
+    const readClient = supabase as unknown as ErrorMemoryReadClient;
+    const result = await readClient
+      .from<ErrorMemoryAttemptRow>("learning_attempts")
+      .select(ERROR_MEMORY_ATTEMPT_SELECT)
+      .eq("user_id", user.id)
+      .in("capability_id", targetIds)
+      .order("created_at", { ascending: false })
+      .limit(200);
+
+    if (result.error) {
+      return { success: false, error: `Không thể đọc error memory: ${result.error.message}` };
+    }
+
+    const memory = buildErrorMemory(result.data ?? []);
+    return {
+      success: true,
+      memory,
+      diagnostics: {
+        attemptCount: result.data?.length ?? 0,
+        recurringCount: memory.recurring.length,
+        observedCount: memory.observed.length,
+        repairedCount: memory.repaired.length,
+        rawResponseSelected: false,
+        fullMetadataSelected: false,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: `Lỗi hệ thống khi dựng error memory: ${message}` };
+  }
+}

--- a/src/lib/learning/error-memory.ts
+++ b/src/lib/learning/error-memory.ts
@@ -1,0 +1,213 @@
+export const ERROR_MEMORY_ATTEMPT_SELECT = [
+  "capability_id",
+  "knowledge_item_id",
+  "correct",
+  "support_level",
+  "lesson_id:metadata->>lessonId",
+  "lesson_version:metadata->>lessonVersion",
+  "action_id:metadata->>actionId",
+  "observed_response:metadata->errorSignals->observedResponse",
+  "error_tags:metadata->errorSignals->errorTags",
+  "created_at",
+].join(", ");
+
+export type ErrorMemoryAttemptRow = {
+  capability_id: string | null;
+  knowledge_item_id: string | null;
+  correct: boolean | null;
+  support_level: number;
+  lesson_id: string | null;
+  lesson_version: string | null;
+  action_id: string | null;
+  observed_response: unknown;
+  error_tags: unknown;
+  created_at: string;
+};
+
+export type ActionableErrorTag = "incorrect-choice" | `missing-target-group:${number}`;
+export type ErrorMemoryStatus = "supported-only" | "observed" | "recurring" | "repaired";
+
+export type ErrorMemoryEntry = {
+  key: string;
+  targetId: string;
+  lessonId: string;
+  lessonVersion: string;
+  actionId: string;
+  errorTag: ActionableErrorTag;
+  status: ErrorMemoryStatus;
+  independentFailureCount: number;
+  supportedFailureCount: number;
+  independentFailuresSinceRepair: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  repairedAt: string | null;
+};
+
+export type ErrorMemorySnapshot = {
+  entries: ErrorMemoryEntry[];
+  recurring: ErrorMemoryEntry[];
+  observed: ErrorMemoryEntry[];
+  repaired: ErrorMemoryEntry[];
+};
+
+type MutableEntry = ErrorMemoryEntry;
+
+/**
+ * Error Memory V1 turns repeated, independent task-coverage failures into a temporary pattern.
+ * One failure is only an observation. Supported failures do not promote recurrence. A later
+ * independent success on the same versioned action repairs all active tags for that action.
+ */
+export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnapshot {
+  const entries = new Map<string, MutableEntry>();
+  const ordered = [...rows].sort((a, b) => {
+    const time = Date.parse(a.created_at) - Date.parse(b.created_at);
+    if (time !== 0) return time;
+    return rowIdentity(a).localeCompare(rowIdentity(b));
+  });
+
+  for (const row of ordered) {
+    const targetId = row.capability_id ?? row.knowledge_item_id;
+    const lessonId = nonEmpty(row.lesson_id);
+    const lessonVersion = nonEmpty(row.lesson_version);
+    const actionId = nonEmpty(row.action_id);
+    if (!targetId || !lessonId || !lessonVersion || !actionId) continue;
+
+    const observedResponse = row.observed_response === true;
+    const supported = Number.isFinite(row.support_level) && row.support_level > 0;
+
+    if (row.correct === true && observedResponse && !supported) {
+      repairActionEntries(entries, targetId, lessonId, lessonVersion, actionId, row.created_at);
+      continue;
+    }
+
+    if (row.correct !== false || !observedResponse) continue;
+
+    for (const errorTag of actionableErrorTags(row.error_tags)) {
+      const key = memoryKey(targetId, lessonId, lessonVersion, actionId, errorTag);
+      const existing = entries.get(key);
+      if (!existing) {
+        entries.set(key, {
+          key,
+          targetId,
+          lessonId,
+          lessonVersion,
+          actionId,
+          errorTag,
+          status: supported ? "supported-only" : "observed",
+          independentFailureCount: supported ? 0 : 1,
+          supportedFailureCount: supported ? 1 : 0,
+          independentFailuresSinceRepair: supported ? 0 : 1,
+          firstSeenAt: row.created_at,
+          lastSeenAt: row.created_at,
+          repairedAt: null,
+        });
+        continue;
+      }
+
+      existing.lastSeenAt = row.created_at;
+      if (supported) {
+        existing.supportedFailureCount += 1;
+      } else {
+        existing.independentFailureCount += 1;
+        existing.independentFailuresSinceRepair += 1;
+        existing.repairedAt = null;
+      }
+      existing.status = statusFor(existing);
+    }
+  }
+
+  const allEntries = [...entries.values()]
+    .map((entry) => ({ ...entry, status: statusFor(entry) }))
+    .sort(compareEntries);
+
+  return {
+    entries: allEntries,
+    recurring: allEntries.filter((entry) => entry.status === "recurring"),
+    observed: allEntries.filter((entry) => entry.status === "observed" || entry.status === "supported-only"),
+    repaired: allEntries.filter((entry) => entry.status === "repaired"),
+  };
+}
+
+export function actionableErrorTags(value: unknown): ActionableErrorTag[] {
+  if (!Array.isArray(value)) return [];
+  const tags = new Set<ActionableErrorTag>();
+  for (const item of value) {
+    if (item === "incorrect-choice") {
+      tags.add(item);
+      continue;
+    }
+    if (typeof item !== "string") continue;
+    const match = /^missing-target-group:(\d+)$/.exec(item);
+    if (!match) continue;
+    tags.add(`missing-target-group:${Number(match[1])}`);
+  }
+  return [...tags].sort();
+}
+
+function repairActionEntries(
+  entries: Map<string, MutableEntry>,
+  targetId: string,
+  lessonId: string,
+  lessonVersion: string,
+  actionId: string,
+  repairedAt: string,
+) {
+  for (const entry of entries.values()) {
+    if (
+      entry.targetId !== targetId
+      || entry.lessonId !== lessonId
+      || entry.lessonVersion !== lessonVersion
+      || entry.actionId !== actionId
+    ) {
+      continue;
+    }
+    if (entry.independentFailureCount === 0) continue;
+    entry.independentFailuresSinceRepair = 0;
+    entry.repairedAt = repairedAt;
+    entry.status = "repaired";
+  }
+}
+
+function statusFor(entry: ErrorMemoryEntry): ErrorMemoryStatus {
+  if (entry.repairedAt && entry.independentFailuresSinceRepair === 0) return "repaired";
+  if (entry.independentFailuresSinceRepair >= 2) return "recurring";
+  if (entry.independentFailuresSinceRepair === 1) return "observed";
+  return "supported-only";
+}
+
+function memoryKey(
+  targetId: string,
+  lessonId: string,
+  lessonVersion: string,
+  actionId: string,
+  errorTag: ActionableErrorTag,
+) {
+  return [targetId, lessonId, lessonVersion, actionId, errorTag].join("|");
+}
+
+function rowIdentity(row: ErrorMemoryAttemptRow) {
+  return [
+    row.capability_id ?? row.knowledge_item_id ?? "",
+    row.lesson_id ?? "",
+    row.lesson_version ?? "",
+    row.action_id ?? "",
+    JSON.stringify(row.error_tags),
+  ].join("|");
+}
+
+function compareEntries(a: ErrorMemoryEntry, b: ErrorMemoryEntry) {
+  const statusRank: Record<ErrorMemoryStatus, number> = {
+    recurring: 0,
+    observed: 1,
+    supported-only: 2,
+    repaired: 3,
+  };
+  return statusRank[a.status] - statusRank[b.status]
+    || b.independentFailuresSinceRepair - a.independentFailuresSinceRepair
+    || Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt)
+    || a.key.localeCompare(b.key);
+}
+
+function nonEmpty(value: string | null) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}

--- a/src/lib/learning/error-memory.ts
+++ b/src/lib/learning/error-memory.ts
@@ -199,7 +199,7 @@ function compareEntries(a: ErrorMemoryEntry, b: ErrorMemoryEntry) {
   const statusRank: Record<ErrorMemoryStatus, number> = {
     recurring: 0,
     observed: 1,
-    supported-only: 2,
+    "supported-only": 2,
     repaired: 3,
   };
   return statusRank[a.status] - statusRank[b.status]


### PR DESCRIPTION
## Why
Structured Error Signals V1 describes one attempt. AtoEnglish still needs a conservative rule for deciding when repeated observations are strong enough to count as a temporary recurring error pattern.

## Stack
- Base: `agent/structured-error-signals-v1` / PR #67
- Head: `agent/error-memory-v1`
- No database migration.
- No Session Planner score change.

## Core policy
One failed task is an observation, not a learner trait.

An error memory is versioned by:
- target/capability;
- lesson id;
- lesson version;
- action id;
- actionable error tag.

V1 aggregates only:
- `incorrect-choice`;
- `missing-target-group:<index>`.

It ignores `no-response` and broad `partial-target-coverage` as persistent patterns.

## States
- `supported-only`: only observed with support active;
- `observed`: one independent failure since last repair;
- `recurring`: at least two independent failures since last repair;
- `repaired`: a later independent success completed the same versioned action.

Supported failures are diagnostic only and cannot manufacture recurrence.

After repair, recurrence resets. One later failure becomes `observed` again rather than reviving a permanent learner label.

## Read boundary
Adds authenticated, read-only `getNếpErrorMemory()` over existing `learning_attempts` RLS.

Projection is data-minimized to target/task identity, correctness/support, derived `errorSignals`, and timestamp. It does not SELECT `response_text` or the full `metadata` object.

## Tests
Covers:
- one-off observation vs recurrence;
- two independent failures required for recurring status;
- supported failures not promoting recurrence;
- no-response/broad tag exclusion;
- later independent success repairing active errors;
- recurrence reset after repair;
- lesson-version/action isolation;
- deterministic replay from newest-first rows;
- privacy-safe read projection.

## Verification
The first CI run caught one syntax error in the status-rank object (`supported-only` needed quoting). After that exact fix, temporary draft PR #70 ran the full `Verify` workflow against `main` for head `6a7dbb2822c029f61429f55f4051a33194734b8e`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #70 was closed without merge after verification. PR #69 is mergeable and remains draft.

## Scope boundary
Error Memory V1 is a deterministic rebuildable read model. It does not yet alter Session Planner, diagnose grammar/pronunciation, use LLM classification, or persist permanent learner labels.

See `docs/nep/ERROR_MEMORY_V1.md` for the policy and planner integration boundary.