### PR TITLE
Restore verified Vercel deployment pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,3 +72,88 @@ jobs:
 
       - name: Run pgTAP database and RLS tests
         run: supabase test db --local
+
+  deploy-preview:
+    name: Vercel preview after Verify
+    needs: [quality, database]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: team_1MZEcAVjG3nrOnklJxYIqGQs
+      VERCEL_PROJECT_ID: prj_2lnCWZp4PvBvuTBksDjMtPPruVqL
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Require Vercel deployment credential
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::Missing GitHub Actions secret VERCEL_TOKEN. Production auto-deploy cannot be restored until this secret is configured."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline
+
+      - name: Pull Vercel preview configuration
+        run: npx --yes vercel@59.10.0 pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel preview
+        run: npx --yes vercel@59.10.0 build --token="$VERCEL_TOKEN"
+
+      - name: Deploy Vercel preview
+        run: |
+          url="$(npx --yes vercel@59.10.0 deploy --prebuilt --token="$VERCEL_TOKEN")"
+          echo "Preview: $url" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-production:
+    name: Vercel production after Verify
+    needs: [quality, database]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      VERCEL_ORG_ID: team_1MZEcAVjG3nrOnklJxYIqGQs
+      VERCEL_PROJECT_ID: prj_2lnCWZp4PvBvuTBksDjMtPPruVqL
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Require Vercel deployment credential
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::Missing GitHub Actions secret VERCEL_TOKEN. Refusing to deploy production without an explicit credential."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline
+
+      - name: Pull Vercel production configuration
+        run: npx --yes vercel@59.10.0 pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel production output
+        run: npx --yes vercel@59.10.0 build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy Vercel production
+        run: |
+          url="$(npx --yes vercel@59.10.0 deploy --prebuilt --prod --token="$VERCEL_TOKEN")"
+          echo "Production: $url" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why
`atoenglish.vercel.app` is still pinned to production deployment commit `1e462367d365d03e01d2b211da2499ac612a57ff` from 2026-07-26 even though `main` has advanced through the Nếp adaptive integration. New pushes and PR events are no longer producing Vercel deployments.

## Change
Extend the existing `Verify` workflow instead of adding an independent deploy path:
- application quality gate stays unchanged;
- fresh PostgreSQL 17 migration/lint/pgTAP gate stays unchanged;
- PR preview deploy runs only after both gates pass;
- production deploy runs only on `main` push after both gates pass;
- Vercel project/team IDs are explicit non-secret identifiers;
- `VERCEL_TOKEN` must come from GitHub Actions Secrets and the workflow fails closed if absent;
- Vercel CLI is pinned to `59.10.0` rather than `latest`.

## Validation goal
This PR itself is the credential/deployment test. After its normal quality + database jobs pass, `Vercel preview after Verify` must either:
1. create a real preview deployment, proving the deployment path is restored; or
2. fail explicitly at the credential gate, proving `VERCEL_TOKEN` is the remaining external setup blocker.

No production deployment occurs from this PR. Production deployment is enabled only after this workflow lands on `main`.