### PR TITLE
Close adaptive catalog cold-start gap V1

### DIFF
--- a/docs/nep/ADAPTIVE_CATALOG_BOOTSTRAP_V1.md
+++ b/docs/nep/ADAPTIVE_CATALOG_BOOTSTRAP_V1.md
@@ -1,0 +1,76 @@
+# Adaptive Catalog Bootstrap V1
+
+## Problem
+
+Session Planner V1 originally compiled only the CAP-002 first-meeting lesson. That lesson declares `CAP-001` as a prerequisite.
+
+For a learner with no persisted skill state, every catalog candidate was therefore blocked by:
+
+```text
+prerequisite-not-ready:CAP-001
+```
+
+Because the catalog contained no CAP-001 practice, the planner had no legitimate way to help a new learner satisfy that prerequisite. This was a catalog deadlock, not a scoring problem.
+
+## Decision
+
+Do not bypass prerequisite gates and do not seed fake mastery.
+
+Instead, add a real evidence-bearing CAP-001 bootstrap lesson and compile Session Planner from a canonical lesson registry.
+
+The registry now contains:
+
+```text
+CAP-001: greet and close
+CAP-002/CAP-003: first meeting + repair
+```
+
+The planner can therefore serve CAP-001 first, then unlock CAP-002 only after persisted evidence makes CAP-001 ready.
+
+## CAP-001 bootstrap
+
+The bootstrap lesson stays intentionally narrow:
+
+- recognition: identify the social job of a greeting;
+- retrieval: recall a greeting + acknowledgement from a cue;
+- production: greet, acknowledge and close aloud;
+- retention targets are published for later review.
+
+It does not claim repair or transfer evidence. `qaLesson()` is now channel-aware, so repair/retry/transfer gates are required only for lessons that actually declare those evidence channels.
+
+This does not weaken the existing CAP-002 first-meeting QA because that lesson still declares repair and transfer.
+
+## Choice presentation
+
+`LessonAction` now has optional learner-visible `choices`.
+
+The correct target remains in hidden `targetSignals`; a safe practice envelope exposes only the labels, never a correctness marker.
+
+This removes the previous fixed-preview hard-code and makes choice practice executable from adaptive planner output.
+
+## Catalog closure gate
+
+`validateNếpSessionCatalog()` statically checks:
+
+- duplicate planner candidate IDs;
+- every declared prerequisite target has at least one evidence-bearing practice candidate in the catalog.
+
+A future capability may not enter the adaptive catalog with an unreachable prerequisite without failing this gate.
+
+## Canonical registry
+
+Planner compilation and server-authoritative execution now resolve lessons from the same `nepLessonRegistryV1`.
+
+This prevents a planner candidate from referring to content that the trusted execution boundary cannot resolve.
+
+## Cold-start behavior
+
+With empty learner state, Session Planner should return eligible CAP-001 opportunities and keep CAP-002 blocked.
+
+After independent CAP-001 retrieval/production evidence raises readiness above the prerequisite floor, a subsequent plan may include CAP-002.
+
+The planner does not simulate mastery inside a session. Unlocking is based on persisted learner state, so a fresh plan is needed after evidence changes.
+
+## Non-claims
+
+This bootstrap ordering is a V1 product policy. It is not a claim that greeting/closing is universally the optimal first English capability or that the current readiness threshold is research-optimal.

--- a/src/__tests__/nep-session-catalog.test.ts
+++ b/src/__tests__/nep-session-catalog.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 
+import { firstMeetingLessonV1 } from "@/lib/nep/lesson-contract";
 import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
 
+function firstMeetingCandidates() {
+  return nepSessionCatalogV1.filter(
+    (candidate) => candidate.metadata?.lessonId === firstMeetingLessonV1.id,
+  );
+}
+
 describe("Nếp session catalog v1", () => {
-  it("compiles only evidence-bearing evaluated actions", () => {
-    expect(nepSessionCatalogV1.map((candidate) => candidate.metadata?.actionKind)).toEqual([
+  it("compiles only evidence-bearing evaluated actions for the first-meeting lesson", () => {
+    expect(firstMeetingCandidates().map((candidate) => candidate.metadata?.actionKind)).toEqual([
       "comprehend",
       "retrieve",
       "produce",
@@ -13,28 +20,44 @@ describe("Nếp session catalog v1", () => {
     ]);
   });
 
-  it("keeps repair on CAP-003 and production/transfer on CAP-002", () => {
-    const repair = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "repair");
-    const production = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "produce");
-    const transfer = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "transfer");
+  it("keeps first-meeting repair on CAP-003 and production/transfer on CAP-002", () => {
+    const candidates = firstMeetingCandidates();
+    const repair = candidates.find((candidate) => candidate.metadata?.actionKind === "repair");
+    const production = candidates.find((candidate) => candidate.metadata?.actionKind === "produce");
+    const transfer = candidates.find((candidate) => candidate.metadata?.actionKind === "transfer");
 
     expect(repair).toMatchObject({ targetId: "CAP-003", evidenceType: "repair" });
     expect(production).toMatchObject({ targetId: "CAP-002", evidenceType: "production" });
     expect(transfer).toMatchObject({ targetId: "CAP-002", evidenceType: "transfer" });
   });
 
-  it("maps comprehension to persisted recognition evidence", () => {
-    const comprehension = nepSessionCatalogV1.find((candidate) => candidate.metadata?.actionKind === "comprehend");
+  it("maps first-meeting comprehension to persisted recognition evidence", () => {
+    const comprehension = firstMeetingCandidates().find(
+      (candidate) => candidate.metadata?.actionKind === "comprehend",
+    );
     expect(comprehension).toMatchObject({ targetId: "CAP-002", evidenceType: "recognition" });
   });
 
-  it("does not schedule the supported retry as mastery evidence", () => {
+  it("does not schedule supported retry as mastery evidence in any lesson", () => {
     expect(nepSessionCatalogV1.some((candidate) => candidate.metadata?.actionKind === "retry")).toBe(false);
   });
 
-  it("preserves declared lesson prerequisites and stable evaluation context", () => {
-    for (const candidate of nepSessionCatalogV1) {
+  it("preserves first-meeting prerequisites and stable evaluation context", () => {
+    for (const candidate of firstMeetingCandidates()) {
       expect(candidate.prerequisiteTargetIds).toEqual(["CAP-001"]);
+      expect(candidate.metadata?.contextId).toBeTypeOf("string");
+      expect(candidate.metadata?.evaluator).toBeTypeOf("string");
+    }
+  });
+
+  it("keeps bootstrap candidates prerequisite-free while preserving evaluation metadata", () => {
+    const bootstrapCandidates = nepSessionCatalogV1.filter(
+      (candidate) => candidate.metadata?.lessonId !== firstMeetingLessonV1.id,
+    );
+
+    expect(bootstrapCandidates.length).toBeGreaterThan(0);
+    for (const candidate of bootstrapCandidates) {
+      expect(candidate.prerequisiteTargetIds).toEqual([]);
       expect(candidate.metadata?.contextId).toBeTypeOf("string");
       expect(candidate.metadata?.evaluator).toBeTypeOf("string");
     }

--- a/src/lib/nep/__tests__/adaptive-catalog-bootstrap.test.ts
+++ b/src/lib/nep/__tests__/adaptive-catalog-bootstrap.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { planSession } from "../../learning/session-planner";
+import { greetCloseLessonV1 } from "../bootstrap-lessons.v1";
+import { qaLesson } from "../lesson-contract";
+import { nepLessonRegistryV1 } from "../lesson-registry.v1";
+import {
+  compileCanonicalNếpPracticeAttempt,
+  NếpPracticeSubmissionSchema,
+  resolveNếpPlannedPractice,
+} from "../practice-execution.v1";
+import { plannerCandidateId } from "../remediation-map.v1";
+import { nepSessionCatalogV1, validateNếpSessionCatalog } from "../session-catalog.v1";
+
+describe("adaptive catalog bootstrap V1", () => {
+  it("keeps every canonical lesson free of blocking QA issues", () => {
+    for (const lesson of nepLessonRegistryV1) {
+      const errors = qaLesson(lesson).filter((issue) => issue.severity === "error");
+      expect(errors, lesson.id).toEqual([]);
+    }
+  });
+
+  it("keeps prerequisite targets learnable inside the planner catalog", () => {
+    expect(validateNếpSessionCatalog()).toEqual([]);
+    expect(nepSessionCatalogV1.some((candidate) => candidate.targetId === "CAP-001")).toBe(true);
+    expect(nepSessionCatalogV1.some((candidate) => candidate.targetId === "CAP-002")).toBe(true);
+  });
+
+  it("gives a cold-start learner eligible CAP-001 practice instead of an empty plan", () => {
+    const plan = planSession({
+      candidates: nepSessionCatalogV1,
+      states: [],
+      sessionSize: 2,
+      now: "2026-09-03T00:00:00.000Z",
+    });
+
+    expect(plan.opportunities.length).toBeGreaterThan(0);
+    expect(plan.opportunities.every((item) => item.candidate.targetId === "CAP-001")).toBe(true);
+    expect(plan.blocked.some((item) => item.reasons.includes("prerequisite-not-ready:CAP-001"))).toBe(true);
+  });
+
+  it("exposes learner-visible choice labels without exposing the correct marker", () => {
+    const envelope = resolveNếpPlannedPractice(
+      plannerCandidateId(greetCloseLessonV1.id, "comprehend"),
+    );
+
+    expect(envelope).toMatchObject({
+      lessonId: greetCloseLessonV1.id,
+      actionId: "comprehend",
+      modality: "choice",
+      choices: ["greeting", "asking for help", "closing"],
+    });
+
+    const serialized = JSON.stringify(envelope);
+    expect(serialized).not.toContain("targetSignals");
+    expect(serialized).not.toContain("requiredSignalGroups");
+    expect(serialized).not.toContain("correctChoice");
+  });
+
+  it("executes CAP-001 through the same canonical server-side compilation path", () => {
+    const parsed = NếpPracticeSubmissionSchema.parse({
+      lessonId: greetCloseLessonV1.id,
+      lessonVersion: greetCloseLessonV1.version,
+      actionId: "retrieve",
+      response: "Hi. Nice to meet you.",
+      responseSource: "speech",
+      supportUsed: false,
+      latencyMs: 800,
+    });
+    const compiled = compileCanonicalNếpPracticeAttempt(parsed)!;
+
+    expect(compiled.evaluation.success).toBe(true);
+    expect(compiled.record.attempt).toMatchObject({
+      capabilityId: "CAP-001",
+      exerciseType: "nep:retrieve",
+      responseModality: "speech",
+      correct: true,
+      responseText: null,
+    });
+    expect(compiled.record.candidate).toMatchObject({
+      type: "retrieval",
+      targetId: "CAP-001",
+      success: true,
+    });
+  });
+});

--- a/src/lib/nep/bootstrap-lessons.v1.ts
+++ b/src/lib/nep/bootstrap-lessons.v1.ts
@@ -1,0 +1,112 @@
+import type { LessonContract } from "./lesson-contract";
+
+const greetingSignals = ["hi", "hello"];
+const acknowledgementSignals = ["nice to meet you", "good to meet you"];
+const closingSignals = ["see you", "bye", "goodbye"];
+
+/**
+ * Small prerequisite lesson that gives a new learner a legitimate path into the adaptive catalog.
+ * It is intentionally narrower than the CAP-002 vertical slice: no repair/transfer claims are made.
+ */
+export const greetCloseLessonV1: LessonContract = {
+  id: "LESSON-CAP001-GREET-CLOSE-V1",
+  version: 1,
+  capabilityId: "CAP-001",
+  embeddedCapabilityIds: [],
+  prerequisites: [],
+  mission: "Meet a colleague, greet them naturally, acknowledge the meeting, and close the short interaction.",
+  learnerCanDo: "Start and end a short first interaction without freezing.",
+  newItems: ["Hi.", "Nice to meet you.", "See you."],
+  reviewTargets: ["Hi.", "Nice to meet you.", "See you."],
+  evidenceChannels: ["comprehension", "retrieval", "production", "retention"],
+  sourceDerived: {
+    principleIds: ["PRN-001", "PRN-002", "PRN-050"],
+    claimIds: ["CLM-FND-001", "CLM-SPK-001"],
+  },
+  productInference: {
+    maxNewItems: 4,
+    notes: [
+      "This bootstrap exists to close the CAP-001 prerequisite gap in the adaptive catalog.",
+      "Recognition, retrieval and production remain separate evidence channels.",
+      "Transcript matching checks declared language coverage only; it does not score pronunciation.",
+    ],
+  },
+  actions: [
+    {
+      id: "context",
+      kind: "context",
+      title: "A colleague greets you at the start of the day",
+      instruction: "Listen for the social job of the short exchange.",
+      modality: "listen",
+      model: "Hi. Nice to meet you.",
+      supportVi: "Bối cảnh: gặp đồng nghiệp mới và chào nhau ngắn gọn.",
+    },
+    {
+      id: "comprehend",
+      kind: "comprehend",
+      title: "What is the colleague doing?",
+      instruction: "Choose the social job of the turn.",
+      modality: "choice",
+      prompt: "Hi. Nice to meet you.",
+      choices: ["greeting", "asking for help", "closing"],
+      targetSignals: ["greeting"],
+      assessment: {
+        targetCapabilityId: "CAP-001",
+        evidenceType: "recognition",
+        contextId: "greet-close:greeting-recognition:v1",
+        evaluator: "nep-choice-v1",
+      },
+    },
+    {
+      id: "notice",
+      kind: "notice",
+      title: "Keep three short social chunks",
+      instruction: "Notice the chunks as complete moves; no grammar explanation is needed.",
+      modality: "read",
+      model: "Hi. / Nice to meet you. / See you.",
+      revealsAnswer: false,
+    },
+    {
+      id: "retrieve",
+      kind: "retrieve",
+      title: "Pull the greeting from memory",
+      instruction: "From the Vietnamese cue, say the short English greeting and acknowledgement aloud.",
+      modality: "speech",
+      prompt: "Chào. Rất vui được gặp bạn.",
+      supportVi: "Thử nhớ trước khi xem lại mẫu câu.",
+      targetSignals: [...greetingSignals, ...acknowledgementSignals],
+      requiredSignalGroups: [greetingSignals, acknowledgementSignals],
+      assessment: {
+        targetCapabilityId: "CAP-001",
+        evidenceType: "retrieval",
+        contextId: "greet-close:vi-cue:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "produce",
+      kind: "produce",
+      title: "Open and close the interaction aloud",
+      instruction: "Greet Maya, acknowledge the meeting, then end the short interaction with a goodbye.",
+      modality: "speech",
+      prompt: "Maya: Hi, I'm Maya. Nice to meet you. [A moment later, you both leave.]",
+      targetSignals: [...greetingSignals, ...acknowledgementSignals, ...closingSignals],
+      requiredSignalGroups: [greetingSignals, acknowledgementSignals, closingSignals],
+      assessment: {
+        targetCapabilityId: "CAP-001",
+        evidenceType: "production",
+        contextId: "greet-close:first-meeting:v1",
+        evaluator: "nep-target-signal-v1",
+      },
+    },
+    {
+      id: "feedback",
+      kind: "feedback",
+      title: "Check the compact social sequence",
+      instruction: "Use this only after attempting retrieval/production.",
+      modality: "read",
+      revealsAnswer: true,
+      model: "Hi. Nice to meet you. See you.",
+    },
+  ],
+};

--- a/src/lib/nep/evaluator.ts
+++ b/src/lib/nep/evaluator.ts
@@ -96,15 +96,19 @@ export function evaluateNếpActionResponse(action: LessonAction, response: stri
 
 export function feedbackForNếpEvaluation(action: LessonAction, result: NếpEvaluationResult) {
   if (result.success) {
+    if (action.kind === "comprehend") {
+      return "Đúng. Bạn đã nhận ra đúng ý định hoặc loại thông tin mà prompt yêu cầu.";
+    }
     return "Transcript đáp ứng đủ target language cần cho task. Đây là language/transcript feedback, không phải điểm phát âm.";
   }
 
   if (!result.observedResponse) {
+    if (action.kind === "comprehend") return "Chưa có lựa chọn để đánh giá.";
     return "Chưa quan sát được câu trả lời. Lần này không nên tạo oral mastery evidence.";
   }
 
   if (action.kind === "comprehend") {
-    return "Chưa đúng. Câu hỏi đang cần thông tin về tên.";
+    return "Chưa đúng. Hãy xác định lại ý định hoặc loại thông tin mà prompt đang yêu cầu.";
   }
 
   if (action.kind === "transfer" || action.kind === "retry") {
@@ -119,7 +123,7 @@ export function feedbackForNếpEvaluation(action: LessonAction, result: NếpEv
 
   if (action.kind === "repair") return "Chưa có repair move cần thiết để xin người đối thoại nhắc lại.";
   if (action.kind === "retrieve" || action.kind === "produce") {
-    return "Chưa có cụm tự giới thiệu cần thiết cho task.";
+    return "Câu trả lời chưa chứa đủ các cụm cần thiết cho task. Tự sửa rồi thử lại.";
   }
 
   return "Câu trả lời chưa đáp ứng đủ target language của task. Tự sửa rồi thử lại.";

--- a/src/lib/nep/lesson-contract.ts
+++ b/src/lib/nep/lesson-contract.ts
@@ -33,6 +33,8 @@ export type LessonAction = {
   prompt?: string;
   model?: string;
   supportVi?: string;
+  /** Learner-visible options. Correctness is still determined from hidden targetSignals. */
+  choices?: string[];
   targetSignals?: string[];
   /** Every group is required; one signal from each group must be observed. */
   requiredSignalGroups?: string[][];
@@ -88,11 +90,18 @@ export function qaLesson(lesson: LessonContract): QaIssue[] {
   const kinds = lesson.actions.map((action) => action.kind);
   const firstRetrieve = kinds.indexOf("retrieve");
   const firstReveal = lesson.actions.findIndex((action) => action.revealsAnswer === true);
+  const comprehension = lesson.actions.find((action) => action.kind === "comprehend");
+  const retrieval = lesson.actions.find((action) => action.kind === "retrieve");
   const production = lesson.actions.find((action) => action.kind === "produce");
   const repair = lesson.actions.find((action) => action.kind === "repair");
   const retry = lesson.actions.find((action) => action.kind === "retry");
   const transfer = lesson.actions.find((action) => action.kind === "transfer");
   const declaredTargets = new Set([lesson.capabilityId, ...lesson.embeddedCapabilityIds]);
+  const needsRetrieval = lesson.evidenceChannels.includes("retrieval");
+  const needsProduction = lesson.evidenceChannels.includes("production");
+  const needsRepairCycle = lesson.evidenceChannels.includes("repair");
+  const needsTransfer = lesson.evidenceChannels.includes("transfer");
+  const needsRetention = lesson.evidenceChannels.includes("retention");
 
   if (!lesson.capabilityId) {
     issues.push({ severity: "error", code: "CAPABILITY_REQUIRED", message: "Lesson must declare a capability ID.", provenance: "product_inference" });
@@ -103,22 +112,24 @@ export function qaLesson(lesson: LessonContract): QaIssue[] {
   if (lesson.newItems.length > lesson.productInference.maxNewItems) {
     issues.push({ severity: "error", code: "TOO_MANY_NEW_ITEMS", message: `Lesson introduces ${lesson.newItems.length} items; V1 preview cap is ${lesson.productInference.maxNewItems}.`, provenance: "product_inference" });
   }
-  if (firstRetrieve === -1 || (firstReveal !== -1 && firstReveal < firstRetrieve)) {
+  if (needsRetrieval && (firstRetrieve === -1 || (firstReveal !== -1 && firstReveal < firstRetrieve))) {
     issues.push({ severity: "error", code: "ATTEMPT_BEFORE_REVEAL", message: "Retrieval attempt must happen before answer-bearing reveal.", provenance: "source_derived" });
   }
-  if (!production || production.modality !== "speech") {
+  if (needsProduction && (!production || production.modality !== "speech")) {
     issues.push({ severity: "error", code: "SPEAKING_NEEDS_SPEECH", message: "A speaking claim requires an observable speech response path.", provenance: "source_derived" });
   }
-  for (const required of ["feedback", "repair", "retry"] as const) {
-    if (!kinds.includes(required)) {
-      issues.push({ severity: "error", code: `MISSING_${required.toUpperCase()}`, message: `Lesson must include ${required}.`, provenance: "source_derived" });
+  if (needsRepairCycle) {
+    for (const required of ["feedback", "repair", "retry"] as const) {
+      if (!kinds.includes(required)) {
+        issues.push({ severity: "error", code: `MISSING_${required.toUpperCase()}`, message: `Lesson with repair evidence must include ${required}.`, provenance: "source_derived" });
+      }
     }
   }
-  if (!transfer || transfer.modality !== "speech" || !transfer.changedContext) {
+  if (needsTransfer && (!transfer || transfer.modality !== "speech" || !transfer.changedContext)) {
     issues.push({ severity: "error", code: "TRANSFER_NEEDS_CHANGED_SPEECH", message: "Transfer requires productive speech in a changed context.", provenance: "source_derived" });
   }
-  if (lesson.reviewTargets.length === 0 || !lesson.evidenceChannels.includes("retention")) {
-    issues.push({ severity: "error", code: "DELAYED_REVIEW_REQUIRED", message: "Lesson must publish review targets and a retention evidence channel.", provenance: "source_derived" });
+  if (needsRetention && lesson.reviewTargets.length === 0) {
+    issues.push({ severity: "error", code: "DELAYED_REVIEW_REQUIRED", message: "A lesson with retention evidence must publish review targets.", provenance: "source_derived" });
   }
   if (lesson.sourceDerived.principleIds.length === 0 || lesson.sourceDerived.claimIds.length === 0) {
     issues.push({ severity: "error", code: "EVIDENCE_TRACE_REQUIRED", message: "Lesson must trace to research principle and claim IDs.", provenance: "product_inference" });
@@ -135,10 +146,21 @@ export function qaLesson(lesson: LessonContract): QaIssue[] {
     if (action.assessment && !declaredTargets.has(action.assessment.targetCapabilityId)) {
       issues.push({ severity: "error", code: "ASSESSMENT_TARGET_UNDECLARED", message: `${action.id} targets ${action.assessment.targetCapabilityId}, which is not the lesson capability or an embedded capability.`, provenance: "product_inference" });
     }
+    if (action.modality === "choice") {
+      const choices = action.choices ?? [];
+      if (choices.length < 2) {
+        issues.push({ severity: "error", code: "CHOICE_OPTIONS_REQUIRED", message: `${action.id} must expose at least two learner-visible choices.`, provenance: "product_inference" });
+      }
+      const choiceSet = new Set(choices.map((choice) => choice.trim().toLowerCase()));
+      for (const signal of action.targetSignals ?? []) {
+        if (!choiceSet.has(signal.trim().toLowerCase())) {
+          issues.push({ severity: "error", code: "CHOICE_TARGET_NOT_PRESENT", message: `${action.id} target signal must exist among learner-visible choices.`, provenance: "product_inference" });
+          break;
+        }
+      }
+    }
   }
 
-  const comprehension = lesson.actions.find((action) => action.kind === "comprehend");
-  const retrieval = lesson.actions.find((action) => action.kind === "retrieve");
   if (comprehension?.assessment && comprehension.assessment.evidenceType !== "recognition") {
     issues.push({ severity: "error", code: "COMPREHENSION_PERSISTS_MODAL_EVIDENCE", message: "Choice comprehension in this slice must persist low-level recognition evidence, not a product-level comprehension label.", provenance: "product_inference" });
   }
@@ -218,6 +240,7 @@ export const firstMeetingLessonV1: LessonContract = {
       instruction: "Choose the information the question is asking for.",
       modality: "choice",
       prompt: "What's your name?",
+      choices: ["name", "job", "country"],
       targetSignals: ["name"],
       assessment: {
         targetCapabilityId: "CAP-002",

--- a/src/lib/nep/lesson-registry.v1.ts
+++ b/src/lib/nep/lesson-registry.v1.ts
@@ -1,0 +1,13 @@
+import { greetCloseLessonV1 } from "./bootstrap-lessons.v1";
+import { firstMeetingLessonV1, type LessonContract } from "./lesson-contract";
+
+export const nepLessonRegistryV1: readonly LessonContract[] = [
+  greetCloseLessonV1,
+  firstMeetingLessonV1,
+];
+
+export function resolveNếpLessonFromRegistry(lessonId: string, lessonVersion: number) {
+  return nepLessonRegistryV1.find(
+    (lesson) => lesson.id === lessonId && lesson.version === lessonVersion,
+  ) ?? null;
+}

--- a/src/lib/nep/practice-execution.v1.ts
+++ b/src/lib/nep/practice-execution.v1.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 
 import { evaluateNếpAction, feedbackForNếpEvaluation } from "./evaluator";
-import { firstMeetingLessonV1, type LessonAction, type LessonContract } from "./lesson-contract";
+import type { LessonAction } from "./lesson-contract";
+import { resolveNếpLessonFromRegistry } from "./lesson-registry.v1";
 import { toLearningAttemptRecord, type NếpResponseSource } from "./learning-evidence-adapter";
 import { nepSessionCatalogV1 } from "./session-catalog.v1";
-
-const lessonRegistryV1: LessonContract[] = [firstMeetingLessonV1];
 
 export const NếpPracticeSubmissionSchema = z.object({
   lessonId: z.string().trim().min(1).max(160),
@@ -29,14 +28,13 @@ export type NếpPracticeEnvelope = {
   title: string;
   instruction: string;
   prompt: string | null;
+  choices: string[];
   supportVi: string | null;
   changedContext: boolean;
 };
 
 export function resolveNếpLesson(lessonId: string, lessonVersion: number) {
-  return lessonRegistryV1.find(
-    (lesson) => lesson.id === lessonId && lesson.version === lessonVersion,
-  ) ?? null;
+  return resolveNếpLessonFromRegistry(lessonId, lessonVersion);
 }
 
 export function resolveNếpAction(lessonId: string, lessonVersion: number, actionId: string) {
@@ -50,7 +48,8 @@ export function resolveNếpAction(lessonId: string, lessonVersion: number, acti
 /**
  * Resolve a planner candidate to a learner-safe presentation envelope.
  * Hidden evaluator targets, expected target signals, evidence type/target and remediation rules
- * are deliberately excluded from this DTO.
+ * are deliberately excluded from this DTO. Choice labels are learner-visible content, but no
+ * correctness marker is exposed.
  */
 export function resolveNếpPlannedPractice(candidateId: string): NếpPracticeEnvelope | null {
   const candidate = nepSessionCatalogV1.find((item) => item.id === candidateId);
@@ -79,6 +78,7 @@ export function resolveNếpPlannedPractice(candidateId: string): NếpPracticeE
     title: resolved.action.title,
     instruction: resolved.action.instruction,
     prompt: resolved.action.prompt ?? null,
+    choices: [...(resolved.action.choices ?? [])],
     supportVi: resolved.action.supportVi ?? null,
     changedContext: resolved.action.changedContext ?? false,
   };

--- a/src/lib/nep/session-catalog.v1.ts
+++ b/src/lib/nep/session-catalog.v1.ts
@@ -1,5 +1,6 @@
 import type { PlannerCandidate } from "../learning/session-planner";
-import { firstMeetingLessonV1, type LessonActionKind, type LessonContract } from "./lesson-contract";
+import type { LessonActionKind, LessonContract } from "./lesson-contract";
+import { nepLessonRegistryV1 } from "./lesson-registry.v1";
 import { plannerCandidateId } from "./remediation-map.v1";
 
 const IMPORTANCE_BY_ACTION: Partial<Record<LessonActionKind, number>> = {
@@ -47,4 +48,27 @@ export function buildLessonPlannerCandidates(lesson: LessonContract): PlannerCan
   });
 }
 
-export const nepSessionCatalogV1 = buildLessonPlannerCandidates(firstMeetingLessonV1);
+export const nepSessionCatalogV1 = nepLessonRegistryV1.flatMap(buildLessonPlannerCandidates);
+
+/**
+ * The adaptive catalog must contain a learnable source for every declared prerequisite.
+ * Otherwise a new learner can be permanently blocked by a target that the planner can never serve.
+ */
+export function validateNếpSessionCatalog(candidates: PlannerCandidate[] = nepSessionCatalogV1) {
+  const issues: string[] = [];
+  const candidateIds = new Set<string>();
+  const targetIds = new Set(candidates.map((candidate) => candidate.targetId));
+
+  for (const candidate of candidates) {
+    if (candidateIds.has(candidate.id)) issues.push(`duplicate-candidate-id:${candidate.id}`);
+    candidateIds.add(candidate.id);
+
+    for (const prerequisite of candidate.prerequisiteTargetIds ?? []) {
+      if (!targetIds.has(prerequisite)) {
+        issues.push(`missing-prerequisite-practice:${candidate.id}:${prerequisite}`);
+      }
+    }
+  }
+
+  return [...new Set(issues)].sort();
+}


### PR DESCRIPTION
## Why
The adaptive catalog previously contained only the CAP-002 first-meeting lesson while that lesson requires CAP-001. A learner with empty state therefore received an empty plan: every candidate was blocked by CAP-001, but the planner had no CAP-001 practice to serve.

This slice closes that cold-start deadlock with real prerequisite learning rather than bypassing gates or seeding fake mastery.

## Stack
- Base: `agent/planned-practice-execution-v1` / PR #77
- Head: `agent/adaptive-catalog-bootstrap-v1`
- No database migration.
- No learner-facing adaptive route yet.

## Canonical registry
Adds `nepLessonRegistryV1` and makes planner compilation + trusted execution resolve from the same lesson registry.

Registry V1 now includes:
- CAP-001 greet/close bootstrap;
- CAP-002 first meeting with embedded CAP-003 repair.

## CAP-001 bootstrap
Adds evidence-bearing recognition, retrieval and production practice for CAP-001 with retention targets. It does not manufacture repair/transfer claims.

## Lesson QA
`qaLesson()` is now evidence-channel aware:
- retrieval-before-reveal is required when retrieval is declared;
- speech path is required when production is declared;
- feedback/repair/retry are required when repair evidence is declared;
- changed-context transfer is required when transfer is declared;
- retention targets are required when retention is declared.

The existing CAP-002 lesson still declares repair + transfer, so its previous gates remain active.

## Choice execution
Adds learner-visible `choices` to choice actions. Correct targets remain hidden in `targetSignals`; safe practice envelopes expose only labels without any correctness marker.

## Catalog closure QA
Adds `validateNếpSessionCatalog()` to reject duplicate candidate IDs and prerequisites with no learnable target in the catalog.

## Cold-start contract
With empty learner state, planner must return eligible CAP-001 opportunities while CAP-002 remains blocked by `prerequisite-not-ready:CAP-001`.

A fresh plan can unlock CAP-002 only after persisted CAP-001 evidence makes the prerequisite ready.

## Tests
Covers:
- every canonical lesson has no blocking QA issue;
- catalog prerequisite closure;
- cold-start learner receives CAP-001 instead of empty plan;
- safe choice envelope exposes labels but no correct marker;
- CAP-001 executes through the same server-authoritative compilation path;
- existing first-meeting catalog regressions are scoped by lesson identity rather than assuming a single-lesson catalog.

## Verification
The first full-stack run exposed four legacy catalog tests that assumed `nepSessionCatalogV1` contained only the first-meeting lesson. The behavior was correct; the tests were updated to scope first-meeting assertions by canonical `lessonId`, while the new bootstrap tests cover the multi-lesson catalog.

Temporary draft PR #80 then ran the full repository `Verify` workflow against `main` for head `88661e2e007f7ea5fa2503550a286459ee17b73c`:
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #80 was closed without merge. PR #79 is mergeable and remains draft.

See `docs/nep/ADAPTIVE_CATALOG_BOOTSTRAP_V1.md`.