### PR TITLE
Add remediation re-probe cycle V1

### DIFF
--- a/docs/nep/ERROR_MEMORY_V1.md
+++ b/docs/nep/ERROR_MEMORY_V1.md
@@ -32,22 +32,31 @@ It deliberately ignores:
 - `no-response` — this may reflect microphone/STT/UI failure rather than learner knowledge;
 - `partial-target-coverage` — this is a broad summary already represented by the specific missing-group tag.
 
+## Independent vs diagnostic attempts
+
+An observation only counts as an independent Error Memory event when it is unassisted **and** the response modality can support that action.
+
+Assistance includes:
+
+- optional support (`support_level > 0`);
+- answer already revealed (`reveal_used = true`).
+
+For Nếp speaking actions (`retrieve`, `produce`, `repair`, `transfer`, `retry`), independent Error Memory evidence requires `response_modality = speech`. Typed fallback is diagnostic only: it can receive target-language feedback but cannot create, satisfy, or repair a recurring speaking pattern.
+
+For Nếp comprehension, the independent modality is `choice`. Historical rows without `actionKind` keep legacy behavior for compatibility.
+
 ## States
 
-Each memory entry has one of four states:
+Each memory entry has one of four primary states:
 
-- `supported-only` — the pattern has only been observed on assisted attempts;
+- `supported-only` — only diagnostic/assisted observations exist;
 - `observed` — one independent failure since the last repair;
 - `recurring` — at least two independent failures since the last repair;
-- `repaired` — a later independent successful response completed the same versioned action.
-
-An attempt is assisted when either optional support was used or the answer had already been revealed. Assisted failures are counted diagnostically but do not promote a pattern to `recurring`.
-
-This prevents retry-after-feedback from becoming fake independent evidence simply because the learner did not open the optional support control.
+- `repaired` — a later independent source success completed the same versioned action.
 
 ## Remediation hints
 
-Each actionable error entry may carry zero or more `remediationCandidateIds`. These IDs are derived from the versioned Nếp content remediation map, not inferred by the generic learner model.
+Each actionable error entry may carry zero or more `remediationCandidateIds`. These IDs come from the versioned Nếp content remediation map, not from planner inference.
 
 Examples:
 
@@ -58,21 +67,43 @@ transfer + missing-target-group:1 -> ...:produce
 
 Historical rows without hints remain valid. Planner logic can use same-action fallback only when an entry has no explicit remediation candidate.
 
-## Repair semantics
+## Remediation satisfaction and re-probe
 
-A later independent successful attempt on the same target + lesson version + action repairs all active error tags for that action.
+A recurring entry also carries:
 
-After repair, the old recurrence is not permanent. A new independent failure becomes `observed` again, and only another independent failure promotes it back to `recurring`.
+```ts
+remediationSatisfiedAt: string | null
+```
 
-This prevents the learner model from becoming a permanent collection of past mistakes.
+An independent success on one of the declared remediation candidates sets this timestamp, but **does not** mark the source error repaired. It only means the narrower remediation task has been completed and the original task should be re-probed.
+
+If the source re-probe succeeds independently, the source entry becomes `repaired`. If the source re-probe fails independently, `remediationSatisfiedAt` is cleared and remediation pressure reopens.
+
+An assisted remediation/source attempt cannot satisfy or repair this cycle.
+
+## Direct repair semantics
+
+A later independent successful attempt on the same target + lesson version + action repairs all active error tags for that action:
+
+```text
+status = repaired
+independentFailuresSinceRepair = 0
+repairedAt = success time
+remediationSatisfiedAt = null
+```
+
+After repair, a new independent failure becomes `observed` again, and only another independent failure promotes it back to `recurring`.
 
 ## Read boundary
 
 `getNếpErrorMemory()` is authenticated and read-only. It reads the learner's own `learning_attempts` rows through existing RLS and projects only:
 
 - target identity;
-- correctness/support/reveal state;
+- correctness;
+- response modality;
+- support/reveal state;
 - lesson/action/version identity;
+- `actionKind`;
 - `errorSignals.observedResponse`;
 - `errorSignals.errorTags`;
 - `errorSignals.remediationHints`;
@@ -82,9 +113,13 @@ It does not SELECT `response_text` or the full attempt `metadata` object.
 
 ## Planner integration
 
-Session Planner receives Error Memory entries but only `recurring` entries create error-repair pressure.
+Only `recurring` entries influence adaptive ranking:
 
-`observed`, `supported-only`, `repaired`, and `no-response` observations have zero ranking effect. Explicit remediation hints can route that pressure to a different evidence-bearing action; hard gates remain authoritative.
+- unresolved recurring error -> remediation pressure;
+- recurring error with `remediationSatisfiedAt` -> source re-probe pressure;
+- `observed`, `supported-only`, `repaired`, and `no-response` -> zero error pressure.
+
+All pressure terms remain below normal planner eligibility gates.
 
 ## What V1 does not do
 
@@ -95,6 +130,9 @@ Error Memory V1 does not:
 - infer grammar or pronunciation problems;
 - use LLM classification;
 - use RL/bandits;
-- persist a permanent learner label.
+- persist a permanent learner label;
+- treat typed fallback as speaking evidence.
 
 The snapshot is rebuilt deterministically from immutable attempts.
+
+See `REMEDIATION_REPROBE_V1.md` for the repair → re-probe state machine.

--- a/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
+++ b/docs/nep/PLANNER_ERROR_REPAIR_PRESSURE_V1.md
@@ -2,17 +2,16 @@
 
 ## Goal
 
-Session Planner already ranks practice using skill gap, cold start, staleness, importance, transfer value and anti-repetition penalties. Error Memory adds one new question:
+Session Planner ranks practice using skill gap, cold start, staleness, importance, transfer value and anti-repetition penalties. Error Memory adds two bounded adaptive questions:
 
-> Does this learner have a recurring task-coverage error that this candidate is explicitly meant to repair?
-
-V1 answers that conservatively with a fixed **binary repair pressure**.
+1. Does this learner have a recurring task-coverage error that this candidate is explicitly meant to remediate?
+2. Has that remediation already succeeded independently, making the original source task ready for re-probe?
 
 ## Eligibility first, ranking second
 
-Error repair pressure is only a score term. It cannot bypass planner hard gates.
+Error repair and re-probe pressures are score terms only. They cannot bypass planner hard gates.
 
-A recurring error does not unlock:
+Neither pressure unlocks:
 
 - an unmet prerequisite;
 - transfer before prior production;
@@ -21,88 +20,109 @@ A recurring error does not unlock:
 
 The planner checks eligibility first and scores only eligible opportunities.
 
-## Matching contract
+## Repair matching contract
 
-`observed`, `supported-only` and `repaired` Error Memory entries always have zero ranking effect.
+`observed`, `supported-only` and `repaired` Error Memory entries always have zero error pressure.
 
-For a `recurring` entry:
+For an unresolved `recurring` entry (`remediationSatisfiedAt === null`):
 
-1. if the entry has explicit `remediationCandidateIds`, a candidate matches only when its stable candidate ID is present in that list;
-2. when explicit remediation exists, the original source action does not also receive same-action pressure;
-3. historical entries with no remediation hint use the older same-action match of target + lesson + version + action for backward compatibility.
+1. if explicit `remediationCandidateIds` exist, only those stable candidate IDs match;
+2. when explicit remediation exists, the original source action does not also receive same-action repair pressure;
+3. historical entries with no remediation hint use legacy same-action target + lesson + version + action matching.
 
-The generic planner never interprets `missing-target-group:0` or other lesson-specific group indexes.
+The generic planner never interprets lesson-specific error-group indexes.
+
+## Re-probe matching contract
+
+When an independent remediation candidate succeeds, Error Memory keeps the source error `recurring` but sets `remediationSatisfiedAt`.
+
+At that point:
+
+- explicit remediation pressure turns off;
+- the exact source candidate receives `errorReprobePressure`;
+- a successful source re-probe repairs the source error;
+- a failed independent source re-probe clears remediation satisfaction and reopens remediation pressure.
+
+The source identity is still strict: target + lesson + version + action.
 
 ## Cross-action remediation
 
-The first Nếp lesson can now route recurring errors across actions and even embedded capability targets. For example:
+The first Nếp lesson can route recurring errors across actions and embedded capability targets. For example:
 
 ```text
 transfer missing repair move -> dedicated repair candidate
 transfer missing introduction -> dedicated production candidate
 ```
 
-This avoids forcing the learner to repeat an entire transfer task when a narrower prerequisite behavior is the thing that needs repair.
+After the narrower remediation succeeds, the planner stops drilling that remediation and prioritizes a new independent attempt on the original transfer task.
 
-## Binary pressure
+## Binary pressures
 
-If at least one recurring entry matches, then:
-
-```text
-errorRepairPressure = 1
-```
-
-Otherwise:
+Repair pressure is bounded:
 
 ```text
-errorRepairPressure = 0
+errorRepairPressure = 0 | 1
 ```
 
-Multiple matching error tags are reported in the planner reason string for explainability, but they do not multiply the score bonus. This avoids an unbounded feedback loop where a long history of failures dominates every future session.
+Re-probe pressure is independently bounded:
 
-## V1 weight
+```text
+errorReprobePressure = 0 | 1
+```
 
-The default ranking term remains:
+Multiple matching error tags may appear in explainability reasons, but neither score term grows beyond `1`.
+
+## V1 weights
+
+Default ranking terms are:
 
 ```text
 errorRepairPressure * 0.65
+errorReprobePressure * 0.60
 ```
 
-`0.65` is a product-policy heuristic for V1. It is not a calibrated learning probability, research-derived optimum, or efficacy claim. It should be tuned only after real learner data can show whether recurring-error opportunities are being over- or under-selected.
+Both weights are V1 product-policy heuristics. They are not calibrated probabilities, research-derived optima, or efficacy claims.
 
 ## Explainability
 
-A selected opportunity may include a reason such as:
+A remediation opportunity may include:
 
 ```text
 recurring-error-repair:2
 ```
 
-This means two recurring Error Memory entries route to that candidate. The score pressure is still binary (`1`), not `2`.
+A source task awaiting validation may include:
 
-The score breakdown exposes `errorRepairPressure` separately from skill gap and other terms.
+```text
+recurring-error-reprobe:1
+```
+
+The score breakdown exposes `errorRepairPressure` and `errorReprobePressure` separately from skill gap and other terms.
 
 ## Read boundary
 
-The authenticated Session Planner server action rebuilds Error Memory from immutable attempts and passes the entries into `planSession()`.
+The authenticated Session Planner server action rebuilds Error Memory from immutable attempts and passes entries into `planSession()`.
 
-The query remains data-minimized. It reads correctness/support/reveal state plus derived structured error/remediation metadata and does not select raw `response_text` or the full `metadata` object.
+The data-minimized Error Memory projection includes correctness, response modality, support/reveal state, action identity/kind, and derived error/remediation signals. It does not select raw `response_text` or the full metadata object.
 
 ## Content ownership
 
-Remediation semantics live in the versioned Nếp remediation map, not in Session Planner. Static QA verifies that a remediation target exists and is evidence-bearing/plannable.
+Remediation semantics live in the versioned Nếp remediation map, not Session Planner. Static QA verifies that remediation targets exist and are evidence-bearing/plannable.
 
-See `EXPLICIT_ERROR_REMEDIATION_V1.md` for the content contract.
+See:
+
+- `EXPLICIT_ERROR_REMEDIATION_V1.md` for content routing;
+- `REMEDIATION_REPROBE_V1.md` for the repair → re-probe state machine.
 
 ## What V1 does not claim
 
-Error repair pressure is not:
+These pressures are not:
 
-- a learner mastery probability;
-- a diagnosis of a misconception;
-- a grammar or pronunciation diagnosis;
+- learner mastery probabilities;
+- diagnoses of misconceptions;
+- grammar or pronunciation diagnoses;
 - reinforcement learning;
 - evidence that more repetition is always better;
-- evidence that the current remediation map is optimal.
+- evidence that the current remediation map or weights are optimal.
 
-It is an explainable ranking heuristic over already-valid practice opportunities.
+They are explainable ranking heuristics over already-valid practice opportunities.

--- a/docs/nep/REMEDIATION_REPROBE_V1.md
+++ b/docs/nep/REMEDIATION_REPROBE_V1.md
@@ -1,0 +1,162 @@
+# Remediation Re-probe V1
+
+## Goal
+
+Explicit remediation routing fixes one problem: a recurring error can be sent to a narrower practice action instead of repeating the whole source task.
+
+It creates another risk if the learner succeeds at that narrower practice:
+
+```text
+source recurring error -> remediation -> remediation success -> remediation again -> remediation again ...
+```
+
+Remediation Re-probe V1 closes that loop.
+
+The policy is:
+
+```text
+recurring source error
+  -> remediation pressure
+  -> independent remediation success
+  -> source re-probe pressure
+  -> source success: repaired
+  -> source failure: remediation reopens
+```
+
+## Remediation success is not source repair
+
+A successful remediation candidate only proves that the learner completed the narrower remediation task independently.
+
+It does **not** prove that the original source task is repaired.
+
+Error Memory therefore keeps the source entry as `recurring` and records:
+
+```ts
+remediationSatisfiedAt: string | null
+```
+
+When `remediationSatisfiedAt` is present:
+
+- remediation candidate pressure turns off;
+- the exact source action receives binary `errorReprobePressure`;
+- the source still must pass normal planner eligibility gates.
+
+## Source re-probe outcomes
+
+### Independent source success
+
+A later independent success on the original target + lesson version + action uses the existing direct repair rule:
+
+```text
+status = repaired
+independentFailuresSinceRepair = 0
+repairedAt = source success time
+remediationSatisfiedAt = null
+```
+
+### Independent source failure
+
+A failed source re-probe means the narrower remediation was not sufficient to eliminate the source error.
+
+The entry remains recurring and clears:
+
+```text
+remediationSatisfiedAt = null
+```
+
+That reopens explicit remediation pressure.
+
+### Assisted source attempt
+
+Support/reveal-assisted source attempts do not close or reopen the cycle. They remain diagnostic only.
+
+## Modality-safe Error Memory
+
+Error Memory now distinguishes task feedback from independent evidence of a recurring learner pattern.
+
+For Nếp speaking actions (`retrieve`, `produce`, `repair`, `transfer`, `retry`), an independent Error Memory observation requires:
+
+```text
+response_modality = speech
+```
+
+A typed fallback may still receive deterministic target-language feedback, but it cannot:
+
+- create a recurring speaking error;
+- satisfy a speaking remediation;
+- repair a recurring speaking error.
+
+For Nếp comprehension, the independent modality is `choice`.
+
+Legacy attempts with no `actionKind` keep the previous behavior so historical rows are not silently discarded.
+
+## Planner terms
+
+Session Planner keeps the existing binary repair term:
+
+```text
+errorRepairPressure * 0.65
+```
+
+and adds a separate binary re-probe term:
+
+```text
+errorReprobePressure * 0.60
+```
+
+Both weights are V1 product-policy heuristics. They are not calibrated probabilities, research optima, or efficacy claims.
+
+Multiple matching errors may be included in explainability reasons, but each pressure stays bounded at `1`.
+
+## Hard gates remain authoritative
+
+Neither remediation nor re-probe pressure can bypass:
+
+- prerequisite readiness;
+- transfer needing prior production;
+- retention needing prior evidence;
+- per-target session cap.
+
+Eligibility is checked before scoring.
+
+## Read boundary
+
+Error Memory's data-minimized projection now needs these additional non-content fields:
+
+- `response_modality`;
+- `actionKind` derived from metadata;
+- `reveal_used`.
+
+It still reads only derived `errorSignals.errorTags` and `errorSignals.remediationHints`, and never selects raw `response_text` or the full metadata object.
+
+## V1 state machine
+
+```text
+ONE INDEPENDENT FAILURE
+  observed
+
+SECOND INDEPENDENT FAILURE
+  recurring + remediationSatisfiedAt=null
+        |
+        v
+REMEDIATION SUCCESS
+  recurring + remediationSatisfiedAt=<time>
+        |
+        v
+SOURCE RE-PROBE
+   | success                  | failure
+   v                          v
+ repaired          recurring + remediationSatisfiedAt=null
+```
+
+## Non-goals
+
+V1 does not claim:
+
+- that one remediation success guarantees transfer;
+- that the remediation mapping is optimal;
+- that a recurring target-coverage error is a psychological misconception;
+- that typed fallback measures speaking ability;
+- that the current ranking weights are calibrated.
+
+A future efficacy loop should measure whether remediation followed by independent source re-probe reduces recurrence and improves delayed transfer/retention.

--- a/src/__tests__/error-memory.test.ts
+++ b/src/__tests__/error-memory.test.ts
@@ -13,11 +13,13 @@ function row(overrides: Partial<ErrorMemoryAttemptRow> = {}): ErrorMemoryAttempt
     capability_id: "CAP-002",
     knowledge_item_id: null,
     correct: false,
+    response_modality: "speech",
     support_level: 0,
     reveal_used: false,
     lesson_id: "nep-first-meeting-v1",
     lesson_version: "1.0.0",
     action_id: "transfer",
+    action_kind: "transfer",
     observed_response: true,
     error_tags: ["partial-target-coverage", "missing-target-group:1"],
     remediation_hints: [{
@@ -37,6 +39,7 @@ describe("Error Memory V1", () => {
     expect(memory.entries[0]).toMatchObject({
       errorTag: "missing-target-group:1",
       remediationCandidateIds: ["nep-first-meeting-v1:produce"],
+      remediationSatisfiedAt: null,
       status: "observed",
       independentFailureCount: 1,
       independentFailuresSinceRepair: 1,
@@ -86,6 +89,37 @@ describe("Error Memory V1", () => {
       independentFailureCount: 1,
       supportedFailureCount: 2,
     });
+  });
+
+  it("does not let typed fallback manufacture recurring speaking errors", () => {
+    const memory = buildErrorMemory([
+      row({ response_modality: "text", created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ response_modality: "text", created_at: "2026-09-02T11:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(0);
+    expect(memory.entries[0]).toMatchObject({
+      status: "supported-only",
+      independentFailureCount: 0,
+      supportedFailureCount: 2,
+    });
+  });
+
+  it("does not let typed fallback success repair a recurring speaking error", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({
+        correct: true,
+        response_modality: "text",
+        error_tags: [],
+        remediation_hints: [],
+        created_at: "2026-09-02T12:00:00.000Z",
+      }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(1);
+    expect(memory.recurring[0]).toMatchObject({ repairedAt: null, remediationSatisfiedAt: null });
   });
 
   it("ignores no-response and broad partial-coverage tags as persistent error patterns", () => {
@@ -140,10 +174,84 @@ describe("Error Memory V1", () => {
       independentFailureCount: 2,
       independentFailuresSinceRepair: 0,
       repairedAt: "2026-09-02T12:00:00.000Z",
+      remediationSatisfiedAt: null,
     });
   });
 
-  it("requires recurrence again after repair instead of making the old pattern permanent", () => {
+  it("marks explicit remediation satisfied without pretending the source error is repaired", () => {
+    const repairHint = [{
+      errorTag: "missing-target-group:0",
+      candidateId: "nep-first-meeting-v1:repair",
+    }];
+    const sourceFailure = {
+      error_tags: ["missing-target-group:0"],
+      remediation_hints: repairHint,
+    };
+    const memory = buildErrorMemory([
+      row({ ...sourceFailure, created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ ...sourceFailure, created_at: "2026-09-02T11:00:00.000Z" }),
+      row({
+        capability_id: "CAP-003",
+        correct: true,
+        action_id: "repair",
+        action_kind: "repair",
+        error_tags: [],
+        remediation_hints: [],
+        created_at: "2026-09-02T12:00:00.000Z",
+      }),
+    ]);
+
+    expect(memory.recurring).toHaveLength(1);
+    expect(memory.recurring[0]).toMatchObject({
+      actionId: "transfer",
+      status: "recurring",
+      repairedAt: null,
+      remediationSatisfiedAt: "2026-09-02T12:00:00.000Z",
+    });
+  });
+
+  it("does not satisfy remediation from an assisted remediation success", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({
+        correct: true,
+        action_id: "produce",
+        action_kind: "produce",
+        support_level: 1,
+        error_tags: [],
+        remediation_hints: [],
+        created_at: "2026-09-02T12:00:00.000Z",
+      }),
+    ]);
+
+    expect(memory.recurring[0]?.remediationSatisfiedAt).toBeNull();
+  });
+
+  it("reopens remediation after the source re-probe fails independently", () => {
+    const memory = buildErrorMemory([
+      row({ created_at: "2026-09-02T10:00:00.000Z" }),
+      row({ created_at: "2026-09-02T11:00:00.000Z" }),
+      row({
+        correct: true,
+        action_id: "produce",
+        action_kind: "produce",
+        error_tags: [],
+        remediation_hints: [],
+        created_at: "2026-09-02T12:00:00.000Z",
+      }),
+      row({ created_at: "2026-09-02T13:00:00.000Z" }),
+    ]);
+
+    expect(memory.recurring[0]).toMatchObject({
+      status: "recurring",
+      independentFailureCount: 3,
+      independentFailuresSinceRepair: 3,
+      remediationSatisfiedAt: null,
+    });
+  });
+
+  it("requires recurrence again after direct source repair instead of making the old pattern permanent", () => {
     const memory = buildErrorMemory([
       row({ created_at: "2026-09-02T10:00:00.000Z" }),
       row({ created_at: "2026-09-02T11:00:00.000Z" }),
@@ -157,6 +265,7 @@ describe("Error Memory V1", () => {
       independentFailureCount: 3,
       independentFailuresSinceRepair: 1,
       repairedAt: null,
+      remediationSatisfiedAt: null,
     });
   });
 
@@ -164,7 +273,7 @@ describe("Error Memory V1", () => {
     const memory = buildErrorMemory([
       row({ lesson_version: "1.0.0", action_id: "transfer" }),
       row({ lesson_version: "2.0.0", action_id: "transfer", created_at: "2026-09-02T11:00:00.000Z" }),
-      row({ lesson_version: "1.0.0", action_id: "repair", created_at: "2026-09-02T12:00:00.000Z" }),
+      row({ lesson_version: "1.0.0", action_id: "repair", action_kind: "repair", created_at: "2026-09-02T12:00:00.000Z" }),
     ]);
 
     expect(memory.entries).toHaveLength(3);
@@ -181,10 +290,12 @@ describe("Error Memory V1", () => {
     expect(buildErrorMemory([...chronological].reverse())).toEqual(buildErrorMemory(chronological));
   });
 
-  it("locks the read projection to derived metadata and assisted-state fields", () => {
+  it("locks the read projection to derived metadata and observation-eligibility fields", () => {
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("error_tags:metadata->errorSignals->errorTags");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("observed_response:metadata->errorSignals->observedResponse");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("remediation_hints:metadata->errorSignals->remediationHints");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("action_kind:metadata->>actionKind");
+    expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("response_modality");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).toContain("reveal_used");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toContain("response_text");
     expect(ERROR_MEMORY_ATTEMPT_SELECT).not.toMatch(/(^|,\s*)metadata($|,)/);

--- a/src/__tests__/planner-error-repair-gates.test.ts
+++ b/src/__tests__/planner-error-repair-gates.test.ts
@@ -11,6 +11,7 @@ const recurringError: ErrorMemoryEntry = {
   actionId: "produce",
   errorTag: "missing-target-group:0",
   remediationCandidateIds: ["candidate-b"],
+  remediationSatisfiedAt: null,
   status: "recurring",
   independentFailureCount: 2,
   supportedFailureCount: 0,

--- a/src/__tests__/planner-error-reprobe-gates.test.ts
+++ b/src/__tests__/planner-error-reprobe-gates.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { ErrorMemoryEntry } from "@/lib/learning/error-memory";
+import { planSession, type PlannerCandidate } from "@/lib/learning/session-planner";
+
+const sourceCandidate: PlannerCandidate = {
+  id: "lesson-b:produce",
+  targetId: "cap-b",
+  evidenceType: "production",
+  prerequisiteTargetIds: ["cap-a"],
+  metadata: {
+    lessonId: "lesson-b",
+    lessonVersion: "1.0.0",
+    actionId: "produce",
+  },
+};
+
+const satisfiedRecurringError: ErrorMemoryEntry = {
+  key: "cap-b|lesson-b|1.0.0|produce|missing-target-group:0",
+  targetId: "cap-b",
+  lessonId: "lesson-b",
+  lessonVersion: "1.0.0",
+  actionId: "produce",
+  errorTag: "missing-target-group:0",
+  remediationCandidateIds: ["lesson-b:retrieve"],
+  remediationSatisfiedAt: "2026-09-02T12:00:00.000Z",
+  status: "recurring",
+  independentFailureCount: 2,
+  supportedFailureCount: 0,
+  independentFailuresSinceRepair: 2,
+  firstSeenAt: "2026-09-01T10:00:00.000Z",
+  lastSeenAt: "2026-09-02T10:00:00.000Z",
+  repairedAt: null,
+};
+
+describe("planner remediation re-probe hard gates", () => {
+  it("does not let source re-probe pressure bypass an unmet prerequisite", () => {
+    const result = planSession({
+      candidates: [sourceCandidate],
+      states: [],
+      sessionSize: 1,
+      now: "2026-09-03T00:00:00.000Z",
+      errorMemory: [satisfiedRecurringError],
+    });
+
+    expect(result.opportunities).toEqual([]);
+    expect(result.blocked[0]?.reasons).toContain("prerequisite-not-ready:cap-a");
+  });
+});

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -43,6 +43,7 @@ function errorMemoryEntry(overrides: Partial<ErrorMemoryEntry> = {}): ErrorMemor
     actionId: "produce",
     errorTag: "missing-target-group:0",
     remediationCandidateIds: [],
+    remediationSatisfiedAt: null,
     status,
     independentFailureCount: status === "recurring" ? 2 : 1,
     supportedFailureCount: 0,
@@ -226,6 +227,7 @@ describe("session planner v1", () => {
 
     expect(result.opportunities[0]?.candidate.id).toBe("z-candidate");
     expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(1);
+    expect(result.opportunities[0]?.breakdown.errorReprobePressure).toBe(0);
     expect(result.opportunities[0]?.reasons).toContain("recurring-error-repair:1");
   });
 
@@ -244,6 +246,7 @@ describe("session planner v1", () => {
 
       expect(result.opportunities[0]?.candidate.id).toBe("a-candidate");
       expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(0);
+      expect(result.opportunities[0]?.breakdown.errorReprobePressure).toBe(0);
     },
   );
 
@@ -259,6 +262,7 @@ describe("session planner v1", () => {
     for (const entry of mismatches) {
       const result = plan({ candidates: [target], states: [], sessionSize: 1, errorMemory: [entry] });
       expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(0);
+      expect(result.opportunities[0]?.breakdown.errorReprobePressure).toBe(0);
     }
   });
 
@@ -298,7 +302,65 @@ describe("session planner v1", () => {
     const repairOpportunity = result.opportunities.find((item) => item.candidate.id === repairId);
     const transferOpportunity = result.opportunities.find((item) => item.candidate.id === transferId);
     expect(repairOpportunity?.breakdown.errorRepairPressure).toBe(1);
+    expect(repairOpportunity?.breakdown.errorReprobePressure).toBe(0);
     expect(transferOpportunity?.breakdown.errorRepairPressure).toBe(0);
+    expect(transferOpportunity?.breakdown.errorReprobePressure).toBe(0);
+  });
+
+  it("switches from remediation pressure to source re-probe after remediation succeeds", () => {
+    const lessonId = "LESSON-CAP002-FIRST-MEETING-V1";
+    const repairId = `${lessonId}:repair`;
+    const transferId = `${lessonId}:transfer`;
+    const repair = candidate({
+      id: repairId,
+      targetId: "CAP-003",
+      evidenceType: "repair",
+      metadata: { lessonId, lessonVersion: "1", actionId: "repair" },
+    });
+    const transfer = candidate({
+      id: transferId,
+      targetId: "CAP-002",
+      evidenceType: "transfer",
+      transferValue: 1,
+      metadata: { lessonId, lessonVersion: "1", actionId: "transfer" },
+    });
+    const satisfiedError = errorMemoryEntry({
+      key: "CAP-002|LESSON-CAP002-FIRST-MEETING-V1|1|transfer|missing-target-group:0",
+      targetId: "CAP-002",
+      lessonId,
+      lessonVersion: "1",
+      actionId: "transfer",
+      remediationCandidateIds: [repairId],
+      remediationSatisfiedAt: "2026-09-02T12:00:00.000Z",
+    });
+
+    const result = plan({
+      candidates: [transfer, repair],
+      states: [state("CAP-002", { production: 0.3, evidenceCount: 1 })],
+      sessionSize: 2,
+      errorMemory: [satisfiedError],
+    });
+
+    const repairOpportunity = result.opportunities.find((item) => item.candidate.id === repairId);
+    const transferOpportunity = result.opportunities.find((item) => item.candidate.id === transferId);
+    expect(repairOpportunity?.breakdown.errorRepairPressure).toBe(0);
+    expect(repairOpportunity?.breakdown.errorReprobePressure).toBe(0);
+    expect(transferOpportunity?.breakdown.errorRepairPressure).toBe(0);
+    expect(transferOpportunity?.breakdown.errorReprobePressure).toBe(1);
+    expect(transferOpportunity?.reasons).toContain("recurring-error-reprobe:1");
+  });
+
+  it("does not leak re-probe pressure to a different source action", () => {
+    const source = plannerCandidate("lesson-b:produce", "cap-b", "lesson-b", "produce");
+    const other = plannerCandidate("lesson-b:retrieve", "cap-b", "lesson-b", "retrieve");
+    const entry = errorMemoryEntry({
+      remediationCandidateIds: ["lesson-b:retrieve"],
+      remediationSatisfiedAt: "2026-09-02T12:00:00.000Z",
+    });
+
+    const result = plan({ candidates: [source, other], states: [], sessionSize: 2, errorMemory: [entry] });
+    expect(result.opportunities.find((item) => item.candidate.id === source.id)?.breakdown.errorReprobePressure).toBe(1);
+    expect(result.opportunities.find((item) => item.candidate.id === other.id)?.breakdown.errorReprobePressure).toBe(0);
   });
 
   it("explicit remediation hints override the legacy same-action fallback", () => {
@@ -317,7 +379,7 @@ describe("session planner v1", () => {
     expect(result.opportunities.find((item) => item.candidate.id === remediation.id)?.breakdown.errorRepairPressure).toBe(1);
   });
 
-  it("keeps recurring error pressure binary even when multiple tags route to one candidate", () => {
+  it("keeps recurring repair pressure binary even when multiple tags route to one candidate", () => {
     const matchingCandidate = plannerCandidate("candidate", "cap-b", "lesson-b");
     const first = errorMemoryEntry({ remediationCandidateIds: [matchingCandidate.id] });
     const second = errorMemoryEntry({
@@ -334,5 +396,19 @@ describe("session planner v1", () => {
 
     expect(result.opportunities[0]?.breakdown.errorRepairPressure).toBe(1);
     expect(result.opportunities[0]?.reasons).toContain("recurring-error-repair:2");
+  });
+
+  it("keeps recurring re-probe pressure binary when multiple satisfied errors share one source", () => {
+    const source = plannerCandidate("lesson-b:produce", "cap-b", "lesson-b");
+    const first = errorMemoryEntry({ remediationSatisfiedAt: "2026-09-02T12:00:00.000Z" });
+    const second = errorMemoryEntry({
+      key: "cap-b|lesson-b|1.0.0|produce|incorrect-choice",
+      errorTag: "incorrect-choice",
+      remediationSatisfiedAt: "2026-09-02T12:30:00.000Z",
+    });
+
+    const result = plan({ candidates: [source], states: [], sessionSize: 1, errorMemory: [first, second] });
+    expect(result.opportunities[0]?.breakdown.errorReprobePressure).toBe(1);
+    expect(result.opportunities[0]?.reasons).toContain("recurring-error-reprobe:2");
   });
 });

--- a/src/lib/learning/error-memory.ts
+++ b/src/lib/learning/error-memory.ts
@@ -2,11 +2,13 @@ export const ERROR_MEMORY_ATTEMPT_SELECT = [
   "capability_id",
   "knowledge_item_id",
   "correct",
+  "response_modality",
   "support_level",
   "reveal_used",
   "lesson_id:metadata->>lessonId",
   "lesson_version:metadata->>lessonVersion",
   "action_id:metadata->>actionId",
+  "action_kind:metadata->>actionKind",
   "observed_response:metadata->errorSignals->observedResponse",
   "error_tags:metadata->errorSignals->errorTags",
   "remediation_hints:metadata->errorSignals->remediationHints",
@@ -17,11 +19,13 @@ export type ErrorMemoryAttemptRow = {
   capability_id: string | null;
   knowledge_item_id: string | null;
   correct: boolean | null;
+  response_modality: string | null;
   support_level: number;
   reveal_used: boolean;
   lesson_id: string | null;
   lesson_version: string | null;
   action_id: string | null;
+  action_kind: string | null;
   observed_response: unknown;
   error_tags: unknown;
   remediation_hints: unknown;
@@ -39,6 +43,7 @@ export type ErrorMemoryEntry = {
   actionId: string;
   errorTag: ActionableErrorTag;
   remediationCandidateIds: string[];
+  remediationSatisfiedAt: string | null;
   status: ErrorMemoryStatus;
   independentFailureCount: number;
   supportedFailureCount: number;
@@ -59,8 +64,10 @@ type MutableEntry = ErrorMemoryEntry;
 
 /**
  * Error Memory V1 turns repeated, independent task-coverage failures into a temporary pattern.
- * One failure is only an observation. Assisted failures (support or answer reveal) do not promote
- * recurrence. A later independent success on the same versioned action repairs all active tags.
+ * One failure is only an observation. Assisted/ineligible-modality attempts do not promote
+ * recurrence. A later independent success on the same versioned action repairs active tags.
+ * A successful explicit remediation candidate satisfies repair pressure until the source is
+ * re-probed; it does not itself prove the original source task repaired.
  */
 export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnapshot {
   const entries = new Map<string, MutableEntry>();
@@ -78,10 +85,14 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
     if (!targetId || !lessonId || !lessonVersion || !actionId) continue;
 
     const observedResponse = row.observed_response === true;
-    const assisted = (Number.isFinite(row.support_level) && row.support_level > 0) || row.reveal_used === true;
+    const supportOrReveal = (Number.isFinite(row.support_level) && row.support_level > 0) || row.reveal_used === true;
+    const modalityEligible = isIndependentModality(row);
+    const independent = observedResponse && !supportOrReveal && modalityEligible;
+    const diagnosticOnly = observedResponse && !independent;
 
-    if (row.correct === true && observedResponse && !assisted) {
+    if (row.correct === true && independent) {
       repairActionEntries(entries, targetId, lessonId, lessonVersion, actionId, row.created_at);
+      satisfyRemediationEntries(entries, candidateIdForAttempt(lessonId, actionId), row.created_at);
       continue;
     }
 
@@ -100,10 +111,11 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
           actionId,
           errorTag,
           remediationCandidateIds,
-          status: assisted ? "supported-only" : "observed",
-          independentFailureCount: assisted ? 0 : 1,
-          supportedFailureCount: assisted ? 1 : 0,
-          independentFailuresSinceRepair: assisted ? 0 : 1,
+          remediationSatisfiedAt: null,
+          status: diagnosticOnly ? "supported-only" : "observed",
+          independentFailureCount: diagnosticOnly ? 0 : 1,
+          supportedFailureCount: diagnosticOnly ? 1 : 0,
+          independentFailuresSinceRepair: diagnosticOnly ? 0 : 1,
           firstSeenAt: row.created_at,
           lastSeenAt: row.created_at,
           repairedAt: null,
@@ -116,12 +128,15 @@ export function buildErrorMemory(rows: ErrorMemoryAttemptRow[]): ErrorMemorySnap
         existing.remediationCandidateIds,
         remediationCandidateIds,
       );
-      if (assisted) {
+      if (diagnosticOnly) {
         existing.supportedFailureCount += 1;
       } else {
         existing.independentFailureCount += 1;
         existing.independentFailuresSinceRepair += 1;
         existing.repairedAt = null;
+        // A new independent source failure is the re-probe result. Any prior remediation success
+        // has been tested and failed to eliminate this source error, so remediation must reopen.
+        existing.remediationSatisfiedAt = null;
       }
       existing.status = statusFor(existing);
     }
@@ -194,7 +209,20 @@ function repairActionEntries(
     if (entry.independentFailureCount === 0) continue;
     entry.independentFailuresSinceRepair = 0;
     entry.repairedAt = repairedAt;
+    entry.remediationSatisfiedAt = null;
     entry.status = "repaired";
+  }
+}
+
+function satisfyRemediationEntries(
+  entries: Map<string, MutableEntry>,
+  successfulCandidateId: string,
+  occurredAt: string,
+) {
+  for (const entry of entries.values()) {
+    if (entry.status !== "recurring") continue;
+    if (!entry.remediationCandidateIds.includes(successfulCandidateId)) continue;
+    entry.remediationSatisfiedAt = occurredAt;
   }
 }
 
@@ -203,6 +231,19 @@ function statusFor(entry: ErrorMemoryEntry): ErrorMemoryStatus {
   if (entry.independentFailuresSinceRepair >= 2) return "recurring";
   if (entry.independentFailuresSinceRepair === 1) return "observed";
   return "supported-only";
+}
+
+function isIndependentModality(row: ErrorMemoryAttemptRow) {
+  const actionKind = nonEmpty(row.action_kind);
+  if (!actionKind) return true;
+
+  if (["retrieve", "produce", "repair", "transfer", "retry"].includes(actionKind)) {
+    return row.response_modality === "speech";
+  }
+  if (actionKind === "comprehend") {
+    return row.response_modality === "choice";
+  }
+  return true;
 }
 
 function memoryKey(
@@ -215,12 +256,18 @@ function memoryKey(
   return [targetId, lessonId, lessonVersion, actionId, errorTag].join("|");
 }
 
+function candidateIdForAttempt(lessonId: string, actionId: string) {
+  return `${lessonId}:${actionId}`;
+}
+
 function rowIdentity(row: ErrorMemoryAttemptRow) {
   return [
     row.capability_id ?? row.knowledge_item_id ?? "",
     row.lesson_id ?? "",
     row.lesson_version ?? "",
     row.action_id ?? "",
+    row.action_kind ?? "",
+    row.response_modality ?? "",
     String(row.correct),
     String(row.support_level),
     String(row.reveal_used),

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -20,6 +20,7 @@ export type SessionPlannerConfig = {
   recentCandidatePenalty: number;
   inSessionRepeatPenalty: number;
   recurringErrorRepairWeight: number;
+  recurringErrorReprobeWeight: number;
 };
 
 export type SessionPlannerInput = {
@@ -40,6 +41,7 @@ export type PlannerScoreBreakdown = {
   importance: number;
   transferValue: number;
   errorRepairPressure: number;
+  errorReprobePressure: number;
   recentTargetPenalty: number;
   recentCandidatePenalty: number;
   inSessionRepeatPenalty: number;
@@ -72,6 +74,7 @@ export const DEFAULT_SESSION_PLANNER_CONFIG: SessionPlannerConfig = {
   recentCandidatePenalty: 0.75,
   inSessionRepeatPenalty: 0.8,
   recurringErrorRepairWeight: 0.65,
+  recurringErrorReprobeWeight: 0.6,
 };
 
 const COLD_START_BONUS: Record<EvidenceType, number> = {
@@ -205,7 +208,9 @@ function scoreCandidate(input: {
   const importance = clamp01(candidate.importance ?? 0.5);
   const transferValue = clamp01(candidate.transferValue ?? 0);
   const recurringErrorCount = matchingRecurringErrorCount(candidate, errorMemory);
+  const recurringReprobeCount = matchingRecurringReprobeCount(candidate, errorMemory);
   const errorRepairPressure = recurringErrorCount > 0 ? 1 : 0;
+  const errorReprobePressure = recurringReprobeCount > 0 ? 1 : 0;
   const recentTargetPenalty = countMatches(recentTargetIds, candidate.targetId) * config.recentTargetPenalty;
   const recentCandidatePenalty = countMatches(recentCandidateIds, candidate.id) * config.recentCandidatePenalty;
   const inSessionRepeatPenalty = selectedForTarget * config.inSessionRepeatPenalty;
@@ -217,6 +222,7 @@ function scoreCandidate(input: {
     + importance * 0.45
     + transferValue * 0.25
     + errorRepairPressure * config.recurringErrorRepairWeight
+    + errorReprobePressure * config.recurringErrorReprobeWeight
     - recentTargetPenalty
     - recentCandidatePenalty
     - inSessionRepeatPenalty;
@@ -229,6 +235,7 @@ function scoreCandidate(input: {
   if (staleness > 0) reasons.push(`staleness:${round(staleness)}`);
   if (transferValue > 0) reasons.push(`transfer-value:${round(transferValue)}`);
   if (errorRepairPressure > 0) reasons.push(`recurring-error-repair:${recurringErrorCount}`);
+  if (errorReprobePressure > 0) reasons.push(`recurring-error-reprobe:${recurringReprobeCount}`);
   if (recentTargetPenalty > 0 || recentCandidatePenalty > 0) reasons.push("recent-practice-penalty");
   if (inSessionRepeatPenalty > 0) reasons.push("in-session-diversity-penalty");
 
@@ -242,6 +249,7 @@ function scoreCandidate(input: {
       importance,
       transferValue,
       errorRepairPressure,
+      errorReprobePressure,
       recentTargetPenalty,
       recentCandidatePenalty,
       inSessionRepeatPenalty,
@@ -252,10 +260,9 @@ function scoreCandidate(input: {
 }
 
 /**
- * Explicit remediation hints override same-action fallback. This allows a recurring transfer
- * failure such as "missing repair move" to pressure the dedicated repair candidate (even when it
- * targets a different embedded capability) without teaching the generic planner what group 0 means.
- * Older error-memory rows without hints keep the previous same-action behavior for compatibility.
+ * Explicit remediation hints override same-action fallback. Repair pressure stays active only until
+ * an independent successful attempt on one of the declared remediation candidates has occurred.
+ * At that point the source task receives re-probe pressure instead.
  */
 function matchingRecurringErrorCount(candidate: PlannerCandidate, entries: ErrorMemoryEntry[]) {
   const lessonId = metadataString(candidate.metadata, "lessonId");
@@ -263,7 +270,7 @@ function matchingRecurringErrorCount(candidate: PlannerCandidate, entries: Error
   const actionId = metadataString(candidate.metadata, "actionId");
 
   return entries.reduce((count, entry) => {
-    if (entry.status !== "recurring") return count;
+    if (entry.status !== "recurring" || entry.remediationSatisfiedAt) return count;
 
     if (entry.remediationCandidateIds.length > 0) {
       return count + (entry.remediationCandidateIds.includes(candidate.id) ? 1 : 0);
@@ -275,6 +282,23 @@ function matchingRecurringErrorCount(candidate: PlannerCandidate, entries: Error
       && entry.lessonVersion === lessonVersion
       && entry.actionId === actionId;
     return count + (legacySameActionMatch ? 1 : 0);
+  }, 0);
+}
+
+function matchingRecurringReprobeCount(candidate: PlannerCandidate, entries: ErrorMemoryEntry[]) {
+  const lessonId = metadataString(candidate.metadata, "lessonId");
+  const lessonVersion = metadataString(candidate.metadata, "lessonVersion");
+  const actionId = metadataString(candidate.metadata, "actionId");
+  if (!lessonId || !lessonVersion || !actionId) return 0;
+
+  return entries.reduce((count, entry) => {
+    const matchesSource = entry.status === "recurring"
+      && entry.remediationSatisfiedAt !== null
+      && entry.targetId === candidate.targetId
+      && entry.lessonId === lessonId
+      && entry.lessonVersion === lessonVersion
+      && entry.actionId === actionId;
+    return count + (matchesSource ? 1 : 0);
   }, 0);
 }
 


### PR DESCRIPTION
## Why
Explicit remediation routing can otherwise loop forever: a recurring source error schedules a narrow remediation, remediation succeeds, but the source error remains recurring so the planner keeps drilling the remediation. This slice adds a conservative remediation → source re-probe cycle.

## Stack
- Base: `agent/explicit-error-remediation-v1` / PR #73
- Head: `agent/remediation-reprobe-v1`
- No database migration.
- No learner-facing route integration.

## Error Memory state
Recurring entries now expose `remediationSatisfiedAt`.

An independent success on an explicitly declared remediation candidate:
- sets `remediationSatisfiedAt` on matching recurring source errors;
- does **not** call the source error repaired;
- turns the next adaptive step into a source-task re-probe.

An independent source re-probe success uses existing direct repair semantics. A failed independent source re-probe clears remediation satisfaction and reopens remediation pressure.

## Modality-safe recurrence
This slice also closes a related evidence bug. Error Memory now reads `response_modality` and derived `actionKind`.

For Nếp speaking actions, only `speech` attempts can independently create, satisfy, or repair a recurring speaking pattern. Typed fallback remains diagnostic only. Comprehension uses `choice`. Support/reveal-assisted attempts remain diagnostic only.

Legacy rows with no actionKind retain prior behavior for compatibility.

## Planner
Adds a separate bounded `errorReprobePressure` term.

Default V1 weights:
```text
errorRepairPressure  * 0.65
errorReprobePressure * 0.60
```

Both are product-policy heuristics, not calibrated probabilities.

Planner behavior becomes:
```text
recurring source error
 -> remediation pressure
 -> independent remediation success
 -> source re-probe pressure
 -> source success: repaired
 -> source failure: remediation reopens
```

Both pressures remain binary and cannot bypass prerequisite, transfer, retention, or per-target session gates.

## Privacy
Error Memory's read projection adds only `response_modality` and derived `actionKind`; raw `response_text` and full metadata remain excluded.

## Tests
Adds/extends regressions for:
- typed fallback cannot create recurring speaking error;
- typed fallback success cannot repair speaking recurrence;
- remediation success sets satisfaction without falsely repairing source;
- assisted remediation success does not satisfy;
- failed source re-probe reopens remediation;
- direct source success still repairs;
- remediation pressure switches off after satisfaction;
- exact source gets re-probe pressure;
- re-probe pressure does not leak across actions;
- repair and re-probe pressures remain binary;
- re-probe pressure cannot bypass hard gates;
- read projection remains privacy-safe.

## Verification
Temporary draft PR #76 ran the full repository `Verify` workflow against `main` for head `75614a48dea22ec90b7c941f8751ecfad37dc7e8`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #76 was closed without merge after verification. PR #75 is mergeable and remains draft.

See `docs/nep/REMEDIATION_REPROBE_V1.md`.