### PR TITLE
Route legacy learning attempts through canonical RPC

### DIFF
--- a/src/app/actions/learning-attempts.ts
+++ b/src/app/actions/learning-attempts.ts
@@ -1,8 +1,14 @@
 "use server";
 
 import { headers } from "next/headers";
-import { createClient } from "@/lib/supabase/server";
-import { createRateLimiter } from "@/lib/security/rate-limit";
+import { z } from "zod";
+
+import { seedUnitVocabToSRS } from "@/app/actions/cards";
+import { completeUnit } from "@/app/actions/unit";
+import {
+  compileLegacyAttemptRpcArgs,
+  type LegacyAttemptRpcArgs,
+} from "@/lib/learning/legacy-attempt-adapter";
 import {
   LearningAttemptBatchSchema,
   type LearningAttemptBatchInput,
@@ -12,12 +18,29 @@ import {
   scoreTrialCheckpoint,
 } from "@/lib/lessons/trial-checkpoint";
 import { GOLD_MISSION_01 } from "@/lib/missions/gold-mission-01";
-import { seedUnitVocabToSRS } from "@/app/actions/cards";
-import { completeUnit } from "@/app/actions/unit";
-import { z } from "zod";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
 
 const attemptLimiter = createRateLimiter(60, 60_000, "learning-attempts");
 
+type RpcError = { message: string } | null;
+type RpcClient = {
+  rpc: (
+    fn: "record_learning_attempt",
+    args: LegacyAttemptRpcArgs,
+  ) => Promise<{ data: unknown; error: RpcError }>;
+};
+
+/**
+ * Compatibility boundary for pre-Nếp mission/checkpoint callers.
+ *
+ * The September learning-core migration replaced the old lesson/activity/score table shape with
+ * the canonical Attempt → Evidence → LearnerSkillState model and revoked direct authenticated
+ * inserts. Legacy callers do not carry enough canonical semantic identity to create trustworthy
+ * mastery evidence, so we preserve them as attempt-only history through the canonical RPC.
+ *
+ * New adaptive learning surfaces must use recordNếpPracticeAttempt() instead.
+ */
 export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
   const parsed = LearningAttemptBatchSchema.safeParse(input);
   if (!parsed.success) {
@@ -45,27 +68,28 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ." };
   }
 
-  const { error } = await supabase.from("learning_attempts").insert(
-    parsed.data.attempts.map((attempt) => ({
-      user_id: user.id,
-      session_id: parsed.data.sessionId,
-      lesson_id: parsed.data.lessonId,
-      activity_id: attempt.activityId,
-      modality: attempt.modality,
-      status: attempt.status,
-      score: attempt.score,
-      error_tags: attempt.errorTags,
-      evaluator: attempt.evaluator,
-      evaluator_version: attempt.evaluatorVersion,
-      latency_ms: attempt.latencyMs,
-    })),
-  );
+  const rpcClient = supabase as unknown as RpcClient;
+  let inserted = 0;
 
-  if (error) {
-    return { success: false as const, error: "Không thể lưu bằng chứng học tập." };
+  // This compatibility path is intentionally attempt-only, so a partial failure cannot mutate
+  // learner mastery state. Persist sequentially to make the returned inserted count explicit.
+  for (const attempt of parsed.data.attempts) {
+    const args = compileLegacyAttemptRpcArgs({
+      sessionId: parsed.data.sessionId,
+      lessonId: parsed.data.lessonId,
+      attempt,
+    });
+    const { error } = await rpcClient.rpc("record_learning_attempt", args);
+    if (error) {
+      return {
+        success: false as const,
+        error: `Không thể lưu attempt tương thích (${inserted}/${parsed.data.attempts.length}): ${error.message}`,
+      };
+    }
+    inserted += 1;
   }
 
-  return { success: true as const, inserted: parsed.data.attempts.length };
+  return { success: true as const, inserted };
 }
 
 const trialCheckpointClaimSchema = z
@@ -132,8 +156,8 @@ export async function claimTrialCheckpoint(input: unknown) {
     };
   }
 
-  // Reuse the existing FSRS deck for communicative chunks after mastery is verified.
-  // Raw audio and transcripts are not persisted here.
+  // Reuse the existing FSRS deck for communicative chunks after the legacy checkpoint gate passes.
+  // This remains separate from canonical Nếp capability mastery evidence.
   const reviewSeed = await seedUnitVocabToSRS({
     vocab: GOLD_MISSION_01.targetChunks.map((chunk) => ({
       word: chunk.english,

--- a/src/app/actions/learning-attempts.ts
+++ b/src/app/actions/learning-attempts.ts
@@ -44,7 +44,7 @@ type RpcClient = {
 export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
   const parsed = LearningAttemptBatchSchema.safeParse(input);
   if (!parsed.success) {
-    return { success: false as const, error: "Dữ liệu lần học không hợp lệ." };
+    return { success: false as const, error: "Dữ liệu lần học không hợp lệ.", inserted: 0 };
   }
 
   const requestHeaders = await headers();
@@ -56,6 +56,7 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     return {
       success: false as const,
       error: "Quá nhiều lần ghi nhận. Vui lòng thử lại sau.",
+      inserted: 0,
     };
   }
 
@@ -65,7 +66,7 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     error: authError,
   } = await supabase.auth.getUser();
   if (authError || !user) {
-    return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ." };
+    return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ.", inserted: 0 };
   }
 
   const rpcClient = supabase as unknown as RpcClient;
@@ -84,6 +85,7 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
       return {
         success: false as const,
         error: `Không thể lưu attempt tương thích (${inserted}/${parsed.data.attempts.length}): ${error.message}`,
+        inserted,
       };
     }
     inserted += 1;

--- a/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
+++ b/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { compileLegacyAttemptRpcArgs } from "@/lib/learning/legacy-attempt-adapter";
+
+const baseAttempt = {
+  activityId: "unit-a0-1:checkpoint:q1",
+  status: "scored" as const,
+  score: 100,
+  errorTags: [],
+  evaluator: "deterministic-answer-key",
+  evaluatorVersion: "2.0.0",
+  latencyMs: 1200,
+};
+
+describe("compileLegacyAttemptRpcArgs", () => {
+  it("preserves a legacy checkpoint as attempt-only canonical history", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        modality: "checkpoint",
+      },
+    });
+
+    expect(result.p_knowledge_item_id).toBe(
+      "legacy:unit-a0-1:checkpoint:q1",
+    );
+    expect(result.p_response_modality).toBe("choice");
+    expect(result.p_correct).toBe(true);
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_evidence_target_id).toBeNull();
+    expect(result.p_capability_id).toBeNull();
+    expect(result.p_metadata).toMatchObject({
+      compatibilitySource: "legacy-learning-attempt-v1",
+      lessonId: "unit-a0-1",
+      legacyScore: 100,
+    });
+  });
+
+  it("does not turn a partial mission score into binary correctness or mastery evidence", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        activityId: "unit-a0-1:mission:mission-meet-new-colleague",
+        modality: "speaking",
+        score: 75,
+        errorTags: ["missing_intent:ask_name"],
+        evaluator: "deterministic-intent-match",
+      },
+    });
+
+    expect(result.p_response_modality).toBe("speech");
+    expect(result.p_correct).toBeNull();
+    expect(result.p_response_text).toBeNull();
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_metadata.legacyErrorTags).toEqual([
+      "missing_intent:ask_name",
+    ]);
+  });
+
+  it("does not infer an observable response modality for legacy listening-only activity metadata", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        activityId: "unit-a0-1:listening:1",
+        modality: "listening",
+        score: 0,
+      },
+    });
+
+    expect(result.p_response_modality).toBe("none");
+    expect(result.p_correct).toBe(false);
+    expect(result.p_evidence_type).toBeNull();
+  });
+});

--- a/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
+++ b/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
@@ -4,6 +4,7 @@ import { compileLegacyAttemptRpcArgs } from "@/lib/learning/legacy-attempt-adapt
 
 const baseAttempt = {
   activityId: "unit-a0-1:checkpoint:q1",
+  modality: "checkpoint" as const,
   status: "scored" as const,
   score: 100,
   errorTags: [],
@@ -76,5 +77,122 @@ describe("compileLegacyAttemptRpcArgs", () => {
     expect(result.p_response_modality).toBe("none");
     expect(result.p_correct).toBe(false);
     expect(result.p_evidence_type).toBeNull();
+  });
+
+  it("maps a failed checkpoint (score 0) to binary false while keeping evidence null", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        modality: "checkpoint",
+        score: 0,
+        errorTags: ["answer_mismatch"],
+      },
+    });
+
+    expect(result.p_correct).toBe(false);
+    expect(result.p_response_modality).toBe("choice");
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_response_text).toBeNull();
+  });
+
+  it("maps speaking and shadowing to speech modality without oral evidence or response text", () => {
+    for (const modality of ["speaking", "shadowing"] as const) {
+      const result = compileLegacyAttemptRpcArgs({
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        lessonId: "unit-a0-1",
+        attempt: {
+          ...baseAttempt,
+          activityId: `unit-a0-1:${modality}:1`,
+          modality,
+          score: 100,
+        },
+      });
+
+      expect(result.p_response_modality).toBe("speech");
+      expect(result.p_response_text).toBeNull();
+      expect(result.p_evidence_type).toBeNull();
+      expect(result.p_evidence_target_id).toBeNull();
+      expect(result.p_capability_id).toBeNull();
+      expect(result.p_metadata.legacyModality).toBe(modality);
+    }
+  });
+
+  it("maps writing to text modality and quiz/checkpoint to choice modality", () => {
+    const writing = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: { ...baseAttempt, modality: "writing", score: 100 },
+    });
+    expect(writing.p_response_modality).toBe("text");
+    expect(writing.p_response_text).toBeNull();
+
+    const quiz = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: { ...baseAttempt, modality: "quiz", score: 100 },
+    });
+    expect(quiz.p_response_modality).toBe("choice");
+    expect(quiz.p_response_text).toBeNull();
+  });
+
+  it("does not infer observable response modalities for non-interactive passive modalities", () => {
+    for (const modality of ["listening", "reading", "vocabulary", "grammar"] as const) {
+      const result = compileLegacyAttemptRpcArgs({
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        lessonId: "unit-a0-1",
+        attempt: {
+          ...baseAttempt,
+          activityId: `unit-a0-1:${modality}:1`,
+          modality,
+          score: 100,
+        },
+      });
+
+      expect(result.p_response_modality).toBe("none");
+      expect(result.p_response_text).toBeNull();
+      expect(result.p_evidence_type).toBeNull();
+    }
+  });
+
+  it("keeps p_correct null for unscored attempts regardless of score value", () => {
+    for (const status of ["unscored", "skipped", "unavailable"] as const) {
+      const result = compileLegacyAttemptRpcArgs({
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        lessonId: "unit-a0-1",
+        attempt: {
+          ...baseAttempt,
+          status,
+          score: 100,
+        },
+      });
+
+      expect(result.p_correct).toBeNull();
+      expect(result.p_evidence_type).toBeNull();
+      expect(result.p_metadata.legacyStatus).toBe(status);
+    }
+  });
+
+  it("guarantees universal null evidence fields and null capability_id across all calls", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: baseAttempt,
+    });
+
+    expect(result.p_capability_id).toBeNull();
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_evidence_target_id).toBeNull();
+    expect(result.p_evidence_success).toBeNull();
+    expect(result.p_evidence_confidence).toBeNull();
+    expect(result.p_evidence_context_id).toBeNull();
+    expect(result.p_evaluator).toBeNull();
+    expect(result.p_evidence_metadata).toEqual({});
+    expect(result.p_response_text).toBeNull();
+    expect(result.p_context_id).toBeNull();
+    expect(result.p_hint_count).toBe(0);
+    expect(result.p_reveal_used).toBe(false);
+    expect(result.p_support_level).toBe(0);
   });
 });

--- a/src/lib/learning/legacy-attempt-adapter.ts
+++ b/src/lib/learning/legacy-attempt-adapter.ts
@@ -1,0 +1,117 @@
+import type { LearningAttemptItem } from "@/lib/lessons/learning-attempt";
+
+export type CanonicalResponseModality =
+  | "choice"
+  | "text"
+  | "speech"
+  | "gesture"
+  | "none";
+
+export type LegacyAttemptRpcArgs = {
+  p_knowledge_item_id: string;
+  p_capability_id: null;
+  p_session_id: string;
+  p_exercise_type: string;
+  p_response_modality: CanonicalResponseModality;
+  p_prompt_id: string;
+  p_context_id: null;
+  p_response_text: null;
+  p_correct: boolean | null;
+  p_latency_ms: number | null;
+  p_hint_count: 0;
+  p_reveal_used: false;
+  p_support_level: 0;
+  p_metadata: {
+    compatibilitySource: "legacy-learning-attempt-v1";
+    lessonId: string;
+    activityId: string;
+    legacyModality: LearningAttemptItem["modality"];
+    legacyStatus: LearningAttemptItem["status"];
+    legacyScore: number | null;
+    legacyErrorTags: string[];
+    legacyEvaluator: string;
+    legacyEvaluatorVersion: string;
+  };
+  p_evidence_type: null;
+  p_evidence_target_id: null;
+  p_evidence_success: null;
+  p_evidence_confidence: null;
+  p_evidence_context_id: null;
+  p_evaluator: null;
+  p_evidence_metadata: Record<string, never>;
+};
+
+function responseModalityForLegacyAttempt(
+  modality: LearningAttemptItem["modality"],
+): CanonicalResponseModality {
+  switch (modality) {
+    case "speaking":
+    case "shadowing":
+      return "speech";
+    case "writing":
+      return "text";
+    case "quiz":
+    case "checkpoint":
+      return "choice";
+    case "vocabulary":
+    case "grammar":
+    case "listening":
+    case "reading":
+      return "none";
+  }
+}
+
+function binaryCorrectness(score: number | null): boolean | null {
+  if (score === 100) return true;
+  if (score === 0) return false;
+  return null;
+}
+
+/**
+ * Compatibility bridge for pre-Nếp lesson/mission callers.
+ *
+ * These callers do not carry enough canonical semantic identity to create trustworthy mastery
+ * evidence. Preserve their observations as immutable attempts through the canonical RPC, but do
+ * not fabricate capability/evidence events or mutate learner_skill_states.
+ */
+export function compileLegacyAttemptRpcArgs(input: {
+  sessionId: string;
+  lessonId: string;
+  attempt: LearningAttemptItem;
+}): LegacyAttemptRpcArgs {
+  const { sessionId, lessonId, attempt } = input;
+
+  return {
+    p_knowledge_item_id: `legacy:${attempt.activityId}`,
+    p_capability_id: null,
+    p_session_id: sessionId,
+    p_exercise_type: `legacy:${attempt.modality}`,
+    p_response_modality: responseModalityForLegacyAttempt(attempt.modality),
+    p_prompt_id: attempt.activityId,
+    p_context_id: null,
+    p_response_text: null,
+    p_correct: attempt.status === "scored" ? binaryCorrectness(attempt.score) : null,
+    p_latency_ms: attempt.latencyMs,
+    p_hint_count: 0,
+    p_reveal_used: false,
+    p_support_level: 0,
+    p_metadata: {
+      compatibilitySource: "legacy-learning-attempt-v1",
+      lessonId,
+      activityId: attempt.activityId,
+      legacyModality: attempt.modality,
+      legacyStatus: attempt.status,
+      legacyScore: attempt.score,
+      legacyErrorTags: attempt.errorTags,
+      legacyEvaluator: attempt.evaluator,
+      legacyEvaluatorVersion: attempt.evaluatorVersion,
+    },
+    p_evidence_type: null,
+    p_evidence_target_id: null,
+    p_evidence_success: null,
+    p_evidence_confidence: null,
+    p_evidence_context_id: null,
+    p_evaluator: null,
+    p_evidence_metadata: {},
+  };
+}

--- a/supabase/tests/database/learning_core.test.sql
+++ b/supabase/tests/database/learning_core.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(46);
+select plan(49);
 
 -- The July 2026 attempt schema must survive a fresh migration replay as an inaccessible archive,
 -- while the stable public name is reclaimed by the canonical Attempt -> Evidence contract.
@@ -550,6 +550,63 @@ select is(
   (select count(*) from public.get_learner_evidence_coverage(array['CAP-TRANSFER'])),
   0::bigint,
   'user 2 cannot observe user 1 aggregate evidence coverage'
+);
+
+reset role;
+
+-- Legacy attempt compatibility path (attempt-only, no evidence, no skill state mutation)
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"11111111-1111-4111-8111-111111111111","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '11111111-1111-4111-8111-111111111111', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+set local role authenticated;
+
+select lives_ok(
+  $$
+    select public.record_learning_attempt(
+      p_knowledge_item_id => 'legacy:unit-a0-1:checkpoint:q1',
+      p_capability_id => null,
+      p_session_id => '11111111-1111-4111-8111-111111111111',
+      p_exercise_type => 'legacy:checkpoint',
+      p_response_modality => 'choice',
+      p_prompt_id => 'unit-a0-1:checkpoint:q1',
+      p_context_id => null,
+      p_response_text => null,
+      p_correct => true,
+      p_latency_ms => 1200,
+      p_hint_count => 0,
+      p_reveal_used => false,
+      p_support_level => 0,
+      p_metadata => '{"compatibilitySource":"legacy-learning-attempt-v1","lessonId":"unit-a0-1"}'::jsonb,
+      p_evidence_type => null,
+      p_evidence_target_id => null,
+      p_evidence_success => null,
+      p_evidence_confidence => null,
+      p_evidence_context_id => null,
+      p_evaluator => null,
+      p_evidence_metadata => '{}'::jsonb
+    );
+  $$,
+  'authenticated user can record compatibility attempt-only history'
+);
+
+select is(
+  (select count(*) from public.learning_evidence_events
+   where user_id = '11111111-1111-4111-8111-111111111111'
+     and attempt_id in (select id from public.learning_attempts where knowledge_item_id = 'legacy:unit-a0-1:checkpoint:q1')),
+  0::bigint,
+  'compatibility attempt creates zero evidence events'
+);
+
+select is(
+  (select count(*) from public.learner_skill_states
+   where user_id = '11111111-1111-4111-8111-111111111111'
+     and target_id = 'legacy:unit-a0-1:checkpoint:q1'),
+  0::bigint,
+  'compatibility attempt creates zero learner skill state mutations'
 );
 
 reset role;


### PR DESCRIPTION
Superseded during PROJECT-RESET-001 by a clean P0 port from current `main@2b85d1c835b3590c4093b14e79a612c1fd30c574` on branch `fix/legacy-attempt-rpc-v2`.

The underlying production compatibility finding remains valid: canonical learner tables reject direct authenticated inserts and `record_learning_attempt(...)` is the supported write boundary. History and this reviewed patch remain preserved here; do not merge this stale branch.