### PR TITLE
Add recurring error repair pressure to Session Planner

### DIFF
--- a/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
+++ b/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
@@ -1,0 +1,104 @@
+# Planner Error Repair Pressure V1
+
+## Goal
+
+Session Planner already ranks practice using skill gap, cold start, staleness, importance, transfer value and anti-repetition penalties. Error Memory V1 adds one new question:
+
+> Has this learner repeatedly failed the exact versioned task demand that this candidate can exercise again?
+
+V1 answers that conservatively with a fixed **binary repair pressure**.
+
+## Eligibility first, ranking second
+
+Error repair pressure is only a score term. It cannot bypass planner hard gates.
+
+A recurring error does not unlock:
+
+- an unmet prerequisite;
+- transfer before prior production;
+- retention before prior evidence;
+- the per-target session cap.
+
+The planner checks eligibility first and scores only eligible opportunities.
+
+## Matching contract
+
+A recurring Error Memory entry affects a candidate only when all of these match:
+
+- `status === recurring`;
+- target/capability id;
+- lesson id;
+- lesson version;
+- action id.
+
+`observed`, `supported-only` and `repaired` entries have zero ranking effect.
+
+This same-action matching is intentionally narrow. V1 does not infer that an error observed in one action should automatically schedule a different repair action.
+
+## Binary pressure
+
+If at least one recurring entry matches, then:
+
+```text
+errorRepairPressure = 1
+```
+
+Otherwise:
+
+```text
+errorRepairPressure = 0
+```
+
+Multiple matching error tags are reported in the planner reason string for explainability, but they do not multiply the score bonus. This avoids an unbounded feedback loop where a long history of failures dominates every future session.
+
+## V1 weight
+
+The default ranking term is:
+
+```text
+errorRepairPressure * 0.65
+```
+
+`0.65` is a product-policy heuristic for V1. It is not a calibrated learning probability, research-derived optimum, or efficacy claim. It should be tuned only after real learner data can show whether recurring-error opportunities are being over- or under-selected.
+
+## Explainability
+
+A selected opportunity may include a reason such as:
+
+```text
+recurring-error-repair:2
+```
+
+This means two recurring Error Memory entries matched the same candidate identity. The score pressure is still binary (`1`), not `2`.
+
+The score breakdown exposes `errorRepairPressure` separately from skill gap and other terms.
+
+## Read boundary
+
+The authenticated Session Planner server action now rebuilds Error Memory from the same immutable attempts used by the Error Memory read model and passes the entries into `planSession()`.
+
+The query remains data-minimized. It reads derived structured error metadata and does not select raw `response_text` or the full `metadata` object.
+
+## Current limitation
+
+V1 repairs the **same versioned action** where recurrence was observed. It does not yet have a semantic remediation map such as:
+
+```text
+transfer missing repair move -> schedule dedicated repair action
+```
+
+That mapping needs an explicit content/knowledge contract. Guessing it from group indexes inside the planner would couple the generic planner to one lesson's internal ordering.
+
+A future V2 can introduce a declared `repairCandidateId` or semantic error target in the lesson compiler, then let Error Memory point to that stable remediation target.
+
+## What V1 does not claim
+
+Error repair pressure is not:
+
+- a learner mastery probability;
+- a diagnosis of a misconception;
+- a grammar or pronunciation diagnosis;
+- reinforcement learning;
+- evidence that more repetition is always better.
+
+It is an explainable ranking heuristic over already-valid practice opportunities.

--- a/src/__tests__/planner-error-repair-gates.test.ts
+++ b/src/__tests__/planner-error-repair-gates.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { ErrorMemoryEntry } from "@/lib/learning/error-memory";
+import { planSession, type PlannerCandidate } from "@/lib/learning/session-planner";
+
+const recurringError: ErrorMemoryEntry = {
+  key: "cap-b|lesson-b|1.0.0|produce|missing-target-group:0",
+  targetId: "cap-b",
+  lessonId: "lesson-b",
+  lessonVersion: "1.0.0",
+  actionId: "produce",
+  errorTag: "missing-target-group:0",
+  status: "recurring",
+  independentFailureCount: 2,
+  supportedFailureCount: 0,
+  independentFailuresSinceRepair: 2,
+  firstSeenAt: "2026-09-01T10:00:00.000Z",
+  lastSeenAt: "2026-09-02T10:00:00.000Z",
+  repairedAt: null,
+};
+
+const gatedCandidate: PlannerCandidate = {
+  id: "candidate-b",
+  targetId: "cap-b",
+  evidenceType: "production",
+  prerequisiteTargetIds: ["cap-a"],
+  importance: 0.5,
+  metadata: {
+    lessonId: "lesson-b",
+    lessonVersion: "1.0.0",
+    actionId: "produce",
+  },
+};
+
+describe("planner recurring-error hard gates", () => {
+  it("does not let recurring error pressure bypass an unmet prerequisite", () => {
+    const result = planSession({
+      candidates: [gatedCandidate],
+      states: [],
+      sessionSize: 1,
+      now: "2026-09-03T00:00:00.000Z",
+      errorMemory: [recurringError],
+    });
+
+    expect(result.opportunities).toEqual([]);
+    expect(result.blocked[0]?.reasons).toContain("prerequisite-not-ready:cap-a");
+  });
+});

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { ErrorMemoryEntry, ErrorMemoryStatus } from "@/lib/learning/error-memory";
 import type { LearnerSkillState } from "@/lib/learning/evidence";
 import {
   planSession,
@@ -30,6 +31,35 @@ function candidate(overrides: Partial<PlannerCandidate> & Pick<PlannerCandidate,
     prerequisiteTargetIds: [],
     ...overrides,
   };
+}
+
+function errorMemoryEntry(overrides: Partial<ErrorMemoryEntry> = {}): ErrorMemoryEntry {
+  const status: ErrorMemoryStatus = overrides.status ?? "recurring";
+  return {
+    key: "cap-b|lesson-b|1.0.0|produce|missing-target-group:0",
+    targetId: "cap-b",
+    lessonId: "lesson-b",
+    lessonVersion: "1.0.0",
+    actionId: "produce",
+    errorTag: "missing-target-group:0",
+    status,
+    independentFailureCount: status === "recurring" ? 2 : 1,
+    supportedFailureCount: 0,
+    independentFailuresSinceRepair: status === "recurring" ? 2 : status === "repaired" ? 0 : 1,
+    firstSeenAt: "2026-09-01T10:00:00.000Z",
+    lastSeenAt: "2026-09-02T10:00:00.000Z",
+    repairedAt: status === "repaired" ? "2026-09-02T11:00:00.000Z" : null,
+    ...overrides,
+  };
+}
+
+function plannerCandidate(id: string, targetId: string, lessonId: string, actionId = "produce") {
+  return candidate({
+    id,
+    targetId,
+    evidenceType: "production",
+    metadata: { lessonId, lessonVersion: "1.0.0", actionId },
+  });
 }
 
 const fixedNow = "2026-09-03T00:00:00.000Z";
@@ -180,5 +210,72 @@ describe("session planner v1", () => {
 
     expect(result.opportunities[0]?.candidate.targetId).toBe("old");
     expect(result.opportunities[0]?.reasons.some((reason) => reason.startsWith("staleness:"))).toBe(true);
+  });
+
+  it("boosts only the matching candidate when a recurring error needs repair", () => {
+    const result = plan({
+      candidates: [
+        plannerCandidate("a-candidate", "cap-a", "lesson-a"),
+        plannerCandidate("z-candidate", "cap-b", "lesson-b"),
+      ],
+      states: [],
+      sessionSize: 1,
+      errorMemory: [errorMemoryEntry()],
+    });
+
+    expect(result.opportunities[0]?.candidate.id).toBe("z-candidate");
+    expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(1);
+    expect(result.opportunities[0]?.reasons).toContain("recurring-error-repair:1");
+  });
+
+  it.each(["observed", "supported-only", "repaired"] as const)(
+    "does not alter ranking for %s error memory",
+    (status) => {
+      const result = plan({
+        candidates: [
+          plannerCandidate("a-candidate", "cap-a", "lesson-a"),
+          plannerCandidate("z-candidate", "cap-b", "lesson-b"),
+        ],
+        states: [],
+        sessionSize: 1,
+        errorMemory: [errorMemoryEntry({ status })],
+      });
+
+      expect(result.opportunities[0]?.candidate.id).toBe("a-candidate");
+      expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(0);
+    },
+  );
+
+  it("does not leak error pressure across target, lesson version, or action identity", () => {
+    const target = plannerCandidate("a-candidate", "cap-a", "lesson-a");
+    const mismatches = [
+      errorMemoryEntry({ targetId: "cap-x" }),
+      errorMemoryEntry({ lessonId: "lesson-x" }),
+      errorMemoryEntry({ lessonVersion: "2.0.0" }),
+      errorMemoryEntry({ actionId: "repair" }),
+    ];
+
+    for (const entry of mismatches) {
+      const result = plan({ candidates: [target], states: [], sessionSize: 1, errorMemory: [entry] });
+      expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(0);
+    }
+  });
+
+  it("keeps recurring error pressure binary even when multiple tags match one action", () => {
+    const matchingCandidate = plannerCandidate("candidate", "cap-b", "lesson-b");
+    const first = errorMemoryEntry();
+    const second = errorMemoryEntry({
+      key: "cap-b|lesson-b|1.0.0|produce|incorrect-choice",
+      errorTag: "incorrect-choice",
+    });
+    const result = plan({
+      candidates: [matchingCandidate],
+      states: [],
+      sessionSize: 1,
+      errorMemory: [first, second],
+    });
+
+    expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(1);
+    expect(result.opportunities[0]?.reasons).toContain("recurring-error-repair:2");
   });
 });

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -3,6 +3,11 @@
 import { headers } from "next/headers";
 
 import {
+  ERROR_MEMORY_ATTEMPT_SELECT,
+  buildErrorMemory,
+  type ErrorMemoryAttemptRow,
+} from "@/lib/learning/error-memory";
+import {
   collectPlannerTargetIds,
   deriveRecentPlannerHistory,
   mapLearnerSkillStateRow,
@@ -71,8 +76,7 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
       .in("target_id", targetIds)
       .limit(100);
 
-    // Attempts are exposure history only. Project just the semantic planner keys from JSON;
-    // do not fetch response_text or the full metadata object.
+    // Recent attempts are exposure history only. Project semantic planner keys, not raw content.
     const recentAttemptQuery = readClient
       .from<RecentLearningAttemptRow>("learning_attempts")
       .select(PLANNER_RECENT_ATTEMPT_SELECT)
@@ -81,16 +85,33 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
       .order("created_at", { ascending: false })
       .limit(40);
 
-    const [stateResult, recentAttemptResult] = await Promise.all([stateQuery, recentAttemptQuery]);
+    // Error memory needs a wider history window, but still only derived structured metadata.
+    const errorMemoryQuery = readClient
+      .from<ErrorMemoryAttemptRow>("learning_attempts")
+      .select(ERROR_MEMORY_ATTEMPT_SELECT)
+      .eq("user_id", user.id)
+      .in("capability_id", targetIds)
+      .order("created_at", { ascending: false })
+      .limit(200);
+
+    const [stateResult, recentAttemptResult, errorMemoryResult] = await Promise.all([
+      stateQuery,
+      recentAttemptQuery,
+      errorMemoryQuery,
+    ]);
     if (stateResult.error) {
       return { success: false, error: `Không thể đọc learner state: ${stateResult.error.message}` };
     }
     if (recentAttemptResult.error) {
       return { success: false, error: `Không thể đọc lịch sử practice gần đây: ${recentAttemptResult.error.message}` };
     }
+    if (errorMemoryResult.error) {
+      return { success: false, error: `Không thể đọc error memory: ${errorMemoryResult.error.message}` };
+    }
 
     const states = (stateResult.data ?? []).map(mapLearnerSkillStateRow);
     const recentHistory = deriveRecentPlannerHistory(recentAttemptResult.data ?? []);
+    const errorMemory = buildErrorMemory(errorMemoryResult.data ?? []);
     const plan = planSession({
       candidates: nepSessionCatalogV1,
       states,
@@ -98,6 +119,7 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
       now: new Date().toISOString(),
       recentTargetIds: recentHistory.recentTargetIds,
       recentCandidateIds: recentHistory.recentCandidateIds,
+      errorMemory: errorMemory.entries,
     });
 
     return {
@@ -108,6 +130,8 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
         catalogSize: nepSessionCatalogV1.length,
         stateCount: states.length,
         recentAttemptCount: recentAttemptResult.data?.length ?? 0,
+        errorMemoryAttemptCount: errorMemoryResult.data?.length ?? 0,
+        recurringErrorCount: errorMemory.recurring.length,
         rawResponseSelected: false,
         fullMetadataSelected: false,
       },

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,3 +1,4 @@
+import type { ErrorMemoryEntry } from "./error-memory";
 import type { EvidenceType, LearnerSkillState } from "./evidence";
 import { createEmptyLearnerSkillState } from "./evidence";
 
@@ -18,6 +19,7 @@ export type SessionPlannerConfig = {
   recentTargetPenalty: number;
   recentCandidatePenalty: number;
   inSessionRepeatPenalty: number;
+  recurringErrorRepairWeight: number;
 };
 
 export type SessionPlannerInput = {
@@ -27,6 +29,7 @@ export type SessionPlannerInput = {
   now?: string;
   recentTargetIds?: string[];
   recentCandidateIds?: string[];
+  errorMemory?: ErrorMemoryEntry[];
   config?: Partial<SessionPlannerConfig>;
 };
 
@@ -36,6 +39,7 @@ export type PlannerScoreBreakdown = {
   staleness: number;
   importance: number;
   transferValue: number;
+  errorRepairPressure: number;
   recentTargetPenalty: number;
   recentCandidatePenalty: number;
   inSessionRepeatPenalty: number;
@@ -67,6 +71,7 @@ export const DEFAULT_SESSION_PLANNER_CONFIG: SessionPlannerConfig = {
   recentTargetPenalty: 0.55,
   recentCandidatePenalty: 0.75,
   inSessionRepeatPenalty: 0.8,
+  recurringErrorRepairWeight: 0.65,
 };
 
 const COLD_START_BONUS: Record<EvidenceType, number> = {
@@ -95,6 +100,7 @@ export function planSession(input: SessionPlannerInput): SessionPlan {
   const now = parseTime(input.now) ?? Date.now();
   const recentTargetIds = input.recentTargetIds ?? [];
   const recentCandidateIds = input.recentCandidateIds ?? [];
+  const errorMemory = input.errorMemory ?? [];
   const selected: PlannedOpportunity[] = [];
   const selectedIds = new Set<string>();
   const targetCounts = new Map<string, number>();
@@ -125,6 +131,7 @@ export function planSession(input: SessionPlannerInput): SessionPlan {
         now,
         recentTargetIds,
         recentCandidateIds,
+        errorMemory,
         selectedForTarget,
         config,
       }));
@@ -178,15 +185,27 @@ function scoreCandidate(input: {
   now: number;
   recentTargetIds: string[];
   recentCandidateIds: string[];
+  errorMemory: ErrorMemoryEntry[];
   selectedForTarget: number;
   config: SessionPlannerConfig;
 }): PlannedOpportunity {
-  const { candidate, state, now, recentTargetIds, recentCandidateIds, selectedForTarget, config } = input;
+  const {
+    candidate,
+    state,
+    now,
+    recentTargetIds,
+    recentCandidateIds,
+    errorMemory,
+    selectedForTarget,
+    config,
+  } = input;
   const skillGap = 1 - clamp01(state[candidate.evidenceType]);
   const coldStart = state.evidenceCount === 0 ? COLD_START_BONUS[candidate.evidenceType] : 0;
   const staleness = calculateStaleness(state.lastEvidenceAt, now);
   const importance = clamp01(candidate.importance ?? 0.5);
   const transferValue = clamp01(candidate.transferValue ?? 0);
+  const recurringErrorCount = matchingRecurringErrorCount(candidate, errorMemory);
+  const errorRepairPressure = recurringErrorCount > 0 ? 1 : 0;
   const recentTargetPenalty = countMatches(recentTargetIds, candidate.targetId) * config.recentTargetPenalty;
   const recentCandidatePenalty = countMatches(recentCandidateIds, candidate.id) * config.recentCandidatePenalty;
   const inSessionRepeatPenalty = selectedForTarget * config.inSessionRepeatPenalty;
@@ -197,6 +216,7 @@ function scoreCandidate(input: {
     + staleness * 0.35
     + importance * 0.45
     + transferValue * 0.25
+    + errorRepairPressure * config.recurringErrorRepairWeight
     - recentTargetPenalty
     - recentCandidatePenalty
     - inSessionRepeatPenalty;
@@ -208,6 +228,7 @@ function scoreCandidate(input: {
   if (coldStart > 0) reasons.push(`cold-start:${candidate.evidenceType}`);
   if (staleness > 0) reasons.push(`staleness:${round(staleness)}`);
   if (transferValue > 0) reasons.push(`transfer-value:${round(transferValue)}`);
+  if (errorRepairPressure > 0) reasons.push(`recurring-error-repair:${recurringErrorCount}`);
   if (recentTargetPenalty > 0 || recentCandidatePenalty > 0) reasons.push("recent-practice-penalty");
   if (inSessionRepeatPenalty > 0) reasons.push("in-session-diversity-penalty");
 
@@ -220,6 +241,7 @@ function scoreCandidate(input: {
       staleness,
       importance,
       transferValue,
+      errorRepairPressure,
       recentTargetPenalty,
       recentCandidatePenalty,
       inSessionRepeatPenalty,
@@ -227,6 +249,27 @@ function scoreCandidate(input: {
     },
     reasons,
   };
+}
+
+function matchingRecurringErrorCount(candidate: PlannerCandidate, entries: ErrorMemoryEntry[]) {
+  const lessonId = metadataString(candidate.metadata, "lessonId");
+  const lessonVersion = metadataString(candidate.metadata, "lessonVersion");
+  const actionId = metadataString(candidate.metadata, "actionId");
+  if (!lessonId || !lessonVersion || !actionId) return 0;
+
+  return entries.reduce((count, entry) => {
+    const matches = entry.status === "recurring"
+      && entry.targetId === candidate.targetId
+      && entry.lessonId === lessonId
+      && entry.lessonVersion === lessonVersion
+      && entry.actionId === actionId;
+    return count + (matches ? 1 : 0);
+  }, 0);
+}
+
+function metadataString(metadata: Record<string, unknown> | undefined, key: string) {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function readiness(state: LearnerSkillState) {


### PR DESCRIPTION
## Why
Error Memory V1 can identify a temporary recurring task-coverage pattern, but Session Planner still ignores it. This slice adds a conservative, explainable ranking term so already-eligible practice can receive extra priority when it directly matches a recurring error.

## Stack
- Base: `agent/error-memory-v1` / PR #69
- Head: `agent/planner-error-repair-pressure-v1`
- No database migration.
- No learner-facing route integration.

## Ranking policy
`SessionPlannerInput` now accepts Error Memory entries and the score breakdown exposes `errorRepairPressure`.

A candidate receives pressure only when a `recurring` entry matches all of:
- target/capability id;
- lesson id;
- lesson version;
- action id.

`observed`, `supported-only` and `repaired` entries have zero ranking effect.

## Binary pressure
If one or more recurring errors match the same candidate:

```text
errorRepairPressure = 1
```

The default V1 score adds:

```text
errorRepairPressure * 0.65
```

Multiple matching tags are exposed in the reason (`recurring-error-repair:N`) for explainability, but do not multiply the bonus. The 0.65 weight is a product-policy heuristic, not a calibrated learning probability or research optimum.

## Hard gates remain authoritative
Error pressure is a ranking term only. It cannot bypass:
- prerequisite readiness;
- transfer needing prior production;
- retention needing prior evidence;
- per-target session cap.

## Read boundary
The authenticated Session Planner action now rebuilds Error Memory from a wider, data-minimized attempt window and passes it into `planSession()`.

It still does not select `response_text` or full attempt metadata. Structured derived error fields are read through the Error Memory projection.

## Tests
Covers:
- recurring matching error boosts the relevant candidate;
- observed/supported-only/repaired states have zero effect;
- no pressure leaks across target, lesson version or action;
- multiple recurring tags keep the score pressure binary;
- recurring error pressure cannot bypass an unmet prerequisite;
- existing planner behavior remains under the same deterministic policy.

## Verification
Temporary draft PR #72 ran the full repository `Verify` workflow against `main` for head `62320654f193f958aa87330a129525b045c08b57`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #72 was closed without merge after verification. PR #71 is mergeable and remains draft.

## Current limitation
V1 only boosts the same versioned action where recurrence was observed. It does not infer cross-action remediation such as `transfer missing repair move -> schedule repair action`. That needs an explicit content-level remediation mapping rather than coupling the generic planner to target-group indexes.

See `docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md` for the policy boundary.