### PR TITLE
Add explicit error remediation routing V1

### DIFF
--- a/docs/nep/ERROR_MEMORY_V1.md
+++ b/docs/nep/ERROR_MEMORY_V1.md
@@ -36,12 +36,27 @@ It deliberately ignores:
 
 Each memory entry has one of four states:
 
-- `supported-only` — observed only while support was active;
+- `supported-only` — the pattern has only been observed on assisted attempts;
 - `observed` — one independent failure since the last repair;
 - `recurring` — at least two independent failures since the last repair;
 - `repaired` — a later independent successful response completed the same versioned action.
 
-Supported failures are counted diagnostically but do not promote a pattern to `recurring`.
+An attempt is assisted when either optional support was used or the answer had already been revealed. Assisted failures are counted diagnostically but do not promote a pattern to `recurring`.
+
+This prevents retry-after-feedback from becoming fake independent evidence simply because the learner did not open the optional support control.
+
+## Remediation hints
+
+Each actionable error entry may carry zero or more `remediationCandidateIds`. These IDs are derived from the versioned Nếp content remediation map, not inferred by the generic learner model.
+
+Examples:
+
+```text
+transfer + missing-target-group:0 -> ...:repair
+transfer + missing-target-group:1 -> ...:produce
+```
+
+Historical rows without hints remain valid. Planner logic can use same-action fallback only when an entry has no explicit remediation candidate.
 
 ## Repair semantics
 
@@ -56,19 +71,25 @@ This prevents the learner model from becoming a permanent collection of past mis
 `getNếpErrorMemory()` is authenticated and read-only. It reads the learner's own `learning_attempts` rows through existing RLS and projects only:
 
 - target identity;
-- correctness/support level;
+- correctness/support/reveal state;
 - lesson/action/version identity;
 - `errorSignals.observedResponse`;
 - `errorSignals.errorTags`;
+- `errorSignals.remediationHints`;
 - timestamp.
 
 It does not SELECT `response_text` or the full attempt `metadata` object.
 
+## Planner integration
+
+Session Planner receives Error Memory entries but only `recurring` entries create error-repair pressure.
+
+`observed`, `supported-only`, `repaired`, and `no-response` observations have zero ranking effect. Explicit remediation hints can route that pressure to a different evidence-bearing action; hard gates remain authoritative.
+
 ## What V1 does not do
 
-Error Memory V1 does not yet:
+Error Memory V1 does not:
 
-- change Session Planner scores;
 - create a new database table;
 - claim an error is a misconception;
 - infer grammar or pronunciation problems;
@@ -77,14 +98,3 @@ Error Memory V1 does not yet:
 - persist a permanent learner label.
 
 The snapshot is rebuilt deterministically from immutable attempts.
-
-## Next boundary
-
-A later planner integration can derive an explicit `errorRepairPressure` only from `recurring` entries. The planner should not receive pressure from `supported-only`, `observed`, `repaired`, or `no-response` events.
-
-Before adding that term, tests should lock:
-
-- one-off failures do not alter planning;
-- two independent recurrent failures increase priority for the relevant repair opportunity;
-- a successful independent repair removes that pressure;
-- unrelated targets/actions are unaffected.

--- a/docs/nep/EXPLICIT_ERROR_REMEDIATION_V1.md
+++ b/docs/nep/EXPLICIT_ERROR_REMEDIATION_V1.md
@@ -1,0 +1,92 @@
+# Explicit Error Remediation V1
+
+## Goal
+
+Recurring Error Memory should not force the learner to repeat the exact task that exposed the error.
+
+The content layer now declares a narrow remediation mapping:
+
+```text
+versioned source action + actionable error tag -> evidence-bearing planner candidate
+```
+
+The generic Session Planner does not interpret `missing-target-group:0` or `:1`. Those indexes are private to the lesson/evaluator contract.
+
+## First-meeting mappings
+
+For `LESSON-CAP002-FIRST-MEETING-V1`:
+
+- comprehension `incorrect-choice` -> `comprehend`;
+- retrieval missing group 0 -> `retrieve`;
+- production missing group 0 -> `retrieve`;
+- repair missing group 0 -> `repair`;
+- transfer missing group 0 -> `repair`;
+- transfer missing group 1 -> `produce`.
+
+The important cross-action cases are:
+
+```text
+transfer missing repair move -> dedicated repair practice
+transfer missing self-introduction -> dedicated production practice
+```
+
+These are V1 product-policy decisions, not research claims that one remediation sequence is universally optimal.
+
+## Persistence boundary
+
+The deterministic evaluator still emits narrow target-coverage error tags. The Nếp adapter adds derived `remediationHints` under `errorSignals`:
+
+```ts
+{
+  errorTag: "missing-target-group:0",
+  candidateId: "LESSON-CAP002-FIRST-MEETING-V1:repair"
+}
+```
+
+No learner transcript or typed response is included in a remediation hint.
+
+## Error Memory
+
+Error Memory carries remediation candidate IDs per actionable error tag. It still requires repeated independent failures before a pattern becomes `recurring`.
+
+Attempts are assisted when either:
+
+- `support_level > 0`; or
+- `reveal_used === true`.
+
+Assisted failures are diagnostic only and cannot create recurrence. This matters for Nếp retry: retry occurs after answer-bearing feedback, so it is stored with `revealUsed=true` even when the learner did not open the optional Vietnamese support.
+
+## Planner behavior
+
+For a recurring Error Memory entry:
+
+1. if explicit remediation candidate IDs exist, only those candidates receive recurring-error pressure;
+2. the original source action does **not** also receive same-action pressure;
+3. older history without remediation hints keeps the previous same-action fallback for backward compatibility;
+4. pressure remains binary and cannot bypass planner hard gates.
+
+This lets remediation cross capability boundaries inside a lesson. For example, a transfer error on `CAP-002` can pressure the dedicated repair action targeting embedded capability `CAP-003`.
+
+## Static QA
+
+The remediation map validates that:
+
+- the source action exists in the declared lesson version;
+- the target action exists;
+- the target action is evidence-bearing and therefore present in the planner catalog;
+- a `missing-target-group:N` rule references a group that actually exists on the source action.
+
+Attempt-only retry cannot be a remediation target.
+
+## Non-goals
+
+V1 does not:
+
+- infer remediation with an LLM;
+- diagnose grammar or pronunciation;
+- call one error a misconception;
+- let error count grow planner pressure without bound;
+- bypass prerequisite/transfer/retention gates;
+- claim the remediation map is optimal.
+
+The next useful validation is empirical: measure whether mapped remediation reduces recurrence on later independent attempts and transfer tasks.

--- a/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
+++ b/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Session Planner already ranks practice using skill gap, cold start, staleness, importance, transfer value and anti-repetition penalties. Error Memory V1 adds one new question:
+Session Planner already ranks practice using skill gap, cold start, staleness, importance, transfer value and anti-repetition penalties. Error Memory adds one new question:
 
-> Has this learner repeatedly failed the exact versioned task demand that this candidate can exercise again?
+> Does this learner have a recurring task-coverage error that this candidate is explicitly meant to repair?
 
 V1 answers that conservatively with a fixed **binary repair pressure**.
 
@@ -23,17 +23,26 @@ The planner checks eligibility first and scores only eligible opportunities.
 
 ## Matching contract
 
-A recurring Error Memory entry affects a candidate only when all of these match:
+`observed`, `supported-only` and `repaired` Error Memory entries always have zero ranking effect.
 
-- `status === recurring`;
-- target/capability id;
-- lesson id;
-- lesson version;
-- action id.
+For a `recurring` entry:
 
-`observed`, `supported-only` and `repaired` entries have zero ranking effect.
+1. if the entry has explicit `remediationCandidateIds`, a candidate matches only when its stable candidate ID is present in that list;
+2. when explicit remediation exists, the original source action does not also receive same-action pressure;
+3. historical entries with no remediation hint use the older same-action match of target + lesson + version + action for backward compatibility.
 
-This same-action matching is intentionally narrow. V1 does not infer that an error observed in one action should automatically schedule a different repair action.
+The generic planner never interprets `missing-target-group:0` or other lesson-specific group indexes.
+
+## Cross-action remediation
+
+The first Nếp lesson can now route recurring errors across actions and even embedded capability targets. For example:
+
+```text
+transfer missing repair move -> dedicated repair candidate
+transfer missing introduction -> dedicated production candidate
+```
+
+This avoids forcing the learner to repeat an entire transfer task when a narrower prerequisite behavior is the thing that needs repair.
 
 ## Binary pressure
 
@@ -53,7 +62,7 @@ Multiple matching error tags are reported in the planner reason string for expla
 
 ## V1 weight
 
-The default ranking term is:
+The default ranking term remains:
 
 ```text
 errorRepairPressure * 0.65
@@ -69,27 +78,21 @@ A selected opportunity may include a reason such as:
 recurring-error-repair:2
 ```
 
-This means two recurring Error Memory entries matched the same candidate identity. The score pressure is still binary (`1`), not `2`.
+This means two recurring Error Memory entries route to that candidate. The score pressure is still binary (`1`), not `2`.
 
 The score breakdown exposes `errorRepairPressure` separately from skill gap and other terms.
 
 ## Read boundary
 
-The authenticated Session Planner server action now rebuilds Error Memory from the same immutable attempts used by the Error Memory read model and passes the entries into `planSession()`.
+The authenticated Session Planner server action rebuilds Error Memory from immutable attempts and passes the entries into `planSession()`.
 
-The query remains data-minimized. It reads derived structured error metadata and does not select raw `response_text` or the full `metadata` object.
+The query remains data-minimized. It reads correctness/support/reveal state plus derived structured error/remediation metadata and does not select raw `response_text` or the full `metadata` object.
 
-## Current limitation
+## Content ownership
 
-V1 repairs the **same versioned action** where recurrence was observed. It does not yet have a semantic remediation map such as:
+Remediation semantics live in the versioned Nếp remediation map, not in Session Planner. Static QA verifies that a remediation target exists and is evidence-bearing/plannable.
 
-```text
-transfer missing repair move -> schedule dedicated repair action
-```
-
-That mapping needs an explicit content/knowledge contract. Guessing it from group indexes inside the planner would couple the generic planner to one lesson's internal ordering.
-
-A future V2 can introduce a declared `repairCandidateId` or semantic error target in the lesson compiler, then let Error Memory point to that stable remediation target.
+See `EXPLICIT_ERROR_REMEDIATION_V1.md` for the content contract.
 
 ## What V1 does not claim
 
@@ -99,6 +102,7 @@ Error repair pressure is not:
 - a diagnosis of a misconception;
 - a grammar or pronunciation diagnosis;
 - reinforcement learning;
-- evidence that more repetition is always better.
+- evidence that more repetition is always better;
+- evidence that the current remediation map is optimal.
 
 It is an explainable ranking heuristic over already-valid practice opportunities.

--- a/src/__tests__/error-memory.test.ts
+++ b/src/__tests__/error-memory.test.ts
@@ -4,6 +4,7 @@ import {
   ERROR_MEMORY_ATTEMPT_SELECT,
   actionableErrorTags,
   buildErrorMemory,
+  remediationCandidateIdsForTag,
   type ErrorMemoryAttemptRow,
 } from "@/lib/learning/error-memory";
 
@@ -13,11 +14,16 @@ function row(overrides: Partial<ErrorMemoryAttemptRow> = {}): ErrorMemoryAttempt
     knowledge_item_id: null,
     correct: false,
     support_level: 0,
+    reveal_used: false,
     lesson_id: "nep-first-meeting-v1",
     lesson_version: "1.0.0",
     action_id: "transfer",
     observed_response: true,
     error_tags: ["partial-target-coverage", "missing-target-group:1"],
+    remediation_hints: [{
+      errorTag: "missing-target-group:1",
+      candidateId: "nep-first-meeting-v1:produce",
+    }],
     created_at: "2026-09-02T10:00:00.000Z",
     ...overrides,
   };
@@ -30,6 +36,7 @@ describe("Error Memory V1", () => {
     expect(memory.recurring).toHaveLength(0);
     expect(memory.entries[0]).toMatchObject({
       errorTag: "missing-target-group:1",
+      remediationCandidateIds: ["nep-first-meeting-v1:produce"],
       status: "observed",
       independentFailureCount: 1,
       independentFailuresSinceRepair: 1,
@@ -66,6 +73,21 @@ describe("Error Memory V1", () => {
     });
   });
 
+  it("does not let a failure after answer reveal manufacture recurrence", () => {
+    const memory = buildErrorMemory([
+      row({ reveal_used: true, created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ reveal_used: true, created_at: "2026-09-02T11:00:00.000Z" }),
+      row({ reveal_used: false, created_at: "2026-09-02T12:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.entries[0]).toMatchObject({
+      status: "observed",
+      independentFailureCount: 1,
+      supportedFailureCount: 2,
+    });
+  });
+
   it("ignores no-response and broad partial-coverage tags as persistent error patterns", () => {
     const memory = buildErrorMemory([
       row({ observed_response: false, error_tags: ["no-response", "missing-target-group:1"] }),
@@ -78,11 +100,38 @@ describe("Error Memory V1", () => {
     ]);
   });
 
+  it("keeps only remediation hints that belong to the exact actionable error tag", () => {
+    const hints = [
+      { errorTag: "missing-target-group:1", candidateId: "lesson:produce" },
+      { errorTag: "missing-target-group:0", candidateId: "lesson:repair" },
+      { errorTag: "missing-target-group:1", candidateId: "lesson:produce" },
+      { errorTag: "missing-target-group:1", candidateId: "" },
+      { bad: true },
+    ];
+
+    expect(remediationCandidateIdsForTag(hints, "missing-target-group:1")).toEqual(["lesson:produce"]);
+  });
+
+  it("merges remediation candidate hints across compatible historical rows", () => {
+    const memory = buildErrorMemory([
+      row({ remediation_hints: [], created_at: "2026-09-02T10:00:00.000Z" }),
+      row({
+        remediation_hints: [{
+          errorTag: "missing-target-group:1",
+          candidateId: "nep-first-meeting-v1:produce",
+        }],
+        created_at: "2026-09-02T11:00:00.000Z",
+      }),
+    ]);
+
+    expect(memory.recurring[0]?.remediationCandidateIds).toEqual(["nep-first-meeting-v1:produce"]);
+  });
+
   it("marks a recurring error repaired after a later independent success on the same action", () => {
     const memory = buildErrorMemory([
       row({ created_at: "2026-09-02T10:00:00.000Z" }),
       row({ created_at: "2026-09-02T11:00:00.000Z" }),
-      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+      row({ correct: true, error_tags: [], remediation_hints: [], created_at: "2026-09-02T12:00:00.000Z" }),
     ]);
 
     expect(memory.recurring).toHaveLength(0);
@@ -98,7 +147,7 @@ describe("Error Memory V1", () => {
     const memory = buildErrorMemory([
       row({ created_at: "2026-09-02T10:00:00.000Z" }),
       row({ created_at: "2026-09-02T11:00:00.000Z" }),
-      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+      row({ correct: true, error_tags: [], remediation_hints: [], created_at: "2026-09-02T12:00:00.000Z" }),
       row({ created_at: "2026-09-02T13:00:00.000Z" }),
     ]);
 
@@ -126,15 +175,17 @@ describe("Error Memory V1", () => {
     const chronological = [
       row({ created_at: "2026-09-02T10:00:00.000Z" }),
       row({ created_at: "2026-09-02T11:00:00.000Z" }),
-      row({ correct: true, error_tags: [], created_at: "2026-09-02T12:00:00.000Z" }),
+      row({ correct: true, error_tags: [], remediation_hints: [], created_at: "2026-09-02T12:00:00.000Z" }),
     ];
 
     expect(buildErrorMemory([...chronological].reverse())).toEqual(buildErrorMemory(chronological));
   });
 
-  it("locks the read projection to derived metadata and excludes raw learner content", () => {
+  it("locks the read projection to derived metadata and assisted-state fields", () => {
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("error_tags:metadata->errorSignals->errorTags");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("observed_response:metadata->errorSignals->observedResponse");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("remediation_hints:metadata->errorSignals->remediationHints");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("reveal_used");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toContain("response_text");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toMatch(/(^|,\s*)metadata($|,)/);
   });

--- a/src/__tests__/planner-error-repair-gates.test.ts
+++ b/src/__tests__/planner-error-repair-gates.test.ts
@@ -10,6 +10,7 @@ const recurringError: ErrorMemoryEntry = {
   lessonVersion: "1.0.0",
   actionId: "produce",
   errorTag: "missing-target-group:0",
+  remediationCandidateIds: ["candidate-b"],
   status: "recurring",
   independentFailureCount: 2,
   supportedFailureCount: 0,
@@ -33,7 +34,7 @@ const gatedCandidate: PlannerCandidate = {
 };
 
 describe("planner recurring-error hard gates", () => {
-  it("does not let recurring error pressure bypass an unmet prerequisite", () => {
+  it("does not let explicit recurring remediation pressure bypass an unmet prerequisite", () => {
     const result = planSession({
       candidates: [gatedCandidate],
       states: [],

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -42,6 +42,7 @@ function errorMemoryEntry(overrides: Partial<ErrorMemoryEntry> = {}): ErrorMemor
     lessonVersion: "1.0.0",
     actionId: "produce",
     errorTag: "missing-target-group:0",
+    remediationCandidateIds: [],
     status,
     independentFailureCount: status === "recurring" ? 2 : 1,
     supportedFailureCount: 0,
@@ -246,7 +247,7 @@ describe("session planner v1", () => {
     },
   );
 
-  it("does not leak error pressure across target, lesson version, or action identity", () => {
+  it("does not leak legacy same-action pressure across target, lesson version, or action identity", () => {
     const target = plannerCandidate("a-candidate", "cap-a", "lesson-a");
     const mismatches = [
       errorMemoryEntry({ targetId: "cap-x" }),
@@ -261,12 +262,68 @@ describe("session planner v1", () => {
     }
   });
 
-  it("keeps recurring error pressure binary even when multiple tags match one action", () => {
+  it("routes recurring pressure to an explicit cross-action remediation candidate", () => {
+    const lessonId = "LESSON-CAP002-FIRST-MEETING-V1";
+    const repairId = `${lessonId}:repair`;
+    const transferId = `${lessonId}:transfer`;
+    const repair = candidate({
+      id: repairId,
+      targetId: "CAP-003",
+      evidenceType: "repair",
+      metadata: { lessonId, lessonVersion: "1", actionId: "repair" },
+    });
+    const transfer = candidate({
+      id: transferId,
+      targetId: "CAP-002",
+      evidenceType: "transfer",
+      transferValue: 1,
+      metadata: { lessonId, lessonVersion: "1", actionId: "transfer" },
+    });
+    const recurringTransferError = errorMemoryEntry({
+      key: "CAP-002|LESSON-CAP002-FIRST-MEETING-V1|1|transfer|missing-target-group:0",
+      targetId: "CAP-002",
+      lessonId,
+      lessonVersion: "1",
+      actionId: "transfer",
+      remediationCandidateIds: [repairId],
+    });
+
+    const result = plan({
+      candidates: [transfer, repair],
+      states: [state("CAP-002", { production: 0.3, evidenceCount: 1 })],
+      sessionSize: 2,
+      errorMemory: [recurringTransferError],
+    });
+
+    const repairOpportunity = result.opportunities.find((item) => item.candidate.id === repairId);
+    const transferOpportunity = result.opportunities.find((item) => item.candidate.id === transferId);
+    expect(repairOpportunity?.breakdown.errorRepairPressure).toBe(1);
+    expect(transferOpportunity?.breakdown.errorRepairPressure).toBe(0);
+  });
+
+  it("explicit remediation hints override the legacy same-action fallback", () => {
+    const source = plannerCandidate("lesson-b:produce", "cap-b", "lesson-b");
+    const remediation = plannerCandidate("lesson-b:retrieve", "cap-b", "lesson-b", "retrieve");
+    const entry = errorMemoryEntry({ remediationCandidateIds: [remediation.id] });
+
+    const result = plan({
+      candidates: [source, remediation],
+      states: [],
+      sessionSize: 2,
+      errorMemory: [entry],
+    });
+
+    expect(result.opportunities.find((item) => item.candidate.id === source.id)?.breakdown.errorRepairPressure).toBe(0);
+    expect(result.opportunities.find((item) => item.candidate.id === remediation.id)?.breakdown.errorRepairPressure).toBe(1);
+  });
+
+  it("keeps recurring error pressure binary even when multiple tags route to one candidate", () => {
     const matchingCandidate = plannerCandidate("candidate", "cap-b", "lesson-b");
-    const first = errorMemoryEntry();
+    const first = errorMemoryEntry({ remediationCandidateIds: [matchingCandidate.id] });
     const second = errorMemoryEntry({
       key: "cap-b|lesson-b|1.0.0|produce|incorrect-choice",
       errorTag: "incorrect-choice",
+      remediationCandidateIds: [matchingCandidate.id],
     });
     const result = plan({
       candidates: [matchingCandidate],

--- a/src/lib/learning/error-memory.ts
+++ b/src/lib/learning/error-memory.ts
@@ -3,11 +3,13 @@ export const ERROR_MEMORY_ATTEMPT_SELECT = [
   "knowledge_item_id",
   "correct",
   "support_level",
+  "reveal_used",
   "lesson_id:metadata->>lessonId",
   "lesson_version:metadata->>lessonVersion",
   "action_id:metadata->>actionId",
   "observed_response:metadata->errorSignals->observedResponse",
   "error_tags:metadata->errorSignals->errorTags",
+  "remediation_hints:metadata->errorSignals->remediationHints",
   "created_at",
 ].join(", ");
 
@@ -16,11 +18,13 @@ export type ErrorMemoryAttemptRow = {
   knowledge_item_id: string | null;
   correct: boolean | null;
   support_level: number;
+  reveal_used: boolean;
   lesson_id: string | null;
   lesson_version: string | null;
   action_id: string | null;
   observed_response: unknown;
   error_tags: unknown;
+  remediation_hints: unknown;
   created_at: string;
 };
 
@@ -34,6 +38,7 @@ export type ErrorMemoryEntry = {
   lessonVersion: string;
   actionId: string;
   errorTag: ActionableErrorTag;
+  remediationCandidateIds: string[];
   status: ErrorMemoryStatus;
   independentFailureCount: number;
   supportedFailureCount: number;
@@ -54,8 +59,8 @@ type MutableEntry = ErrorMemoryEntry;
 
 /**
  * Error Memory V1 turns repeated, independent task-coverage failures into a temporary pattern.
- * One failure is only an observation. Supported failures do not promote recurrence. A later
- * independent success on the same versioned action repairs all active tags for that action.
+ * One failure is only an observation. Assisted failures (support or answer reveal) do not promote
+ * recurrence. A later independent success on the same versioned action repairs all active tags.
  */
 export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnapshot {
   const entries = new Map<string, MutableEntry>();
@@ -73,9 +78,9 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
     if (!targetId || !lessonId || !lessonVersion || !actionId) continue;
 
     const observedResponse = row.observed_response === true;
-    const supported = Number.isFinite(row.support_level) && row.support_level > 0;
+    const assisted = (Number.isFinite(row.support_level) && row.support_level > 0) || row.reveal_used === true;
 
-    if (row.correct === true && observedResponse && !supported) {
+    if (row.correct === true && observedResponse && !assisted) {
       repairActionEntries(entries, targetId, lessonId, lessonVersion, actionId, row.created_at);
       continue;
     }
@@ -84,6 +89,7 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
 
     for (const errorTag of actionableErrorTags(row.error_tags)) {
       const key = memoryKey(targetId, lessonId, lessonVersion, actionId, errorTag);
+      const remediationCandidateIds = remediationCandidateIdsForTag(row.remediation_hints, errorTag);
       const existing = entries.get(key);
       if (!existing) {
         entries.set(key, {
@@ -93,10 +99,11 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
           lessonVersion,
           actionId,
           errorTag,
-          status: supported ? "supported-only" : "observed",
-          independentFailureCount: supported ? 0 : 1,
-          supportedFailureCount: supported ? 1 : 0,
-          independentFailuresSinceRepair: supported ? 0 : 1,
+          remediationCandidateIds,
+          status: assisted ? "supported-only" : "observed",
+          independentFailureCount: assisted ? 0 : 1,
+          supportedFailureCount: assisted ? 1 : 0,
+          independentFailuresSinceRepair: assisted ? 0 : 1,
           firstSeenAt: row.created_at,
           lastSeenAt: row.created_at,
           repairedAt: null,
@@ -105,7 +112,11 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
       }
 
       existing.lastSeenAt = row.created_at;
-      if (supported) {
+      existing.remediationCandidateIds = mergeCandidateIds(
+        existing.remediationCandidateIds,
+        remediationCandidateIds,
+      );
+      if (assisted) {
         existing.supportedFailureCount += 1;
       } else {
         existing.independentFailureCount += 1;
@@ -117,7 +128,11 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
   }
 
   const allEntries = [...entries.values()]
-    .map((entry) => ({ ...entry, status: statusFor(entry) }))
+    .map((entry) => ({
+      ...entry,
+      remediationCandidateIds: [...entry.remediationCandidateIds].sort(),
+      status: statusFor(entry),
+    }))
     .sort(compareEntries);
 
   return {
@@ -142,6 +157,21 @@ export function actionableErrorTags(value: unknown): ActionableErrorTag[] {
     tags.add(`missing-target-group:${Number(match[1])}`);
   }
   return [...tags].sort();
+}
+
+export function remediationCandidateIdsForTag(value: unknown, errorTag: ActionableErrorTag) {
+  if (!Array.isArray(value)) return [];
+  const candidateIds = new Set<string>();
+
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const hint = item as Record<string, unknown>;
+    if (hint.errorTag !== errorTag) continue;
+    const candidateId = typeof hint.candidateId === "string" ? hint.candidateId.trim() : "";
+    if (candidateId) candidateIds.add(candidateId);
+  }
+
+  return [...candidateIds].sort();
 }
 
 function repairActionEntries(
@@ -191,7 +221,11 @@ function rowIdentity(row: ErrorMemoryAttemptRow) {
     row.lesson_id ?? "",
     row.lesson_version ?? "",
     row.action_id ?? "",
+    String(row.correct),
+    String(row.support_level),
+    String(row.reveal_used),
     JSON.stringify(row.error_tags),
+    JSON.stringify(row.remediation_hints),
   ].join("|");
 }
 
@@ -206,6 +240,10 @@ function compareEntries(a: ErrorMemoryEntry, b: ErrorMemoryEntry) {
     || b.independentFailuresSinceRepair - a.independentFailuresSinceRepair
     || Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt)
     || a.key.localeCompare(b.key);
+}
+
+function mergeCandidateIds(first: string[], second: string[]) {
+  return [...new Set([...first, ...second])].sort();
 }
 
 function nonEmpty(value: string | null) {

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -251,19 +251,30 @@ function scoreCandidate(input: {
   };
 }
 
+/**
+ * Explicit remediation hints override same-action fallback. This allows a recurring transfer
+ * failure such as "missing repair move" to pressure the dedicated repair candidate (even when it
+ * targets a different embedded capability) without teaching the generic planner what group 0 means.
+ * Older error-memory rows without hints keep the previous same-action behavior for compatibility.
+ */
 function matchingRecurringErrorCount(candidate: PlannerCandidate, entries: ErrorMemoryEntry[]) {
   const lessonId = metadataString(candidate.metadata, "lessonId");
   const lessonVersion = metadataString(candidate.metadata, "lessonVersion");
   const actionId = metadataString(candidate.metadata, "actionId");
-  if (!lessonId || !lessonVersion || !actionId) return 0;
 
   return entries.reduce((count, entry) => {
-    const matches = entry.status === "recurring"
-      && entry.targetId === candidate.targetId
+    if (entry.status !== "recurring") return count;
+
+    if (entry.remediationCandidateIds.length > 0) {
+      return count + (entry.remediationCandidateIds.includes(candidate.id) ? 1 : 0);
+    }
+
+    if (!lessonId || !lessonVersion || !actionId) return count;
+    const legacySameActionMatch = entry.targetId === candidate.targetId
       && entry.lessonId === lessonId
       && entry.lessonVersion === lessonVersion
       && entry.actionId === actionId;
-    return count + (matches ? 1 : 0);
+    return count + (legacySameActionMatch ? 1 : 0);
   }, 0);
 }
 

--- a/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
+++ b/src/lib/nep/__tests__/learning-evidence-adapter.test.ts
@@ -72,12 +72,29 @@ describe("Nếp → learning-core adapter", () => {
         matchedTargetGroupIndexes: [0],
         missingTargetGroupIndexes: [1],
         errorTags: ["partial-target-coverage", "missing-target-group:1"],
+        remediationHints: [{
+          errorTag: "missing-target-group:1",
+          candidateId: "LESSON-CAP002-FIRST-MEETING-V1:produce",
+        }],
       },
     });
     expect(record?.candidate?.metadata).toMatchObject({
       errorSignals: {
         missingTargetGroupIndexes: [1],
         errorTags: ["partial-target-coverage", "missing-target-group:1"],
+      },
+    });
+  });
+
+  it("routes a missing transfer repair move to the dedicated repair candidate", () => {
+    const record = recordFor("transfer", "My name is Hoang.", "speech");
+
+    expect(record?.attempt.metadata).toMatchObject({
+      errorSignals: {
+        remediationHints: [{
+          errorTag: "missing-target-group:0",
+          candidateId: "LESSON-CAP002-FIRST-MEETING-V1:repair",
+        }],
       },
     });
   });
@@ -110,6 +127,19 @@ describe("Nếp → learning-core adapter", () => {
     expect(materializeEvidence({ attempt: record!.attempt, candidate: record!.candidate! })).toBeNull();
   });
 
+  it("marks retry after answer-bearing feedback as revealed even when support was not opened", () => {
+    const record = recordFor(
+      "retry",
+      "Could you say that again? My name is Hoang.",
+      "speech",
+      false,
+    );
+
+    expect(record?.attempt.revealUsed).toBe(true);
+    expect(record?.attempt.supportLevel).toBe(0);
+    expect(record?.candidate).toBeNull();
+  });
+
   it("stores supported retry as attempt-only while retaining derived evaluation signals", () => {
     const record = recordFor(
       "retry",
@@ -119,9 +149,10 @@ describe("Nếp → learning-core adapter", () => {
     );
 
     expect(record?.attempt.supportLevel).toBe(1);
+    expect(record?.attempt.revealUsed).toBe(true);
     expect(record?.attempt.correct).toBe(true);
     expect(record?.attempt.metadata).toMatchObject({
-      errorSignals: { errorTags: [], missingTargetGroupIndexes: [] },
+      errorSignals: { errorTags: [], missingTargetGroupIndexes: [], remediationHints: [] },
     });
     expect(record?.candidate).toBeNull();
   });

--- a/src/lib/nep/__tests__/remediation-map.test.ts
+++ b/src/lib/nep/__tests__/remediation-map.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateNếpAction } from "../evaluator";
+import { firstMeetingLessonV1 } from "../lesson-contract";
+import {
+  plannerCandidateId,
+  remediationHintsForEvaluation,
+  validateNếpRemediationMap,
+} from "../remediation-map.v1";
+
+function action(id: string) {
+  return firstMeetingLessonV1.actions.find((item) => item.id === id)!;
+}
+
+describe("Nếp remediation map V1", () => {
+  it("passes static content QA for the first-meeting lesson", () => {
+    expect(validateNếpRemediationMap(firstMeetingLessonV1)).toEqual([]);
+  });
+
+  it("routes missing repair language in transfer to the repair candidate", () => {
+    const transfer = action("transfer");
+    const evaluation = evaluateNếpAction(transfer, "My name is Hoang.");
+
+    expect(remediationHintsForEvaluation({
+      lesson: firstMeetingLessonV1,
+      action: transfer,
+      evaluation,
+    })).toEqual([{
+      errorTag: "missing-target-group:0",
+      candidateId: plannerCandidateId(firstMeetingLessonV1.id, "repair"),
+    }]);
+  });
+
+  it("routes missing introduction language in transfer to the production candidate", () => {
+    const transfer = action("transfer");
+    const evaluation = evaluateNếpAction(transfer, "Could you say that again?");
+
+    expect(remediationHintsForEvaluation({
+      lesson: firstMeetingLessonV1,
+      action: transfer,
+      evaluation,
+    })).toEqual([{
+      errorTag: "missing-target-group:1",
+      candidateId: plannerCandidateId(firstMeetingLessonV1.id, "produce"),
+    }]);
+  });
+
+  it("routes a failed production frame back to retrieval practice", () => {
+    const produce = action("produce");
+    const evaluation = evaluateNếpAction(produce, "hello");
+
+    expect(remediationHintsForEvaluation({
+      lesson: firstMeetingLessonV1,
+      action: produce,
+      evaluation,
+    })).toEqual([{
+      errorTag: "missing-target-group:0",
+      candidateId: plannerCandidateId(firstMeetingLessonV1.id, "retrieve"),
+    }]);
+  });
+
+  it("emits no remediation hint for a successful response", () => {
+    const transfer = action("transfer");
+    const evaluation = evaluateNếpAction(
+      transfer,
+      "Could you say that again? My name is Hoang.",
+    );
+
+    expect(remediationHintsForEvaluation({
+      lesson: firstMeetingLessonV1,
+      action: transfer,
+      evaluation,
+    })).toEqual([]);
+  });
+
+  it("does not route attempt-only retry through the evidence-bearing planner catalog", () => {
+    const retry = action("retry");
+    const evaluation = evaluateNếpAction(retry, "hello");
+
+    expect(remediationHintsForEvaluation({
+      lesson: firstMeetingLessonV1,
+      action: retry,
+      evaluation,
+    })).toEqual([]);
+  });
+});

--- a/src/lib/nep/learning-evidence-adapter.ts
+++ b/src/lib/nep/learning-evidence-adapter.ts
@@ -1,6 +1,7 @@
 import type { RecordLearningAttemptInput } from "../learning/validation";
 import type { NếpEvaluationResult } from "./evaluator";
 import type { LessonAction, LessonContract } from "./lesson-contract";
+import { remediationHintsForEvaluation } from "./remediation-map.v1";
 
 export type NếpResponseSource = "speech" | "text" | null;
 
@@ -21,7 +22,11 @@ function responseModality(action: LessonAction, source: NếpResponseSource) {
   return "none" as const;
 }
 
-function structuredErrorSignals(evaluation: NếpEvaluationResult) {
+function structuredErrorSignals(
+  lesson: LessonContract,
+  action: LessonAction,
+  evaluation: NếpEvaluationResult,
+) {
   return {
     version: 1,
     evaluator: evaluation.evaluator,
@@ -29,6 +34,7 @@ function structuredErrorSignals(evaluation: NếpEvaluationResult) {
     matchedTargetGroupIndexes: evaluation.matchedTargetGroupIndexes,
     missingTargetGroupIndexes: evaluation.missingTargetGroupIndexes,
     errorTags: evaluation.errorTags,
+    remediationHints: remediationHintsForEvaluation({ lesson, action, evaluation }),
   };
 }
 
@@ -44,7 +50,10 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
 
   const modality = responseModality(action, responseSource);
   const safeLatency = Math.min(60 * 60 * 1000, Math.max(0, Math.round(latencyMs)));
-  const errorSignals = structuredErrorSignals(evaluation);
+  const errorSignals = structuredErrorSignals(lesson, action, evaluation);
+  // Retry happens after answer-bearing feedback in this contract. It remains attempt-only and
+  // must never be replayed by Error Memory as an independent learner failure.
+  const revealUsed = action.kind === "retry";
   const metadata = {
     lessonId: lesson.id,
     lessonVersion: lesson.version,
@@ -69,7 +78,7 @@ export function toLearningAttemptRecord(input: EvaluatedNếpAction): RecordLear
       correct: evaluation.success,
       latencyMs: safeLatency,
       hintCount: 0,
-      revealUsed: false,
+      revealUsed,
       supportLevel: supportUsed ? 1 : 0,
       metadata,
     },

--- a/src/lib/nep/remediation-map.v1.ts
+++ b/src/lib/nep/remediation-map.v1.ts
@@ -1,0 +1,145 @@
+import type { NếpEvaluationErrorTag, NếpEvaluationResult } from "./evaluator";
+import type { LessonAction, LessonContract } from "./lesson-contract";
+
+export type NếpRemediationHint = {
+  errorTag: NếpEvaluationErrorTag;
+  candidateId: string;
+};
+
+type RemediationRule = {
+  lessonId: string;
+  lessonVersion: number;
+  sourceActionId: string;
+  errorTag: NếpEvaluationErrorTag;
+  targetActionId: string;
+};
+
+/**
+ * Product-policy mapping for the first Nếp vertical slice.
+ * The generic planner never interprets target-group indexes itself. Content explicitly says
+ * which evidence-bearing action is the safer next practice for a derived task-coverage error.
+ */
+export const NẾP_REMEDIATION_RULES_V1: RemediationRule[] = [
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "comprehend",
+    errorTag: "incorrect-choice",
+    targetActionId: "comprehend",
+  },
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "retrieve",
+    errorTag: "missing-target-group:0",
+    targetActionId: "retrieve",
+  },
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "produce",
+    errorTag: "missing-target-group:0",
+    targetActionId: "retrieve",
+  },
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "repair",
+    errorTag: "missing-target-group:0",
+    targetActionId: "repair",
+  },
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "transfer",
+    errorTag: "missing-target-group:0",
+    targetActionId: "repair",
+  },
+  {
+    lessonId: "LESSON-CAP002-FIRST-MEETING-V1",
+    lessonVersion: 1,
+    sourceActionId: "transfer",
+    errorTag: "missing-target-group:1",
+    targetActionId: "produce",
+  },
+];
+
+export function plannerCandidateId(lessonId: string, actionId: string) {
+  return `${lessonId}:${actionId}`;
+}
+
+export function remediationHintsForEvaluation(input: {
+  lesson: LessonContract;
+  action: LessonAction;
+  evaluation: NếpEvaluationResult;
+}): NếpRemediationHint[] {
+  const { lesson, action, evaluation } = input;
+  const observedTags = new Set<NếpEvaluationErrorTag>(evaluation.errorTags);
+  const hints = NẾP_REMEDIATION_RULES_V1.flatMap((rule) => {
+    if (
+      rule.lessonId !== lesson.id
+      || rule.lessonVersion !== lesson.version
+      || rule.sourceActionId !== action.id
+      || !observedTags.has(rule.errorTag)
+    ) {
+      return [];
+    }
+
+    return [{
+      errorTag: rule.errorTag,
+      candidateId: plannerCandidateId(lesson.id, rule.targetActionId),
+    }];
+  });
+
+  return dedupeHints(hints);
+}
+
+/**
+ * Static content QA for remediation rules. A remediation target must exist in the same versioned
+ * lesson and must compile to an evidence-bearing planner candidate. Attempt-only retry cannot be
+ * used as a remediation target.
+ */
+export function validateNếpRemediationMap(lesson: LessonContract) {
+  const issues: string[] = [];
+  const actionById = new Map(lesson.actions.map((action) => [action.id, action]));
+
+  for (const rule of NẾP_REMEDIATION_RULES_V1) {
+    if (rule.lessonId !== lesson.id || rule.lessonVersion !== lesson.version) continue;
+
+    const source = actionById.get(rule.sourceActionId);
+    const target = actionById.get(rule.targetActionId);
+    if (!source) {
+      issues.push(`missing-source:${rule.sourceActionId}`);
+      continue;
+    }
+    if (!target) {
+      issues.push(`missing-target:${rule.targetActionId}`);
+      continue;
+    }
+    if (!target.assessment?.evidenceType) {
+      issues.push(`target-not-plannable:${rule.targetActionId}`);
+    }
+
+    const missingGroup = /^missing-target-group:(\d+)$/.exec(rule.errorTag);
+    if (missingGroup) {
+      const groupIndex = Number(missingGroup[1]);
+      const groupCount = source.requiredSignalGroups?.length ?? 0;
+      if (groupIndex >= groupCount) {
+        issues.push(`source-group-out-of-range:${rule.sourceActionId}:${groupIndex}`);
+      }
+    }
+  }
+
+  return [...new Set(issues)].sort();
+}
+
+function dedupeHints(hints: NếpRemediationHint[]) {
+  const byKey = new Map<string, NếpRemediationHint>();
+  for (const hint of hints) {
+    byKey.set(`${hint.errorTag}|${hint.candidateId}`, hint);
+  }
+  return [...byKey.values()].sort((a, b) => {
+    const tag = a.errorTag.localeCompare(b.errorTag);
+    return tag !== 0 ? tag : a.candidateId.localeCompare(b.candidateId);
+  });
+}

--- a/src/lib/nep/session-catalog.v1.ts
+++ b/src/lib/nep/session-catalog.v1.ts
@@ -1,5 +1,6 @@
 import type { PlannerCandidate } from "../learning/session-planner";
 import { firstMeetingLessonV1, type LessonActionKind, type LessonContract } from "./lesson-contract";
+import { plannerCandidateId } from "./remediation-map.v1";
 
 const IMPORTANCE_BY_ACTION: Partial<Record<LessonActionKind, number>> = {
   comprehend: 0.8,
@@ -27,7 +28,7 @@ export function buildLessonPlannerCandidates(lesson: LessonContract): PlannerCan
     if (!assessment?.evidenceType) return [];
 
     return [{
-      id: `${lesson.id}:${action.id}`,
+      id: plannerCandidateId(lesson.id, action.id),
       targetId: assessment.targetCapabilityId,
       evidenceType: assessment.evidenceType,
       prerequisiteTargetIds: lesson.prerequisites,


### PR DESCRIPTION
## Why
Recurring Error Memory should not always force the learner to repeat the same task that exposed the error. This slice lets versioned content explicitly route a recurring task-coverage error to a narrower evidence-bearing remediation candidate.

## Stack
- Base: `agent/planner-error-repair-pressure-v1` / PR #71
- Head: `agent/explicit-error-remediation-v1`
- No database migration.
- No learner-facing route integration.

## Explicit remediation map
Adds a versioned Nếp remediation map. The generic planner does not interpret lesson-specific target-group indexes.

Current first-meeting mappings include:
- transfer missing repair move -> dedicated `repair` candidate;
- transfer missing self-introduction -> dedicated `produce` candidate;
- production missing its target frame -> `retrieve` practice;
- repair/retrieval/comprehension errors stay on their narrow evidence-bearing repair opportunity.

Remediation rules are V1 product policy, not an efficacy claim.

## Persistence
The Nếp adapter persists privacy-safe derived `remediationHints` inside `errorSignals`, keyed by actionable error tag and stable planner candidate ID. Raw learner text/transcript remains excluded.

## Error Memory
Error Memory now carries `remediationCandidateIds` per actionable error tag.

It also fixes an assisted-attempt bug: `reveal_used=true` now counts as assisted just like `support_level>0`, so retry after answer-bearing feedback cannot manufacture an independent recurring error merely because optional Vietnamese support was not opened.

## Planner behavior
For a recurring entry:
1. explicit remediation candidate IDs override legacy same-action matching;
2. only the declared remediation candidate gets error-repair pressure;
3. old rows without hints keep same-action fallback for compatibility;
4. pressure remains binary;
5. hard eligibility gates remain authoritative.

This allows a recurring transfer error on CAP-002 to pressure the dedicated repair opportunity on embedded CAP-003 without teaching Session Planner what `missing-target-group:0` means.

## Static QA
The remediation map validates that source/target actions exist, target actions are evidence-bearing/plannable, and missing-group rules reference valid source groups. Attempt-only retry cannot be a remediation target.

## Tests
Adds/extends regressions for:
- transfer missing repair -> repair candidate;
- transfer missing introduction -> production candidate;
- production failure -> retrieval candidate;
- successful/attempt-only retry produces no remediation hint;
- remediation hints persist without raw learner text;
- answer-revealed retry is marked `revealUsed`;
- reveal-assisted failures do not create recurrence;
- Error Memory carries/deduplicates per-tag remediation IDs;
- explicit cross-action planner pressure;
- explicit hints override same-action fallback;
- binary pressure remains bounded;
- explicit remediation still cannot bypass planner hard gates;
- privacy-safe read projection includes only derived hints plus reveal state.

## Verification
Temporary draft PR #74 ran the full repository `Verify` workflow against `main` for head `e13a652aaa87299abea597cb55eab5f64b59a43b`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #74 was closed without merge after verification. PR #73 is mergeable and remains draft.

See `docs/nep/EXPLICIT_ERROR_REMEDIATION_V1.md`.