### PR TITLE
Activate learner-safe adaptive practice preview V1

### DIFF
--- a/docs/nep/ADAPTIVE_PRACTICE_SURFACE_V1.md
+++ b/docs/nep/ADAPTIVE_PRACTICE_SURFACE_V1.md
@@ -1,0 +1,105 @@
+# Adaptive Practice Surface V1
+
+## Goal
+
+Turn the adaptive core into an inspectable learner-facing preview without replacing the fixed Nếp vertical slice or exposing planner internals to the browser.
+
+The new route is:
+
+```text
+/adaptive-preview
+```
+
+It is non-indexed and requires an authenticated learner state. `/data-preview` remains the fixed public reference slice.
+
+## Browser trust boundary
+
+The adaptive browser surface receives only learner-safe practice envelopes:
+
+- lesson id/version;
+- action id/candidate id;
+- action kind/modality;
+- title/instruction/prompt;
+- learner-visible choice labels;
+- optional Vietnamese task support;
+- changed-context presentation flag.
+
+It does not receive:
+
+- target capability id;
+- evidence type;
+- evaluator id;
+- targetSignals / requiredSignalGroups;
+- remediation rules;
+- planner scores/ranking reasons;
+- internal blocked-candidate diagnostics.
+
+`getNếpAdaptivePracticeQueue()` is a server-only projection over the internal planner action. The client component does not call `getNếpSessionPlan()` directly.
+
+## Trusted execution
+
+For each practice, the browser sends only observed interaction data to `recordNếpPracticeAttempt()`.
+
+The server resolves canonical content and recomputes correctness, target, evidence type, evaluator, reveal semantics and remediation hints.
+
+Raw learner speech/text is used transiently for deterministic evaluation and is not persisted as `response_text`.
+
+## Session behavior
+
+V1 uses short queues. After a persisted attempt:
+
+1. feedback is shown;
+2. the current practice is considered consumed for that queue whether correct or incorrect;
+3. the learner moves to the next planned practice;
+4. after the queue ends, the learner explicitly requests a fresh plan.
+
+The client does not retry the same prompt repeatedly and does not simulate learner-state updates.
+
+A wrong response is an observation. A future fresh plan decides whether to repeat, remediate or re-probe based on persisted state/error memory.
+
+## Cold-start sequencing
+
+Catalog bootstrap alone is not enough. A new target could still rank retrieval above recognition because normal ranking weights value retrieval/transfer potential.
+
+V1 therefore adds this conservative hard gate:
+
+```text
+if target has a recognition candidate
+and learner has zero persisted evidence for target
+then non-recognition candidates are blocked by:
+  cold-start-needs-recognition
+```
+
+The planner does not simulate recognition success inside the same plan. After the recognition attempt persists, the surface requests a new plan before retrieval/production can become eligible.
+
+This rule applies only when the catalog actually provides a recognition candidate. Targets without recognition practice are not globally blocked by this gate.
+
+## Speaking behavior
+
+Speech practice prefers browser SpeechRecognition when available.
+
+If the learner edits/types the transcript field, response source becomes `text`, so the existing learning-core policy prevents that response from becoming speaking evidence.
+
+Transcript matching remains language-coverage feedback, not pronunciation scoring.
+
+## Auth/session expiry
+
+Adaptive planning requires login because it reads persisted learner state.
+
+If authentication disappears after a plan has already loaded, trusted execution may still return canonical feedback but `persisted=false`. The adaptive surface does not advance that practice because learner state did not change; it asks the learner to sign in again.
+
+## Empty/error behavior
+
+An empty plan is shown explicitly. The client never bypasses prerequisites or manufactures mastery to fill the queue.
+
+Infrastructure/read-model errors are surfaced as preview errors with a retry action.
+
+## Deployment limitation
+
+This route depends on the stacked learning-core migrations and RLS/read models. Those migrations have not been applied to production Supabase in this workstream.
+
+Therefore repository CI can validate code/contracts, but an isolated Supabase migration/RLS integration test remains a deployment gate before enabling the adaptive route in production.
+
+## Non-claims
+
+The queue size, recognition-first cold-start rule, planner weights and current CAP-001/CAP-002 content are V1 product policies. They are not calibrated efficacy claims or evidence that this ordering is universally optimal.

--- a/src/__tests__/adaptive-practice-surface-boundary.test.ts
+++ b/src/__tests__/adaptive-practice-surface-boundary.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(__dirname, "../..");
+const surfacePath = resolve(
+  repositoryRoot,
+  "src/features/adaptive-practice/AdaptivePracticePreview.tsx",
+);
+const safeActionPath = resolve(repositoryRoot, "src/app/actions/adaptive-practice.ts");
+
+describe("adaptive practice learner-facing boundaries", () => {
+  it("uses the learner-safe queue action instead of consuming the internal planner action", () => {
+    const source = readFileSync(surfacePath, "utf8");
+
+    expect(source).toContain("getNếpAdaptivePracticeQueue");
+    expect(source).not.toContain("getNếpSessionPlan");
+    expect(source).not.toContain("result.plan");
+    expect(source).not.toContain("evaluateNếpAction");
+    expect(source).not.toContain("toLearningAttemptRecord");
+  });
+
+  it("keeps internal planner diagnostics behind a server-only projection", () => {
+    const source = readFileSync(safeActionPath, "utf8");
+
+    expect(source).toMatch(/^\s*["']use server["'];?/m);
+    expect(source).toContain("getNếpSessionPlan");
+    expect(source).toContain("practices: result.practices");
+    expect(source).toContain("practiceCount: result.practices.length");
+    expect(source).not.toContain("plan: result.plan");
+    expect(source).not.toContain("opportunities: result.plan");
+    expect(source).not.toContain("blocked: result.plan");
+  });
+});

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -188,7 +188,7 @@ describe("session planner v1", () => {
         candidate({ id: "a:retrieval", targetId: "a", evidenceType: "retrieval" }),
         candidate({ id: "a:listening", targetId: "a", evidenceType: "listening" }),
       ],
-      states: [],
+      states: [state("a", { recognition: 0.3, evidenceCount: 1 })],
       sessionSize: 3,
       config: { maxPerTarget: 2 },
     });

--- a/src/app/actions/adaptive-practice.ts
+++ b/src/app/actions/adaptive-practice.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { getNếpSessionPlan } from "@/app/actions/session-planner";
+import type { NếpPracticeEnvelope } from "@/lib/nep/practice-execution.v1";
+
+export type GetNếpAdaptivePracticeQueueResult =
+  | {
+      success: false;
+      error: string;
+      authRequired: boolean;
+    }
+  | {
+      success: true;
+      practices: NếpPracticeEnvelope[];
+      summary: {
+        practiceCount: number;
+        catalogSize: number;
+        recurringErrorCount: number;
+        stateCount: number;
+      };
+    };
+
+/**
+ * Learner-facing planner boundary.
+ *
+ * The internal planner action remains useful for diagnostics, but a browser learning surface must
+ * not receive planner scores, target IDs, evidence types, evaluator identifiers or ranking reasons.
+ * This action deliberately strips those fields and returns only safe practice envelopes plus a
+ * minimal operational summary.
+ */
+export async function getNếpAdaptivePracticeQueue(
+  sessionSize = 2,
+): Promise<GetNếpAdaptivePracticeQueueResult> {
+  const result = await getNếpSessionPlan({ sessionSize });
+  if (!result.success) {
+    const error = result.error ?? "Không thể tạo session học thích ứng.";
+    return {
+      success: false,
+      error,
+      authRequired: error.includes("đăng nhập"),
+    };
+  }
+
+  return {
+    success: true,
+    practices: result.practices,
+    summary: {
+      practiceCount: result.practices.length,
+      catalogSize: result.diagnostics.catalogSize,
+      recurringErrorCount: result.diagnostics.recurringErrorCount,
+      stateCount: result.diagnostics.stateCount,
+    },
+  };
+}

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -17,8 +17,11 @@ import {
   type LearnerSkillStateRow,
   type RecentLearningAttemptRow,
 } from "@/lib/learning/session-input";
-import { planSession } from "@/lib/learning/session-planner";
-import { resolveNếpPlannedPractice } from "@/lib/nep/practice-execution.v1";
+import { planSession, type SessionPlan } from "@/lib/learning/session-planner";
+import {
+  resolveNếpPlannedPractice,
+  type NếpPracticeEnvelope,
+} from "@/lib/nep/practice-execution.v1";
 import { nepSessionCatalogV1 } from "@/lib/nep/session-catalog.v1";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
@@ -44,13 +47,38 @@ export type GetNếpSessionPlanInput = {
   sessionSize?: number;
 };
 
+export type GetNếpSessionPlanResult =
+  | {
+      success: false;
+      error: string;
+    }
+  | {
+      success: true;
+      plan: SessionPlan;
+      practices: NếpPracticeEnvelope[];
+      diagnostics: {
+        sessionSize: number;
+        catalogSize: number;
+        practiceEnvelopeCount: number;
+        stateCount: number;
+        recentAttemptCount: number;
+        errorMemoryAttemptCount: number;
+        recurringErrorCount: number;
+        rawResponseSelected: false;
+        fullMetadataSelected: false;
+        hiddenEvaluatorTargetsExposedInPractices: false;
+      };
+    };
+
 /**
  * Read-only authenticated boundary for Session Planner V1.
  * It deliberately selects no raw response/transcript content and does not mutate learner state.
  * Alongside diagnostic planner data it returns learner-safe practice envelopes whose hidden
  * evaluator targets/evidence metadata have been stripped by the canonical execution compiler.
  */
-export async function getNếpSessionPlan(input: GetNếpSessionPlanInput = {}) {
+export async function getNếpSessionPlan(
+  input: GetNếpSessionPlanInput = {},
+): Promise<GetNếpSessionPlanResult> {
   try {
     const reqHeaders = await headers();
     const ip = reqHeaders.get("x-forwarded-for")?.split(",")[0].trim() || "127.0.0.1";

--- a/src/app/adaptive-preview/page.tsx
+++ b/src/app/adaptive-preview/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { AdaptivePracticePreview } from "@/features/adaptive-practice/AdaptivePracticePreview";
+
+export const metadata: Metadata = {
+  title: "Nếp Adaptive Practice Preview — AtoEnglish",
+  description: "Authenticated preview of learner-state-driven Nếp practice selection and trusted server-side evaluation.",
+  robots: { index: false, follow: false },
+};
+
+export default function AdaptivePreviewPage() {
+  return <AdaptivePracticePreview />;
+}

--- a/src/features/adaptive-practice/AdaptivePracticePreview.tsx
+++ b/src/features/adaptive-practice/AdaptivePracticePreview.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowRight,
+  CircleAlert,
+  Headphones,
+  Loader2,
+  LogIn,
+  Mic2,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import { useRef, useState } from "react";
+
+import { getNếpAdaptivePracticeQueue } from "@/app/actions/adaptive-practice";
+import { recordNếpPracticeAttempt } from "@/app/actions/learning-evidence";
+import type { NếpPracticeEnvelope } from "@/lib/nep/practice-execution.v1";
+
+type SurfacePhase =
+  | "idle"
+  | "planning"
+  | "active"
+  | "complete"
+  | "empty"
+  | "auth-required"
+  | "error";
+
+type SaveState = "idle" | "saving" | "evidence" | "attempt" | "not-saved" | "error";
+
+type RecognitionCtor = new () => {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  start: () => void;
+  onresult: ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null;
+  onerror: (() => void) | null;
+  onend: (() => void) | null;
+};
+
+function recognitionCtor(): RecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const browserWindow = window as unknown as {
+    SpeechRecognition?: RecognitionCtor;
+    webkitSpeechRecognition?: RecognitionCtor;
+  };
+  return browserWindow.SpeechRecognition ?? browserWindow.webkitSpeechRecognition ?? null;
+}
+
+function saveLabel(state: SaveState) {
+  if (state === "saving") return "Đang lưu attempt…";
+  if (state === "evidence") return "Attempt + mastery evidence đã được ghi.";
+  if (state === "attempt") return "Attempt đã được ghi; lần này không tạo mastery evidence.";
+  if (state === "not-saved") return "Phiên đăng nhập không còn hợp lệ; kết quả chưa được lưu.";
+  if (state === "error") return "Attempt chưa lưu được. Có thể thử gửi lại.";
+  return null;
+}
+
+export function AdaptivePracticePreview() {
+  const [phase, setPhase] = useState<SurfacePhase>("idle");
+  const [practices, setPractices] = useState<NếpPracticeEnvelope[]>([]);
+  const [index, setIndex] = useState(0);
+  const [answer, setAnswer] = useState("");
+  const [answerSource, setAnswerSource] = useState<"speech" | "text" | null>(null);
+  const [supportUsed, setSupportUsed] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [evaluationSuccess, setEvaluationSuccess] = useState<boolean | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const attemptStartedAt = useRef<number | null>(null);
+
+  const practice = practices[index] ?? null;
+  const saving = saveState === "saving";
+  const speechAvailable = typeof window !== "undefined" && recognitionCtor() !== null;
+  const persistedLabel = saveLabel(saveState);
+
+  const resetResponse = () => {
+    setAnswer("");
+    setAnswerSource(null);
+    setSupportUsed(false);
+    setListening(false);
+    setFeedback(null);
+    setEvaluationSuccess(null);
+    setSaveState("idle");
+    setSubmitted(false);
+    attemptStartedAt.current = Date.now();
+  };
+
+  const loadQueue = async () => {
+    setPhase("planning");
+    setError(null);
+    setPractices([]);
+    setIndex(0);
+
+    const result = await getNếpAdaptivePracticeQueue(2);
+    if (!result.success) {
+      setError(result.error);
+      setPhase(result.authRequired ? "auth-required" : "error");
+      return;
+    }
+
+    if (result.practices.length === 0) {
+      setPhase("empty");
+      return;
+    }
+
+    setPractices(result.practices);
+    setIndex(0);
+    setPhase("active");
+    resetResponse();
+  };
+
+  const selectChoice = (choice: string) => {
+    if (saving || submitted) return;
+    setAnswer(choice);
+    setAnswerSource(null);
+    setFeedback(null);
+    setEvaluationSuccess(null);
+    setSaveState("idle");
+  };
+
+  const startSpeech = () => {
+    if (!practice || saving || submitted) return;
+    const Recognition = recognitionCtor();
+    if (!Recognition) {
+      setFeedback("Browser này không hỗ trợ speech recognition. Có thể dùng text fallback, nhưng text không tạo speaking evidence.");
+      return;
+    }
+
+    const recognition = new Recognition();
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.continuous = false;
+    recognition.onresult = (event) => {
+      setAnswer(event.results[0]?.[0]?.transcript ?? "");
+      setAnswerSource("speech");
+      setListening(false);
+      setFeedback(null);
+      setEvaluationSuccess(null);
+      setSaveState("idle");
+    };
+    recognition.onerror = () => {
+      setListening(false);
+      setFeedback("Không lấy được transcript. Thử mic lại hoặc dùng text fallback.");
+    };
+    recognition.onend = () => setListening(false);
+    setListening(true);
+    recognition.start();
+  };
+
+  const submit = async () => {
+    if (!practice || saving || submitted || answer.trim().length === 0) return;
+
+    const now = Date.now();
+    const latencyMs = attemptStartedAt.current === null ? 0 : now - attemptStartedAt.current;
+    setSaveState("saving");
+    setError(null);
+
+    const result = await recordNếpPracticeAttempt({
+      lessonId: practice.lessonId,
+      lessonVersion: practice.lessonVersion,
+      actionId: practice.actionId,
+      response: answer,
+      responseSource: practice.modality === "choice" ? null : answerSource,
+      supportUsed,
+      latencyMs,
+    });
+
+    if (!result.success) {
+      setFeedback(result.feedback ?? result.error);
+      setEvaluationSuccess(result.evaluation?.success ?? null);
+      setSaveState("error");
+      return;
+    }
+
+    setFeedback(result.feedback);
+    setEvaluationSuccess(result.evaluation.success);
+
+    if (!result.persisted) {
+      setSaveState("not-saved");
+      return;
+    }
+
+    setSaveState(result.evidenceRecorded ? "evidence" : "attempt");
+    setSubmitted(true);
+  };
+
+  const next = () => {
+    if (!submitted) return;
+    if (index < practices.length - 1) {
+      setIndex((value) => value + 1);
+      resetResponse();
+      return;
+    }
+    setPhase("complete");
+  };
+
+  const progress = practices.length > 0 ? Math.round(((index + 1) / practices.length) * 100) : 0;
+
+  return (
+    <main className="min-h-screen bg-[#f6f4ed] text-[#171713]">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-6 sm:px-6 sm:py-10">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#2d6a4f]">Nếp · adaptive preview V1</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight sm:text-5xl">Practice tiếp theo được chọn từ learner state.</h1>
+          </div>
+          <ShieldCheck className="hidden size-8 text-[#2d6a4f] sm:block" />
+        </header>
+
+        {phase === "idle" && (
+          <section className="my-auto py-16">
+            <div className="rounded-[32px] border border-black/10 bg-white p-6 shadow-[0_24px_80px_rgba(20,30,20,.07)] sm:p-9">
+              <div className="flex items-center gap-2 text-sm font-semibold text-[#24583f]"><Sparkles className="size-4" /> Session Planner V1</div>
+              <p className="mt-5 max-w-xl text-lg leading-8 text-black/65">Planner đọc learner state, lịch sử practice và recurring errors để chọn một queue ngắn. Browser chỉ nhận task an toàn; score, target/evidence metadata và evaluator internals không được gửi ra learner surface.</p>
+              <button type="button" onClick={loadQueue} className="mt-8 flex items-center gap-2 rounded-full bg-[#173d2e] px-5 py-3 text-sm font-bold text-white">Tạo session thích ứng <ArrowRight className="size-4" /></button>
+              <p className="mt-4 text-xs leading-5 text-black/40">Route này cần đăng nhập vì adaptive planning phụ thuộc vào learner state đã persist.</p>
+            </div>
+          </section>
+        )}
+
+        {phase === "planning" && (
+          <section className="my-auto flex flex-col items-center py-20 text-center">
+            <Loader2 className="size-8 animate-spin text-[#2d6a4f]" />
+            <p className="mt-4 font-semibold">Đang dựng session từ learner state…</p>
+          </section>
+        )}
+
+        {phase === "auth-required" && (
+          <section className="my-auto py-16">
+            <div className="rounded-[32px] border border-black/10 bg-white p-7 sm:p-9">
+              <LogIn className="size-7 text-[#2d6a4f]" />
+              <h2 className="mt-5 text-2xl font-semibold">Cần đăng nhập để dùng adaptive planner.</h2>
+              <p className="mt-3 max-w-xl leading-7 text-black/60">{error}</p>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Link href="/login?mode=login&next=/adaptive-preview" className="rounded-full bg-[#173d2e] px-5 py-3 text-sm font-bold text-white">Đăng nhập</Link>
+                <Link href="/data-preview" className="rounded-full border border-black/10 px-5 py-3 text-sm font-semibold">Xem fixed public preview</Link>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {phase === "error" && (
+          <section className="my-auto py-16">
+            <div className="rounded-[32px] border border-[#b42318]/20 bg-white p-7 sm:p-9">
+              <CircleAlert className="size-7 text-[#b42318]" />
+              <h2 className="mt-5 text-2xl font-semibold">Chưa tạo được adaptive session.</h2>
+              <p className="mt-3 leading-7 text-black/60">{error}</p>
+              <button type="button" onClick={loadQueue} className="mt-7 flex items-center gap-2 rounded-full border border-black/10 px-5 py-3 text-sm font-semibold"><RefreshCw className="size-4" /> Thử lại</button>
+            </div>
+          </section>
+        )}
+
+        {phase === "empty" && (
+          <section className="my-auto py-16">
+            <div className="rounded-[32px] border border-black/10 bg-white p-7 sm:p-9">
+              <CircleAlert className="size-7 text-[#8a5b00]" />
+              <h2 className="mt-5 text-2xl font-semibold">Hiện chưa có practice đủ điều kiện.</h2>
+              <p className="mt-3 leading-7 text-black/60">Planner không tự bỏ prerequisite hoặc bịa mastery để lấp queue. Refresh để đọc lại learner state mới nhất.</p>
+              <button type="button" onClick={loadQueue} className="mt-7 flex items-center gap-2 rounded-full border border-black/10 px-5 py-3 text-sm font-semibold"><RefreshCw className="size-4" /> Lập plan lại</button>
+            </div>
+          </section>
+        )}
+
+        {phase === "active" && practice && (
+          <section className="flex flex-1 flex-col justify-center py-10">
+            <div className="mb-7">
+              <div className="flex items-center justify-between text-xs font-bold uppercase tracking-[0.16em] text-black/40">
+                <span>{practice.kind} · {practice.modality}</span>
+                <span>{index + 1}/{practices.length}</span>
+              </div>
+              <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-black/[0.07]"><div className="h-full rounded-full bg-[#2d6a4f]" style={{ width: `${progress}%` }} /></div>
+            </div>
+
+            <h2 className="text-3xl font-semibold leading-tight sm:text-5xl">{practice.title}</h2>
+            <p className="mt-4 max-w-xl text-base leading-7 text-black/60">{practice.instruction}</p>
+
+            <div className="mt-8 rounded-[28px] border border-black/10 bg-white p-5 shadow-[0_24px_80px_rgba(20,30,20,.07)] sm:p-8">
+              {practice.prompt && (
+                <div className="mb-6 rounded-2xl bg-[#f5f3ec] p-5">
+                  <p className="text-xs font-bold uppercase tracking-[.16em] text-black/35">Prompt</p>
+                  <p className="mt-2 text-xl font-medium leading-relaxed">{practice.prompt}</p>
+                </div>
+              )}
+
+              {practice.modality === "choice" ? (
+                <div className="grid gap-3 sm:grid-cols-3">
+                  {practice.choices.map((choice) => (
+                    <button key={choice} type="button" disabled={saving || submitted} onClick={() => selectChoice(choice)} className={`rounded-2xl border px-4 py-4 text-left font-semibold transition disabled:opacity-50 ${answer === choice ? "border-[#2d6a4f] bg-[#edf5ef]" : "border-black/10 hover:bg-black/[0.02]"}`}>{choice}</button>
+                  ))}
+                </div>
+              ) : practice.modality === "speech" ? (
+                <>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <button type="button" onClick={startSpeech} disabled={listening || saving || submitted} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>
+                    {!speechAvailable && <span className="text-xs text-[#8a5b00]">Browser không hỗ trợ speech recognition.</span>}
+                  </div>
+                  <textarea value={answer} disabled={saving || submitted} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); setEvaluationSuccess(null); setSaveState("idle"); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60 disabled:opacity-50" />
+                  <p className="mt-2 text-xs leading-5 text-black/40">Gõ text chỉ là fallback để kiểm language coverage; không được tính speaking evidence.</p>
+                </>
+              ) : (
+                <textarea value={answer} disabled={saving || submitted} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); }} className="min-h-24 w-full rounded-2xl border border-black/10 p-4" />
+              )}
+
+              {practice.supportVi && (
+                <div className="mt-5 border-t border-black/[0.07] pt-5">
+                  <button type="button" disabled={saving || submitted} onClick={() => setSupportUsed((value) => !value)} className="text-sm font-semibold text-black/45 disabled:opacity-40">{supportUsed ? "Ẩn hỗ trợ tiếng Việt" : "Xem hỗ trợ tiếng Việt"}</button>
+                  {supportUsed && <p className="mt-2 text-sm leading-6 text-black/55">{practice.supportVi}</p>}
+                </div>
+              )}
+
+              {!submitted && saveState !== "not-saved" && (
+                <button type="button" onClick={submit} disabled={answer.trim().length === 0 || saving} className="mt-6 flex items-center gap-2 rounded-full bg-[#2d6a4f] px-5 py-3 text-sm font-bold text-white disabled:opacity-30">{saving && <Loader2 className="size-4 animate-spin" />} Kiểm tra & lưu attempt</button>
+              )}
+
+              {feedback && (
+                <div className={`mt-5 rounded-2xl p-4 text-sm leading-6 ${evaluationSuccess ? "bg-[#edf5ef] text-[#24583f]" : "bg-[#fff7e6] text-[#6f4d00]"}`}>
+                  {feedback}
+                </div>
+              )}
+              {persistedLabel && <p className="mt-3 text-xs leading-5 text-black/40">{persistedLabel}</p>}
+
+              {saveState === "not-saved" && (
+                <Link href="/login?mode=login&next=/adaptive-preview" className="mt-5 inline-flex items-center gap-2 rounded-full border border-black/10 px-4 py-2 text-sm font-semibold"><LogIn className="size-4" /> Đăng nhập lại</Link>
+              )}
+            </div>
+
+            <div className="mt-7 flex justify-end">
+              {submitted && <button type="button" onClick={next} className="flex items-center gap-2 rounded-full bg-[#173d2e] px-6 py-3 text-sm font-bold text-white">{index === practices.length - 1 ? "Kết thúc session" : "Practice tiếp theo"}<ArrowRight className="size-4" /></button>}
+            </div>
+          </section>
+        )}
+
+        {phase === "complete" && (
+          <section className="my-auto py-16">
+            <div className="rounded-[32px] bg-[#173d2e] p-7 text-white sm:p-10">
+              <Sparkles className="size-7" />
+              <h2 className="mt-5 text-3xl font-semibold">Session đã xong.</h2>
+              <p className="mt-3 max-w-xl leading-7 text-white/70">Không mở khóa capability ở client. Tạo session mới để planner đọc lại learner state và các error/remediation signals vừa persist, rồi chọn practice tiếp theo từ dữ liệu thật.</p>
+              <button type="button" onClick={loadQueue} className="mt-7 flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-bold text-[#173d2e]"><RefreshCw className="size-4" /> Lập session tiếp theo</button>
+            </div>
+          </section>
+        )}
+
+        <footer className="mt-auto pt-6 text-center text-[11px] leading-5 text-black/35">
+          <Headphones className="mr-1 inline size-3" /> Planner chọn task; server đánh giá; DB quyết định evidence. Transcript thô không được persist. Text fallback ≠ speaking evidence.
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -100,6 +100,11 @@ const EVIDENCE_TIE_ORDER: Record<EvidenceType, number> = {
 export function planSession(input: SessionPlannerInput): SessionPlan {
   const config = { ...DEFAULT_SESSION_PLANNER_CONFIG, ...input.config };
   const states = new Map(input.states.map((state) => [state.targetId, state]));
+  const recognitionTargets = new Set(
+    input.candidates
+      .filter((candidate) => candidate.evidenceType === "recognition")
+      .map((candidate) => candidate.targetId),
+  );
   const now = parseTime(input.now) ?? Date.now();
   const recentTargetIds = input.recentTargetIds ?? [];
   const recentCandidateIds = input.recentCandidateIds ?? [];
@@ -122,7 +127,12 @@ export function planSession(input: SessionPlannerInput): SessionPlan {
         continue;
       }
 
-      const eligibility = checkEligibility(candidate, states, config);
+      const eligibility = checkEligibility(
+        candidate,
+        states,
+        config,
+        recognitionTargets.has(candidate.targetId),
+      );
       if (!eligibility.eligible) {
         blocked.set(candidate.id, { candidate, reasons: eligibility.reasons });
         continue;
@@ -161,6 +171,7 @@ function checkEligibility(
   candidate: PlannerCandidate,
   states: Map<string, LearnerSkillState>,
   config: SessionPlannerConfig,
+  targetHasRecognitionCandidate: boolean,
 ): { eligible: boolean; reasons: string[] } {
   const reasons: string[] = [];
 
@@ -172,6 +183,13 @@ function checkEligibility(
   }
 
   const targetState = states.get(candidate.targetId) ?? createEmptyLearnerSkillState(candidate.targetId);
+  if (
+    targetHasRecognitionCandidate
+    && targetState.evidenceCount === 0
+    && candidate.evidenceType !== "recognition"
+  ) {
+    reasons.push("cold-start-needs-recognition");
+  }
   if (candidate.evidenceType === "transfer" && targetState.production < config.transferProductionFloor) {
     reasons.push("transfer-needs-prior-production");
   }

--- a/src/lib/nep/__tests__/adaptive-catalog-bootstrap.test.ts
+++ b/src/lib/nep/__tests__/adaptive-catalog-bootstrap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { LearnerSkillState } from "../../learning/evidence";
 import { planSession } from "../../learning/session-planner";
 import { greetCloseLessonV1 } from "../bootstrap-lessons.v1";
 import { qaLesson } from "../lesson-contract";
@@ -11,6 +12,22 @@ import {
 } from "../practice-execution.v1";
 import { plannerCandidateId } from "../remediation-map.v1";
 import { nepSessionCatalogV1, validateNếpSessionCatalog } from "../session-catalog.v1";
+
+function state(overrides: Partial<LearnerSkillState> = {}): LearnerSkillState {
+  return {
+    targetId: "CAP-001",
+    recognition: 0,
+    retrieval: 0,
+    listening: 0,
+    production: 0,
+    repair: 0,
+    transfer: 0,
+    retention: 0,
+    evidenceCount: 0,
+    lastEvidenceAt: null,
+    ...overrides,
+  };
+}
 
 describe("adaptive catalog bootstrap V1", () => {
   it("keeps every canonical lesson free of blocking QA issues", () => {
@@ -26,16 +43,38 @@ describe("adaptive catalog bootstrap V1", () => {
     expect(nepSessionCatalogV1.some((candidate) => candidate.targetId === "CAP-002")).toBe(true);
   });
 
-  it("gives a cold-start learner eligible CAP-001 practice instead of an empty plan", () => {
+  it("starts a target with recognition when the catalog provides a recognition candidate", () => {
     const plan = planSession({
       candidates: nepSessionCatalogV1,
       states: [],
-      sessionSize: 2,
+      sessionSize: 3,
       now: "2026-09-03T00:00:00.000Z",
     });
 
-    expect(plan.opportunities.length).toBeGreaterThan(0);
-    expect(plan.opportunities.every((item) => item.candidate.targetId === "CAP-001")).toBe(true);
+    expect(plan.opportunities).toHaveLength(1);
+    expect(plan.opportunities[0]?.candidate).toMatchObject({
+      targetId: "CAP-001",
+      evidenceType: "recognition",
+    });
+    expect(plan.blocked.some((item) =>
+      item.candidate.targetId === "CAP-001"
+      && item.candidate.evidenceType === "retrieval"
+      && item.reasons.includes("cold-start-needs-recognition"),
+    )).toBe(true);
+    expect(plan.blocked.some((item) => item.reasons.includes("prerequisite-not-ready:CAP-001"))).toBe(true);
+  });
+
+  it("allows retrieval after persisted recognition instead of simulating unlock inside the same plan", () => {
+    const plan = planSession({
+      candidates: nepSessionCatalogV1,
+      states: [state({ recognition: 0.35, evidenceCount: 1, lastEvidenceAt: "2026-09-03T00:01:00.000Z" })],
+      sessionSize: 2,
+      now: "2026-09-03T00:02:00.000Z",
+    });
+
+    expect(plan.opportunities.some((item) =>
+      item.candidate.targetId === "CAP-001" && item.candidate.evidenceType === "retrieval",
+    )).toBe(true);
     expect(plan.blocked.some((item) => item.reasons.includes("prerequisite-not-ready:CAP-001"))).toBe(true);
   });
 


### PR DESCRIPTION
## Why
The adaptive core could plan and execute trusted practice but still had no learner-facing surface. This slice adds a separate authenticated `/adaptive-preview` without replacing the fixed public `/data-preview`.

## Stack
- Base: `agent/adaptive-catalog-bootstrap-v1` / PR #79
- Head: `agent/adaptive-practice-surface-v1`
- No database migration.
- `/data-preview` remains unchanged.

## Learner-safe planning boundary
The browser does not call the internal `getNếpSessionPlan()` action. New `getNếpAdaptivePracticeQueue()` projects the internal result server-side and returns only safe practice envelopes plus minimal operational counts.

The learner surface does not receive planner scores, ranking reasons, blocked candidates, target IDs, evidence types or evaluator identifiers.

## Adaptive route
Adds non-indexed `/adaptive-preview`.

Flow:
1. authenticated learner requests a short queue;
2. planner reads persisted state/recent attempts/Error Memory;
3. browser receives only safe practice envelopes;
4. learner responds via choice/speech/text fallback;
5. trusted `recordNếpPracticeAttempt()` evaluates and persists server-side;
6. after a persisted attempt, the queue advances whether the response was correct or incorrect;
7. after queue completion, a fresh plan is requested so new persisted state drives the next selection.

The client never simulates mastery/unlocks.

## Cold-start sequencing
Adds a generic hard gate: when a target has a recognition candidate and learner state has zero evidence for that target, non-recognition candidates are blocked by `cold-start-needs-recognition`.

This prevents retrieval/production from outranking recognition for an unseen target. The planner does not simulate recognition success inside the same plan; a fresh plan is required after persistence.

Targets without a recognition candidate are not globally blocked by this rule.

## Submission behavior
The adaptive surface does not immediately retry the same failed prompt. A persisted failure becomes an observation and the queue moves on; future planning decides whether to repeat, remediate or re-probe.

If auth expires after planning, canonical feedback may still be returned but `persisted=false`; the adaptive surface does not advance and asks the learner to log in again.

## Speech/privacy
Browser SpeechRecognition is preferred for speech tasks. Editing/typing the transcript changes response source to text, so existing policy prevents speaking evidence.

Raw transcript is not persisted as `response_text`; transcript matching is language coverage feedback, not pronunciation scoring.

## Tests
Adds/extends regressions for:
- cold-start recognition-only plan when recognition exists;
- retrieval becomes eligible only after persisted recognition state;
- learner surface imports only safe queue + trusted submission boundaries;
- learner surface does not call internal planner/evaluator/adapter directly;
- learner-safe projection does not return internal plan opportunities/blocked data;
- `maxPerTarget` policy remains tested independently from the cold-start recognition gate.

## Verification
Two CI failures during this slice exposed test/typing assumptions rather than planner-policy regressions:
- internal planner result needed an explicit discriminated return contract so learner-safe projection could narrow `practices`/`diagnostics` without non-null assertions;
- the legacy `maxPerTarget` test used `states: []`, so the new cold-start gate correctly limited the plan to recognition before the session-cap policy could be exercised. That fixture now uses an already-observed learner state and tests only the cap policy.

Temporary CI PR #82 then ran the repository `Verify` workflow against `main` for head `be6e12bed15ca36ebf3dbac0d3e83a458d9972f0` (run #382):
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅

PR #82 was closed without merge. PR #81 is mergeable and remains draft.

## Deployment gate
The adaptive route depends on the stacked learning-core migrations/RLS. Those have not been applied to production Supabase. Repository CI is necessary but isolated migration/RLS integration remains required before production activation.

See `docs/nep/ADAPTIVE_PRACTICE_SURFACE_V1.md`.