### PR TITLE
Add trusted planned practice execution V1

### DIFF
--- a/docs/nep/PLANNED_PRACTICE_EXECUTION_V1.md
+++ b/docs/nep/PLANNED_PRACTICE_EXECUTION_V1.md
@@ -1,0 +1,132 @@
+# Planned Practice Execution V1
+
+## Problem
+
+Session Planner can rank a canonical practice candidate, but ranking alone is not a trustworthy execution boundary.
+
+Before this slice the preview did this in the browser:
+
+```text
+learner response
+ -> client evaluator
+ -> client builds correct/target/evidence/remediation metadata
+ -> generic server write action
+```
+
+That made the client authoritative for fields that belong to the learning core. A modified client could submit a structurally valid learning event with caller-chosen correctness, evidence type, target, evaluator or derived error metadata.
+
+## V1 trust boundary
+
+The execution path is now:
+
+```text
+learner response + canonical lesson/action identity
+ -> server resolves versioned canonical action
+ -> server deterministic evaluator
+ -> server canonical Attempt/Evidence adapter
+ -> domain evidence policy
+ -> database RPC
+```
+
+The browser can submit only observed interaction data:
+
+- lesson id;
+- lesson version;
+- action id;
+- response;
+- response source (`speech` / `text` / null);
+- support-used flag;
+- response latency.
+
+The submission schema strips unknown fields. Caller-supplied values such as `correct`, `capabilityId`, `evidenceType`, `evaluator` or remediation hints do not enter the canonical compiler.
+
+## What the server recomputes
+
+From the canonical lesson/action contract the server derives:
+
+- deterministic success/failure;
+- target capability;
+- evidence type;
+- evaluator identity;
+- context id;
+- retry/reveal semantics;
+- structured error signals;
+- explicit remediation hints;
+- attempt/evidence metadata.
+
+PostgreSQL remains authoritative for persisted-history invariants such as changed-context transfer.
+
+## Public preview
+
+Public preview still works without authentication.
+
+The server evaluates the canonical task first. If there is no authenticated user it returns feedback with:
+
+```text
+persisted = false
+persistence = local-only
+```
+
+No learning attempt/evidence is written.
+
+For an authenticated learner, the same canonical compiled record goes through the database persistence path.
+
+## Raw response boundary
+
+The raw learner response is sent to the application server because server-side deterministic evaluation needs the response itself.
+
+Application code does not place that raw response in the attempt record and does not pass it to the persistence RPC:
+
+```text
+attempt.responseText = null
+rawResponsePersisted = false
+```
+
+This is a database/application persistence guarantee, not a claim about lower-level network or hosting infrastructure logs outside this application contract.
+
+## Safe planned-practice envelope
+
+`resolveNếpPlannedPractice(candidateId)` converts a planner candidate into a learner-facing DTO containing only presentation identity/content needed to perform the task:
+
+- candidate id;
+- lesson/action identity;
+- action kind/modality;
+- title/instruction;
+- prompt;
+- optional support text;
+- changed-context flag.
+
+It deliberately excludes:
+
+- target signals;
+- required target groups;
+- target capability;
+- evidence type;
+- evaluator identity;
+- remediation rules.
+
+Attempt-only retry is not a planner candidate and cannot be resolved through this surface.
+
+## Planner read boundary
+
+Authenticated `getNếpSessionPlan()` now returns:
+
+- internal explainable `plan` data;
+- ordered learner-safe `practices` envelopes compiled from selected opportunities;
+- diagnostics.
+
+The future learner-facing adaptive route should consume `practices`, not reconstruct tasks from raw planner metadata.
+
+## Remaining limits
+
+V1 does not provide cryptographic attestation that a caller marked `responseSource="speech"` only after genuine microphone use. Browser speech APIs do not provide that attestation. The system should therefore treat speech source as application-observed interaction metadata, not anti-cheat proof.
+
+V1 also does not yet:
+
+- replace the full fixed mission UI with the adaptive `practices` sequence;
+- persist a signed plan/session token;
+- guarantee idempotency across duplicate direct server-action submissions;
+- expose comprehension distractor choices through the practice envelope;
+- execute multi-step pedagogic scaffolding around every selected candidate.
+
+Those are separate execution/product layers. This slice first removes caller authority over learning truth.

--- a/src/app/actions/learning-evidence.ts
+++ b/src/app/actions/learning-evidence.ts
@@ -2,8 +2,13 @@
 
 import { headers } from "next/headers";
 
-import { materializeEvidence, type EvidenceEvent } from "@/lib/learning/evidence";
+import {
+  materializeEvidence,
+  type EvidenceEvent,
+  type EvidenceType,
+} from "@/lib/learning/evidence";
 import type { RecordLearningAttemptInput } from "@/lib/learning/validation";
+import type { NếpEvaluationResult } from "@/lib/nep/evaluator";
 import {
   compileCanonicalNếpPracticeAttempt,
   NếpPracticeSubmissionSchema,
@@ -18,6 +23,36 @@ type RpcError = { message: string } | null;
 type RpcClient = {
   rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: RpcError }>;
 };
+
+export type RecordNếpPracticeAttemptResult =
+  | {
+      success: false;
+      error: string;
+      evaluation?: NếpEvaluationResult;
+      feedback?: string;
+    }
+  | {
+      success: true;
+      persisted: false;
+      persistence: "local-only";
+      attemptId: null;
+      evaluation: NếpEvaluationResult;
+      feedback: string;
+      evidenceRecorded: false;
+      evidenceType: null;
+      evidenceRejection: null;
+    }
+  | {
+      success: true;
+      persisted: true;
+      persistence: "database";
+      attemptId: string | null;
+      evaluation: NếpEvaluationResult;
+      feedback: string;
+      evidenceRecorded: boolean;
+      evidenceType: EvidenceType | null;
+      evidenceRejection: string | null;
+    };
 
 function rpcArgs(
   attempt: RecordLearningAttemptInput["attempt"],
@@ -61,7 +96,9 @@ function isTransferPolicyRejection(message: string): boolean {
  * evaluator, reveal semantics and remediation metadata. Raw learner response is used transiently
  * for deterministic evaluation and is never passed to the persistence RPC.
  */
-export async function recordNếpPracticeAttempt(input: NếpPracticeSubmission) {
+export async function recordNếpPracticeAttempt(
+  input: NếpPracticeSubmission,
+): Promise<RecordNếpPracticeAttemptResult> {
   try {
     const reqHeaders = await headers();
     const ip = reqHeaders.get("x-forwarded-for")?.split(",")[0].trim() || "127.0.0.1";
@@ -100,7 +137,8 @@ export async function recordNếpPracticeAttempt(input: NếpPracticeSubmission)
       return {
         success: true,
         persisted: false,
-        persistence: "local-only" as const,
+        persistence: "local-only",
+        attemptId: null,
         evaluation,
         feedback,
         evidenceRecorded: false,
@@ -137,7 +175,7 @@ export async function recordNếpPracticeAttempt(input: NếpPracticeSubmission)
     return {
       success: true,
       persisted: true,
-      persistence: "database" as const,
+      persistence: "database",
       attemptId: typeof data === "string" ? data : null,
       evaluation,
       feedback,

--- a/src/app/actions/learning-evidence.ts
+++ b/src/app/actions/learning-evidence.ts
@@ -3,10 +3,12 @@
 import { headers } from "next/headers";
 
 import { materializeEvidence, type EvidenceEvent } from "@/lib/learning/evidence";
+import type { RecordLearningAttemptInput } from "@/lib/learning/validation";
 import {
-  RecordLearningAttemptSchema,
-  type RecordLearningAttemptInput,
-} from "@/lib/learning/validation";
+  compileCanonicalNếpPracticeAttempt,
+  NếpPracticeSubmissionSchema,
+  type NếpPracticeSubmission,
+} from "@/lib/nep/practice-execution.v1";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
 
@@ -19,7 +21,7 @@ type RpcClient = {
 
 function rpcArgs(
   attempt: RecordLearningAttemptInput["attempt"],
-  evidence: EvidenceEvent | null
+  evidence: EvidenceEvent | null,
 ): Record<string, unknown> {
   return {
     p_knowledge_item_id: attempt.knowledgeItemId ?? null,
@@ -47,15 +49,19 @@ function rpcArgs(
 }
 
 function isTransferPolicyRejection(message: string): boolean {
-  return message.includes("Transfer requires") || message.includes("Evidence context must match attempted context");
+  return message.includes("Transfer requires")
+    || message.includes("Evidence context must match attempted context");
 }
 
 /**
- * Canonical write path for the new learning core.
- * UI records what happened; domain policy decides which evidence is structurally eligible;
- * PostgreSQL is authoritative for persisted-history invariants such as changed-context transfer.
+ * Trusted Nếp execution boundary.
+ *
+ * The browser sends only observed interaction data plus canonical action identity. The server
+ * resolves the versioned lesson/action and recomputes correctness, target, evidence type,
+ * evaluator, reveal semantics and remediation metadata. Raw learner response is used transiently
+ * for deterministic evaluation and is never passed to the persistence RPC.
  */
-export async function recordLearningAttempt(input: RecordLearningAttemptInput) {
+export async function recordNếpPracticeAttempt(input: NếpPracticeSubmission) {
   try {
     const reqHeaders = await headers();
     const ip = reqHeaders.get("x-forwarded-for")?.split(",")[0].trim() || "127.0.0.1";
@@ -64,20 +70,26 @@ export async function recordLearningAttempt(input: RecordLearningAttemptInput) {
       return { success: false, error: "Yêu cầu quá thường xuyên. Vui lòng thử lại sau." };
     }
 
-    const parsed = RecordLearningAttemptSchema.safeParse(input);
+    const parsed = NếpPracticeSubmissionSchema.safeParse(input);
     if (!parsed.success) {
       return {
         success: false,
-        error: `Dữ liệu attempt không hợp lệ: ${parsed.error.issues.map((issue) => issue.message).join(", ")}`,
+        error: `Dữ liệu practice không hợp lệ: ${parsed.error.issues.map((issue) => issue.message).join(", ")}`,
       };
     }
 
-    const { attempt, candidate } = parsed.data;
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed.data);
+    if (!compiled) {
+      return { success: false, error: "Lesson/action không tồn tại trong canonical Nếp contract." };
+    }
+
+    const { record, evaluation, feedback } = compiled;
+    const { attempt, candidate } = record;
     const evidence = candidate
       ? materializeEvidence({
           attempt,
           candidate,
-          // Transfer depends on persisted history, not a caller-provided previous context.
+          // Transfer depends on persisted history, not caller-provided previous context.
           deferTransferContextCheck: candidate.type === "transfer",
         })
       : null;
@@ -85,7 +97,16 @@ export async function recordLearningAttempt(input: RecordLearningAttemptInput) {
     const supabase = await createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
-      return { success: false, error: "Bạn cần đăng nhập để ghi nhận tiến trình học." };
+      return {
+        success: true,
+        persisted: false,
+        persistence: "local-only" as const,
+        evaluation,
+        feedback,
+        evidenceRecorded: false,
+        evidenceType: null,
+        evidenceRejection: null,
+      };
     }
 
     const rpcClient = supabase as unknown as RpcClient;
@@ -95,7 +116,7 @@ export async function recordLearningAttempt(input: RecordLearningAttemptInput) {
 
     // A changed-context decision depends on persisted history and can lose a race between
     // concurrent requests. Preserve the immutable attempt even when the DB correctly rejects
-    // only the transfer evidence. Infrastructure/permission errors are never downgraded.
+    // only transfer evidence. Infrastructure/permission errors are never downgraded.
     if (error && evidence?.type === "transfer" && isTransferPolicyRejection(error.message)) {
       evidenceRejection = error.message;
       const retry = await rpcClient.rpc("record_learning_attempt", rpcArgs(attempt, null));
@@ -105,12 +126,21 @@ export async function recordLearningAttempt(input: RecordLearningAttemptInput) {
     }
 
     if (error) {
-      return { success: false, error: `Không thể lưu learning event: ${error.message}` };
+      return {
+        success: false,
+        error: `Không thể lưu learning event: ${error.message}`,
+        evaluation,
+        feedback,
+      };
     }
 
     return {
       success: true,
+      persisted: true,
+      persistence: "database" as const,
       attemptId: typeof data === "string" ? data : null,
+      evaluation,
+      feedback,
       evidenceRecorded,
       evidenceType: evidenceRecorded ? evidence?.type ?? null : null,
       evidenceRejection,

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -18,6 +18,7 @@ import {
   type RecentLearningAttemptRow,
 } from "@/lib/learning/session-input";
 import { planSession } from "@/lib/learning/session-planner";
+import { resolveNếpPlannedPractice } from "@/lib/nep/practice-execution.v1";
 import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
@@ -46,7 +47,8 @@ export type GetNếpSessionPlanInput = {
 /**
  * Read-only authenticated boundary for Session Planner V1.
  * It deliberately selects no raw response/transcript content and does not mutate learner state.
- * This action is not yet wired to the learner-facing route.
+ * Alongside diagnostic planner data it returns learner-safe practice envelopes whose hidden
+ * evaluator targets/evidence metadata have been stripped by the canonical execution compiler.
  */
 export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) {
   try {
@@ -121,19 +123,26 @@ export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) 
       recentCandidateIds: recentHistory.recentCandidateIds,
       errorMemory: errorMemory.entries,
     });
+    const practices = plan.opportunities.flatMap((opportunity) => {
+      const practice = resolveNếpPlannedPractice(opportunity.candidate.id);
+      return practice ? [practice] : [];
+    });
 
     return {
       success: true,
       plan,
+      practices,
       diagnostics: {
         sessionSize,
         catalogSize: nepSessionCatalogV1.length,
+        practiceEnvelopeCount: practices.length,
         stateCount: states.length,
         recentAttemptCount: recentAttemptResult.data?.length ?? 0,
         errorMemoryAttemptCount: errorMemoryResult.data?.length ?? 0,
         recurringErrorCount: errorMemory.recurring.length,
         rawResponseSelected: false,
         fullMetadataSelected: false,
+        hiddenEvaluatorTargetsExposedInPractices: false,
       },
     };
   } catch (error) {

--- a/src/features/data-driven-preview/DataDrivenPreview.tsx
+++ b/src/features/data-driven-preview/DataDrivenPreview.tsx
@@ -3,11 +3,9 @@
 import { ArrowLeft, ArrowRight, CircleAlert, Headphones, Mic2, RefreshCw, ShieldCheck, Sparkles, Target, Volume2 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
-import { recordLearningAttempt } from "@/app/actions/learning-evidence";
+import { recordNếpPracticeAttempt } from "@/app/actions/learning-evidence";
 import { capabilityGraphV1 } from "@/lib/nep/capabilities.v1";
-import { evaluateNếpAction, feedbackForNếpEvaluation, type NếpEvaluationResult } from "@/lib/nep/evaluator";
 import { firstMeetingLessonV1, qaLesson } from "@/lib/nep/lesson-contract";
-import { toLearningAttemptRecord } from "@/lib/nep/learning-evidence-adapter";
 
 type EvidenceKey = "comprehension" | "retrieval" | "production" | "repair" | "transfer";
 type EvidenceState = Record<EvidenceKey, boolean>;
@@ -49,10 +47,10 @@ function evidenceKeyForAction(kind: string): EvidenceKey | null {
 }
 
 function persistenceLabel(state: PersistenceState) {
-  if (state === "saving") return "Đang lưu learning event…";
+  if (state === "saving") return "Đang đánh giá và lưu learning event…";
   if (state === "evidence-saved") return "Attempt + evidence đã được lưu vào learner model.";
   if (state === "attempt-saved") return "Attempt đã được lưu; lần này không tạo mastery evidence.";
-  if (state === "local-only") return "Preview công khai: kết quả đang chỉ giữ trong phiên này.";
+  if (state === "local-only") return "Preview công khai: server đã đánh giá, nhưng kết quả không được persist.";
   if (state === "error") return "Flow vẫn tiếp tục, nhưng learning event chưa lưu được.";
   return null;
 }
@@ -130,77 +128,84 @@ export function DataDrivenPreview() {
     recognition.start();
   };
 
-  const persistEvaluation = async (evaluation: NếpEvaluationResult) => {
-    const submissionKey = `${action.id}|${answerSource ?? "none"}|support:${supportUsed ? 1 : 0}|${answer.trim()}`;
+  const evaluate = async () => {
+    if (saving || !action.assessment) return;
+
+    const submissionKey = `${lesson.id}|${lesson.version}|${action.id}|${answerSource ?? "none"}|support:${supportUsed ? 1 : 0}|${answer.trim()}`;
     if (lastSubmissionKey.current === submissionKey) return;
 
     const now = Date.now();
     const latencyMs = attemptStartedAt.current === null ? 0 : now - attemptStartedAt.current;
-    const record = toLearningAttemptRecord({
-      lesson,
-      action,
+    lastSubmissionKey.current = submissionKey;
+    setPersistenceState("saving");
+
+    const result = await recordNếpPracticeAttempt({
+      lessonId: lesson.id,
+      lessonVersion: lesson.version,
+      actionId: action.id,
       response: answer,
       responseSource: answerSource,
-      evaluation,
       supportUsed,
       latencyMs,
     });
-    if (!record) return;
 
-    lastSubmissionKey.current = submissionKey;
-    setPersistenceState("saving");
-    const result = await recordLearningAttempt(record);
-    if (result.success) {
-      setPersistenceState(result.evidenceRecorded ? "evidence-saved" : "attempt-saved");
+    if (!result.success) {
+      lastSubmissionKey.current = null;
+      setPersistenceState("error");
+      if ("feedback" in result && typeof result.feedback === "string") {
+        setFeedback(result.feedback);
+      }
       return;
     }
-    const error = "error" in result ? result.error ?? "" : "";
-    if (error.includes("đăng nhập")) {
-      setPersistenceState("local-only");
-      return;
-    }
-    lastSubmissionKey.current = null;
-    setPersistenceState("error");
-  };
 
-  const evaluate = async () => {
-    if (saving) return;
+    setPersistenceState(
+      result.persisted
+        ? result.evidenceRecorded
+          ? "evidence-saved"
+          : "attempt-saved"
+        : "local-only",
+    );
 
-    const evaluation = evaluateNếpAction(action, answer);
-    const ok = evaluation.success;
+    const ok = result.evaluation.success;
     if (action.kind === "comprehend") {
-      setEvidence((current) => ({ ...current, comprehension: ok }));
-      setFeedback(ok ? "Đúng: Maya đang hỏi tên." : feedbackForNếpEvaluation(action, evaluation));
-      await persistEvaluation(evaluation);
+      const observedEvidence = result.persisted ? result.evidenceRecorded : ok;
+      setEvidence((current) => ({ ...current, comprehension: observedEvidence }));
+      setFeedback(ok ? "Đúng: Maya đang hỏi tên." : result.feedback);
       return;
     }
 
     const channel = evidenceKeyForAction(action.kind);
-    const observedSpeech = answerSource === "speech";
-    const canShowEvidence = channel && observedSpeech && ok && (channel !== "transfer" || evidence.production);
-
-    if (canShowEvidence && channel) {
-      setEvidence((current) => ({ ...current, [channel]: true }));
-    }
-
     if (channel && answerSource !== "speech") {
       setFeedback(
         ok
           ? "Text có đủ target language, nhưng không cộng speaking evidence vì không có oral response quan sát được."
-          : `${feedbackForNếpEvaluation(action, evaluation)} Text fallback không tạo speaking evidence.`,
+          : `${result.feedback} Text fallback không tạo speaking evidence.`,
       );
-      await persistEvaluation(evaluation);
       return;
     }
 
-    if (channel === "transfer" && ok && !evidence.production) {
-      setFeedback("Transcript đáp ứng task, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
-      await persistEvaluation(evaluation);
+    const locallyEligible = Boolean(
+      channel
+      && answerSource === "speech"
+      && ok
+      && (channel !== "transfer" || evidence.production),
+    );
+    const observedEvidence = result.persisted ? result.evidenceRecorded : locallyEligible;
+
+    if (channel && observedEvidence) {
+      setEvidence((current) => ({ ...current, [channel]: true }));
+    }
+
+    if (channel === "transfer" && ok && !observedEvidence) {
+      if (result.persisted && result.evidenceRejection) {
+        setFeedback("Transcript đáp ứng task, nhưng persisted history chưa đủ điều kiện để ghi transfer evidence.");
+      } else {
+        setFeedback("Transcript đáp ứng task, nhưng chưa có production evidence độc lập trước đó nên chưa thể gọi đây là transfer.");
+      }
       return;
     }
 
-    setFeedback(feedbackForNếpEvaluation(action, evaluation));
-    await persistEvaluation(evaluation);
+    setFeedback(result.feedback);
   };
 
   const next = () => {
@@ -289,7 +294,7 @@ export function DataDrivenPreview() {
           <div className="mt-8 flex items-center justify-between"><button type="button" onClick={() => { setStep((value) => Math.max(0, value - 1)); resetAttempt(); }} disabled={step === 0 || saving} className="rounded-full px-4 py-3 text-sm font-semibold text-black/45 disabled:opacity-20"><RefreshCw className="mr-2 inline size-3" />Quay lại</button><button type="button" onClick={next} disabled={saving} className="flex items-center gap-2 rounded-full bg-[#2d6a4f] px-6 py-3 text-sm font-semibold text-white disabled:opacity-40">{step === lesson.actions.length - 1 ? "Kết thúc slice" : "Tiếp theo"}<ArrowRight className="size-4" /></button></div>
         </section>
 
-        <footer className="pb-4 text-center text-[11px] leading-5 text-black/35"><Headphones className="mr-1 inline size-3" /> Transcript feedback ≠ pronunciation score. Raw transcript không được persist. Text fallback ≠ speaking evidence.{supportUsed && " Vietnamese support usage is tracked separately."}</footer>
+        <footer className="pb-4 text-center text-[11px] leading-5 text-black/35"><Headphones className="mr-1 inline size-3" /> Server resolves canonical task/evaluator. Transcript feedback ≠ pronunciation score. Raw transcript không được persist. Text fallback ≠ speaking evidence.{supportUsed && " Vietnamese support usage is tracked separately."}</footer>
       </div>
     </main>
   );

--- a/src/lib/nep/__tests__/practice-execution.test.ts
+++ b/src/lib/nep/__tests__/practice-execution.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { materializeEvidence } from "../../learning/evidence";
+import {
+  compileCanonicalNếpPracticeAttempt,
+  NếpPracticeSubmissionSchema,
+  resolveNếpPlannedPractice,
+} from "../practice-execution.v1";
+import { firstMeetingLessonV1 } from "../lesson-contract";
+import { plannerCandidateId } from "../remediation-map.v1";
+
+function submission(overrides: Record<string, unknown> = {}) {
+  return {
+    lessonId: firstMeetingLessonV1.id,
+    lessonVersion: firstMeetingLessonV1.version,
+    actionId: "produce",
+    response: "My name is Hoang.",
+    responseSource: "speech" as const,
+    supportUsed: false,
+    latencyMs: 900,
+    ...overrides,
+  };
+}
+
+describe("trusted Nếp practice execution V1", () => {
+  it("strips caller-supplied mastery/evidence fields from the submission contract", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({
+      correct: true,
+      capabilityId: "FAKE-CAP",
+      evidenceType: "transfer",
+      evaluator: "fake-evaluator",
+      remediationHints: [{ errorTag: "incorrect-choice", candidateId: "fake" }],
+    }));
+
+    expect(parsed).not.toHaveProperty("correct");
+    expect(parsed).not.toHaveProperty("capabilityId");
+    expect(parsed).not.toHaveProperty("evidenceType");
+    expect(parsed).not.toHaveProperty("evaluator");
+    expect(parsed).not.toHaveProperty("remediationHints");
+  });
+
+  it("recomputes target, correctness and evidence type from canonical content", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({
+      correct: false,
+      capabilityId: "FAKE-CAP",
+      evidenceType: "recognition",
+    }));
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed)!;
+
+    expect(compiled.evaluation.success).toBe(true);
+    expect(compiled.record.attempt).toMatchObject({
+      capabilityId: "CAP-002",
+      exerciseType: "nep:produce",
+      correct: true,
+      responseModality: "speech",
+      responseText: null,
+    });
+    expect(compiled.record.candidate).toMatchObject({
+      type: "production",
+      targetId: "CAP-002",
+      success: true,
+    });
+  });
+
+  it("never places the raw learner response into the persistence record", () => {
+    const raw = "My name is Hoang and this exact raw response must not persist";
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({ response: raw }));
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed)!;
+
+    expect(compiled.record.attempt.responseText).toBeNull();
+    expect(JSON.stringify(compiled.record)).not.toContain(raw);
+  });
+
+  it("keeps typed fallback out of speaking evidence even when target language is correct", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({ responseSource: "text" }));
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed)!;
+
+    expect(compiled.evaluation.success).toBe(true);
+    expect(compiled.record.attempt.responseModality).toBe("text");
+    expect(compiled.record.candidate).not.toBeNull();
+    expect(materializeEvidence({
+      attempt: compiled.record.attempt,
+      candidate: compiled.record.candidate!,
+    })).toBeNull();
+  });
+
+  it("recomputes retry reveal semantics and keeps retry attempt-only", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({
+      actionId: "retry",
+      response: "Could you say that again? My name is Hoang.",
+    }));
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed)!;
+
+    expect(compiled.record.attempt.revealUsed).toBe(true);
+    expect(compiled.record.candidate).toBeNull();
+  });
+
+  it("rejects unknown canonical lesson/action identity", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse(submission({ actionId: "fake-action" }));
+    expect(compileCanonicalNếpPracticeAttempt(parsed)).toBeNull();
+  });
+
+  it("resolves a planner candidate to a learner-safe practice envelope", () => {
+    const envelope = resolveNếpPlannedPractice(
+      plannerCandidateId(firstMeetingLessonV1.id, "transfer"),
+    );
+
+    expect(envelope).toMatchObject({
+      lessonId: firstMeetingLessonV1.id,
+      lessonVersion: 1,
+      actionId: "transfer",
+      kind: "transfer",
+      modality: "speech",
+      changedContext: true,
+    });
+    expect(envelope?.prompt).toContain("what should I call you");
+
+    const serialized = JSON.stringify(envelope);
+    expect(serialized).not.toContain("targetSignals");
+    expect(serialized).not.toContain("requiredSignalGroups");
+    expect(serialized).not.toContain("targetCapabilityId");
+    expect(serialized).not.toContain("evidenceType");
+    expect(serialized).not.toContain("evaluator");
+  });
+
+  it("does not expose attempt-only retry as a planner practice candidate", () => {
+    expect(resolveNếpPlannedPractice(
+      plannerCandidateId(firstMeetingLessonV1.id, "retry"),
+    )).toBeNull();
+  });
+});

--- a/src/lib/nep/practice-execution.v1.ts
+++ b/src/lib/nep/practice-execution.v1.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+import { evaluateNếpAction, feedbackForNếpEvaluation } from "./evaluator";
+import { firstMeetingLessonV1, type LessonAction, type LessonContract } from "./lesson-contract";
+import { toLearningAttemptRecord, type NếpResponseSource } from "./learning-evidence-adapter";
+import { nepSessionCatalogV1 } from "./session-catalog.v1";
+
+const lessonRegistryV1: LessonContract[] = [firstMeetingLessonV1];
+
+export const NếpPracticeSubmissionSchema = z.object({
+  lessonId: z.string().trim().min(1).max(160),
+  lessonVersion: z.number().int().positive(),
+  actionId: z.string().trim().min(1).max(120),
+  response: z.string().max(1200),
+  responseSource: z.enum(["speech", "text"]).nullable(),
+  supportUsed: z.boolean(),
+  latencyMs: z.number().finite().min(0).max(60 * 60 * 1000),
+});
+
+export type NếpPracticeSubmission = z.infer<typeof NếpPracticeSubmissionSchema>;
+
+export type NếpPracticeEnvelope = {
+  candidateId: string;
+  lessonId: string;
+  lessonVersion: number;
+  actionId: string;
+  kind: LessonAction["kind"];
+  modality: LessonAction["modality"];
+  title: string;
+  instruction: string;
+  prompt: string | null;
+  supportVi: string | null;
+  changedContext: boolean;
+};
+
+export function resolveNếpLesson(lessonId: string, lessonVersion: number) {
+  return lessonRegistryV1.find(
+    (lesson) => lesson.id === lessonId && lesson.version === lessonVersion,
+  ) ?? null;
+}
+
+export function resolveNếpAction(lessonId: string, lessonVersion: number, actionId: string) {
+  const lesson = resolveNếpLesson(lessonId, lessonVersion);
+  if (!lesson) return null;
+  const action = lesson.actions.find((item) => item.id === actionId) ?? null;
+  if (!action) return null;
+  return { lesson, action };
+}
+
+/**
+ * Resolve a planner candidate to a learner-safe presentation envelope.
+ * Hidden evaluator targets, expected target signals, evidence type/target and remediation rules
+ * are deliberately excluded from this DTO.
+ */
+export function resolveNếpPlannedPractice(candidateId: string): NếpPracticeEnvelope | null {
+  const candidate = nepSessionCatalogV1.find((item) => item.id === candidateId);
+  if (!candidate) return null;
+
+  const lessonId = metadataString(candidate.metadata, "lessonId");
+  const actionId = metadataString(candidate.metadata, "actionId");
+  const versionValue = candidate.metadata?.lessonVersion;
+  const lessonVersion = typeof versionValue === "number"
+    ? versionValue
+    : typeof versionValue === "string"
+      ? Number(versionValue)
+      : Number.NaN;
+  if (!lessonId || !actionId || !Number.isInteger(lessonVersion)) return null;
+
+  const resolved = resolveNếpAction(lessonId, lessonVersion, actionId);
+  if (!resolved || !resolved.action.assessment?.evidenceType) return null;
+
+  return {
+    candidateId: candidate.id,
+    lessonId: resolved.lesson.id,
+    lessonVersion: resolved.lesson.version,
+    actionId: resolved.action.id,
+    kind: resolved.action.kind,
+    modality: resolved.action.modality,
+    title: resolved.action.title,
+    instruction: resolved.action.instruction,
+    prompt: resolved.action.prompt ?? null,
+    supportVi: resolved.action.supportVi ?? null,
+    changedContext: resolved.action.changedContext ?? false,
+  };
+}
+
+/**
+ * Server-authoritative compilation of one learner response.
+ * The caller supplies only observed interaction data. Correctness, learning target, evidence type,
+ * evaluator identity, reveal semantics and remediation metadata are all recomputed from canonical
+ * content on the server.
+ */
+export function compileCanonicalNếpPracticeAttempt(input: NếpPracticeSubmission) {
+  const resolved = resolveNếpAction(input.lessonId, input.lessonVersion, input.actionId);
+  if (!resolved?.action.assessment) return null;
+
+  const evaluation = evaluateNếpAction(resolved.action, input.response);
+  const feedback = feedbackForNếpEvaluation(resolved.action, evaluation);
+  const record = toLearningAttemptRecord({
+    lesson: resolved.lesson,
+    action: resolved.action,
+    response: input.response,
+    responseSource: input.responseSource as NếpResponseSource,
+    evaluation,
+    supportUsed: input.supportUsed,
+    latencyMs: input.latencyMs,
+  });
+  if (!record) return null;
+
+  return {
+    lesson: resolved.lesson,
+    action: resolved.action,
+    evaluation,
+    feedback,
+    record,
+  };
+}
+
+function metadataString(metadata: Record<string, unknown> | undefined, key: string) {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}


### PR DESCRIPTION
## Why
Session Planner can rank practice, but the old preview still let the browser compute correctness and construct target/evidence/remediation metadata before calling a generic write action. That made the client authoritative for learning truth.

This slice moves canonical resolution, deterministic evaluation and Attempt/Evidence compilation to the server while preserving the public preview.

## Stack
- Base: `agent/remediation-reprobe-v1` / PR #75
- Head: `agent/planned-practice-execution-v1`
- No database migration.
- Fixed mission UI remains; adaptive learner-facing route is not switched on yet.

## Trusted submission contract
The browser can submit only:
- lesson id/version;
- action id;
- raw response;
- response source;
- support-used flag;
- latency.

Unknown caller fields are stripped. The client no longer supplies `correct`, target capability, evidence type, evaluator or remediation metadata.

The server resolves the versioned canonical lesson/action, runs the deterministic evaluator, runs the canonical Nếp adapter and then applies the existing learning-core/DB policies.

## Public preview
Server evaluation happens before auth persistence. Anonymous preview gets canonical feedback with `persisted=false`; authenticated learners use the same compiled record and persist it.

## Raw-response boundary
Raw response is transiently available to application-server evaluation, but the compiled attempt keeps `responseText=null` and the raw response is never passed to the persistence RPC. This is an application/DB persistence guarantee, not an infrastructure-log claim.

## Safe practice envelopes
Adds `resolveNếpPlannedPractice(candidateId)`, which exposes only learner-facing task presentation fields and deliberately omits hidden evaluator targets, target groups, capability/evidence type, evaluator identity and remediation rules.

`getNếpSessionPlan()` now returns ordered `practices` envelopes alongside internal explainable `plan` data. Future learner UI should consume `practices` rather than reconstruct tasks from planner metadata.

Attempt-only retry cannot resolve as a planner practice candidate.

## Preview integration
The current Nếp preview now calls the trusted server action. Logged-in evidence display follows persisted `evidenceRecorded`; anonymous preview keeps a local evidence visualization after server evaluation.

## Tests
Covers:
- caller-supplied correctness/target/evidence/evaluator/remediation fields are stripped;
- canonical target/correctness/evidence type are recomputed;
- raw learner response never enters persistence record;
- typed fallback still cannot create speaking evidence;
- retry reveal semantics are recomputed server-side and remain attempt-only;
- unknown lesson/action identity is rejected;
- safe practice envelope excludes hidden evaluation fields;
- retry is not exposed through planner practice surface.

## Verification
The first CI run exposed a TypeScript weakness in the server-action result union. The action now returns an explicit discriminated result contract; UI success branches always receive canonical `evaluation` + `feedback`.

Temporary draft PR #78 then ran the full repository `Verify` workflow against `main` for head `80639b6040c602d87324e1d50865386beb81ec3c`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #78 was closed without merge after verification. PR #77 is mergeable and remains draft.

See `docs/nep/PLANNED_PRACTICE_EXECUTION_V1.md`.