### PR TITLE
Add realtime WebRTC speech capture V1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
+# OpenAI Realtime — server-only key, never expose with NEXT_PUBLIC_*
+OPENAI_API_KEY=
+
 # Upstash Redis — Rate Limiting (Production)
 # Đăng ký tại https://upstash.com (free tier: 10k requests/day)
 # Dashboard > Create Database > REST API tab

--- a/AGENT_BACKLOG.md
+++ b/AGENT_BACKLOG.md
@@ -1,55 +1,95 @@
 # Agent Backlog — Active Tasks Only
 
-> Use `docs/product/CURRENT_PRIORITY.md` for ordering and `docs/product/DO_NOT_BUILD.md` for deferred scope.
+> Use `docs/product/CURRENT_PRIORITY.md` for ordering, `docs/product/DO_NOT_BUILD.md` for guardrails and `docs/product/FRONTIER_LEDGER.md` for material frontier gaps.
 
 ## Rules
 
 1. Use a dedicated branch and reviewed pull request.
 2. Never merge or deploy automatically.
 3. Keep one bounded outcome per pull request.
-4. Every task must name the current AtoEnglish blocker it resolves.
-5. Do not add cleanup, abstraction, infrastructure, or agent capability without a current product need.
-6. Stop and document ambiguous behavior instead of guessing.
-7. Completed work belongs in Git history and pull requests, not the active backlog.
+4. Every task must identify the learner/evidence/frontier gap it closes.
+5. Reuse current AtoEnglish code before adding a parallel system.
+6. Check maintained external implementations before custom-building commodity infrastructure.
+7. External reuse requires license, security, privacy, maintenance, compatibility and cost review.
+8. Passing technical checks is not learner validation.
+9. Do not let model sophistication override evidence integrity.
+10. Completed work belongs in Git history/pull requests, not this active backlog.
 
 ## Active queue
 
-### PRODUCT-001 — Product truth and agent constitution
+### FRONTIER-001 — Product truth and Frontier Ledger
 
 - **Status:** `in_progress`
-- **Outcome:** Repository-owned product truth, active priority, do-not-build boundary, and agent operating contract.
-- **Scope:** Documentation only.
-- **Blocked by:** Nothing.
+- **Outcome:** repository guidance reflects the 2026 frontier objective while preserving outcome-first evidence and privacy rules.
+- **Scope:** documentation only.
+- **Branch:** `frontier/product-truth-2026-09`.
 
-### TOOLING-001 — Focused verification entry point
+### FRONTIER-002 — Canonical adaptive runtime convergence
 
-- **Status:** `ready_after_product_001`
-- **Outcome:** One command or manifest that selects and reports existing checks for a focused AtoEnglish change.
-- **Initial consumer:** The Gold Day 1 curriculum pull request.
-- **Required behavior:** Report executed, passed, failed, and unavailable checks; distinguish technical checks from manual product review.
-- **Forbidden scope:** Product behavior, new CI platform, generic orchestration framework, remote sandbox, auto-merge, auto-deploy.
+- **Status:** `ready_after_frontier_001`
+- **Outcome:** one authoritative learner-facing adaptive execution path built on the already-integrated Nếp practice compiler and `record_learning_attempt` RPC.
+- **Initial audit:** identify remaining legacy score-only/direct-write paths such as the older mission runtime and prevent them from becoming the new proving surface.
+- **Keep:** canonical Attempt → Evidence → LearnerSkillState, privacy-safe oral observation, Error Memory V1, Session Planner V1, adaptive practice queue.
+- **Forbidden:** new database model, new mastery store, broad curriculum rewrite, pronunciation score.
 
-### CURRICULUM-001 — Gold Day 1 lesson
+### FRONTIER-003 — Realtime voice benchmark and transport V1
 
-- **Status:** `blocked`
-- **Blocked by:** PRODUCT-001 and TOOLING-001.
-- **Outcome:** A 10–15 minute Day 1 lesson for greeting, name, Vietnamese-name spelling, one lightweight repeat request, and one final spoken output.
-- **Expected scope:** `src/lib/data/units/unitA01.ts`, direct targeted tests, and the smallest relevant lesson smoke assertion.
-- **Forbidden scope:** Role, company, responsibility, all five questions, full repair training, auth, database, analytics infrastructure, XP, FSRS, unrelated units, and major `UnitTemplate` refactor.
+- **Status:** `blocked_by_frontier_002`
+- **Outcome:** replace one-turn browser speech UX in the adaptive proving surface with a low-latency, interruptible realtime voice path while keeping server-authoritative learning evidence.
+- **First external candidate:** official OpenAI Realtime/Agents SDK reference implementation for Next.js/TypeScript.
+- **Comparison candidate:** LiveKit AgentsJS if provider portability/production voice infrastructure justifies additional complexity.
+- **Measure:** end-of-turn latency, interruption/turn reliability, mobile/browser support, cost, failure rate, privacy boundary.
+- **Forbidden:** realtime model writing mastery directly; raw-audio analytics persistence by default.
 
-### PILOT-OPS-001 — Recruit and operate the first learner pilot
+### FRONTIER-004 — Calibrated speech diagnostics V1
 
-- **Status:** `planned`
-- **Starts when:** The first-week journey and baseline flow are usable enough for real learners.
-- **Outcome:** Obtain learner, learning, support-cost, and payment evidence.
-- **Default approach:** Manual operations before new infrastructure.
+- **Status:** `blocked_by_frontier_003`
+- **Outcome:** establish a real acoustic evidence path for high-value pronunciation/intelligibility feedback.
+- **Current correct behavior:** pronunciation scoring remains unavailable rather than derived from transcript matching.
+- **Work:** benchmark candidate providers/models, define Vietnamese-learner calibration sample and human rating protocol, then expose only claims supported by calibration.
+- **Forbidden:** native-accent imitation objective, opaque fake score, transcript-only phoneme claims.
+
+### FRONTIER-005 — Adaptive vertical-slice learner validation
+
+- **Status:** `blocked_by_frontier_002/003`
+- **Outcome:** real learner can complete a bounded loop:
+  `recognition → retrieval → production → feedback → repair/retry → changed-context transfer → delayed retrieval`.
+- **Measure:** activation, independent success, feedback→repair, retry improvement, transfer, delay/retention and learner minutes.
+
+### FRONTIER-006 — Planner calibration
+
+- **Status:** `blocked_by_real_data`
+- **Outcome:** calibrate deterministic Session Planner weights/gates from longitudinal AtoEnglish evidence and compare against simpler baselines.
+- **Do not start with:** neural KT, RL or bandits.
+
+### FRONTIER-007 — Probabilistic learner-model benchmark
+
+- **Status:** `blocked_by_real_data`
+- **Outcome:** benchmark knowledge-tracing/probabilistic models offline only if the dataset is large and structured enough for meaningful validation.
+- **External research candidate:** pyKT or equivalent benchmark toolkit.
+- **Promotion rule:** complexity enters production only if it predicts/plans learner outcomes better than current explainable rules.
+
+### FRONTIER-008 — Frontier expansion
+
+- **Status:** `later`
+- **Outcome:** systematically close remaining ledger items in listening decoding, vocabulary/chunk memory, grammar-in-use, broader skills, real-world transfer, self-regulation, assessment and experimentation.
+- **Ordering:** expected learner value and measurement quality, not feature count.
+
+## Current external-reuse shortlist
+
+- `openai/openai-realtime-agents` / OpenAI Agents SDK Realtime patterns — best first fit for current Next.js/TypeScript stack.
+- LiveKit AgentsJS — compare when multi-provider production voice infrastructure becomes necessary.
+- browser/Silero VAD libraries — optional only if native/provider turn detection is insufficient and mobile compatibility is acceptable.
+- pyKT — offline learner-model benchmark later, not a runtime dependency now.
+- GrowthBook or equivalent — later, only when experimentation operations become a real bottleneck.
 
 ## Interrupt policy
 
-Only these may interrupt the queue:
+These may interrupt the queue:
 
-- a production defect blocking the pilot journey;
-- a security, privacy, or data-integrity defect;
-- a repeated development blocker observed in at least two real AtoEnglish tasks.
+- security/privacy/data-integrity defect;
+- production defect blocking the current proving surface;
+- new research/technology that materially changes a frontier decision;
+- repeated development blocker that materially slows frontier implementation.
 
-An interrupt still requires explicit scope, acceptance criteria, verification, and a separate pull request.
+An interrupt still requires bounded scope, acceptance criteria, verification and rollback.

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -1,45 +1,81 @@
 # Agent Plan — Current Work Only
 
-> Product direction is defined in `docs/product/PRODUCT_TRUTH.md`. Ordered work is defined in `docs/product/CURRENT_PRIORITY.md`.
+> Product direction is defined in `docs/product/PRODUCT_TRUTH.md`. Ordered work is defined in `docs/product/CURRENT_PRIORITY.md`. Material frontier gaps are tracked in `docs/product/FRONTIER_LEDGER.md`.
 
 ## Current task
 
 | Field | Value |
 |---|---|
-| Task | PRODUCT-001 — Encode AtoEnglish product truth and agent development rules |
+| Task | FRONTIER-001 — Align repository product truth with the 2026 frontier objective |
 | Status | in progress — documentation-only pull request |
-| Goal | Make the current 28-day pilot direction discoverable and prevent agents from selecting stale cleanup or premature feature work |
+| Goal | Remove stale policy conflicts so future bounded implementation can reuse current code and current external technology to maximize measurable learner outcomes |
 
-## Scope
+## Problem
 
-This task may change only repository guidance and planning documents:
+Repository guidance from 2026-07-24 still forbids realtime AI conversation, phoneme-level diagnostics and other advanced adaptive/speech work until the old focused pilot is validated. The owner has explicitly changed the product objective: AtoEnglish should be pushed to the practical frontier of current learning science and technology, with learner outcomes—not feature comparisons—determining whether it is best.
 
-- `AGENTS.md`
+Main has also advanced substantially since the old guidance: Nếp adaptive learning core V1 is now integrated and production database verification has passed. The documentation therefore understates the current implementation and blocks the next intended work.
+
+## Outcome
+
+After this task:
+
+- Durable Transferable Learning Gain per Minute is the north star;
+- the Vietnamese false-beginner speaking slice remains the first measurable proving ground, not the permanent product ceiling;
+- realtime voice, calibrated speech diagnostics and adaptive-learning technology are allowed when bounded by evidence/privacy;
+- reuse of maintained external/open-source implementations is explicitly preferred when it shortens the path safely;
+- fake mastery/pronunciation evidence remains prohibited;
+- a Frontier Ledger provides a finite definition of what remains before current-frontier completion.
+
+## Allowed files
+
+- `docs/product/**`
 - `AGENT_PLAN.md`
 - `AGENT_BACKLOG.md`
-- `docs/product/**`
 
-It must not change product runtime, lesson data, tests, dependencies, database, authentication, analytics, XP, FSRS, payment, or deployment behavior.
+## Forbidden scope
 
-## Acceptance
+This pull request must not change:
 
-- The target learner, 28-day promise, final speaking outcome, and evidence hierarchy are explicit.
-- Agents have one mandatory reading order and one task-contract format.
-- The active priority and deferred scope are explicit.
-- Historical cleanup tasks no longer appear as current work.
-- No runtime source or configuration changes are included.
+- runtime product code;
+- lesson content;
+- dependencies;
+- database schema/RLS;
+- authentication;
+- analytics taxonomy;
+- FSRS parameters;
+- deployment behavior.
 
-## Completed baseline
+## Acceptance criteria
 
-The repository already contains:
+- Product truth reflects the owner’s 2026-09-03 objective.
+- Current priority starts from the Nếp adaptive core already merged to `main`.
+- Advanced technology is gated by learner value/evidence rather than categorically deferred.
+- External reuse requires license/security/privacy/maintenance/compatibility checks.
+- Frontier Ledger has explicit statuses and a critical path.
+- No marketing claim of “best in world” is made without learner evidence.
 
-- aligned pilot promise;
-- baseline/final speaking assessment and rubric;
-- privacy-bounded pilot analytics;
-- Supabase security hardening;
-- a repository-owned 28-day speaking-journey contract;
-- an explicit Day 1 lesson boundary.
+## Technical checks
 
-## Next action
+Documentation-only review:
 
-Review and merge this documentation reset. The next separate task is TOOLING-001: create one small verification entry point for a focused AtoEnglish curriculum slice without changing product behavior.
+- inspect final diff for internal contradictions;
+- verify referenced repository paths exist;
+- do not claim application tests ran unless they actually run on this branch.
+
+## Product checks
+
+Manual review should answer:
+
+- Does the new policy optimize learner ability rather than competitor parity?
+- Does it permit frontier technology without making AI the mastery authority?
+- Does it preserve privacy and evidence integrity?
+- Does it keep a measurable first proving ground while allowing broader eventual scope?
+
+## Rollback
+
+Close the branch/PR without merge. `main` remains unchanged.
+
+## Next task
+
+`FRONTIER-002 — Canonical adaptive runtime convergence and learner-surface audit`, followed by a separate realtime-voice benchmark/integration slice.

--- a/docs/product/CURRENT_PRIORITY.md
+++ b/docs/product/CURRENT_PRIORITY.md
@@ -1,130 +1,189 @@
 # AtoEnglish current priority
 
-**Updated:** 2026-07-24  
-**Owner:** Thunderkill016  
-**Primary roadmap:** GitHub issue #20
+**Updated:** 2026-09-03  
+**Owner:** Thunderkill016
 
 ## North star
 
-Prove that one Vietnamese adult beginner can follow a coherent 28-day, 10–15 minute-per-day journey and improve a practical work-speaking performance.
+Maximize **Durable Transferable Learning Gain per Minute** for the target learner, using the best currently practical science and technology while preserving trustworthy learner evidence.
 
-Everything else is secondary until the repository can support and measure that journey.
+The immediate proving ground remains Vietnamese beginner/false-beginner spoken English because it gives AtoEnglish a narrow, measurable environment in which to validate the learning engine. It is not the permanent product ceiling.
 
 ## Current phase
 
-**Phase: make AtoEnglish safe and legible for AI-assisted development, then implement the first gold lesson.**
+**Phase: close the gap between the already-integrated Nếp adaptive core and a frontier-quality learner loop.**
 
-The repository already has enough application, authentication, assessment, analytics, database, and testing infrastructure for bounded curriculum work. The immediate risk is not missing platform capability. It is allowing agents to choose work that does not serve the pilot outcome.
+Main already contains the Nếp adaptive-learning foundation: canonical Attempt → Evidence → LearnerSkillState persistence, privacy-safe oral observations, Error Memory V1, deterministic Session Planner V1, trusted practice execution and an authenticated adaptive preview.
+
+The immediate risk is now fragmentation: legacy mission/unit paths still coexist with the canonical adaptive path, browser SpeechRecognition remains the main speech transport, pronunciation assessment is intentionally unavailable, and real learner evidence is still sparse.
 
 ## Ordered queue
 
-### 1. Product and agent truth — in progress
+### 1. Frontier product truth and ledger — now
 
-Establish repository-owned rules that every agent can read before proposing work:
+Align repository-owned guidance with the owner’s current objective:
 
-- `AGENTS.md`;
-- `docs/product/PRODUCT_TRUTH.md`;
-- this current-priority document;
-- `docs/product/DO_NOT_BUILD.md`;
-- current `AGENT_PLAN.md` and `AGENT_BACKLOG.md`.
+- outcome-first rather than competitor-first;
+- reuse existing AtoEnglish code aggressively;
+- adopt maintained external/open-source code where appropriate;
+- allow realtime voice, speech diagnostics and adaptive technology when bounded by evidence/privacy;
+- keep claims proportional to validated learner evidence;
+- maintain a Frontier Ledger of known gaps and current scientific/technical limits.
 
-**Done when:** the repository has one discoverable product direction, stale cleanup plans no longer select work, and every future task must show how it serves the current priority.
+**Done when:** repository guidance no longer forbids work that the current frontier objective explicitly requires, while still preventing novelty-driven scope expansion.
 
-### 2. One verification entry point — next
+### 2. Canonical learning runtime convergence — next
 
-Create the smallest repository-owned verification wrapper or manifest that maps a changed surface to the checks already available.
+Remove or bypass parallel learning truth paths in the proving surface.
 
-Initial goal:
+Initial goals:
 
-- preserve existing commands rather than inventing a new CI system;
-- support a focused curriculum slice first;
-- report which checks ran, passed, failed, or were unavailable;
-- distinguish technical checks from manual product review;
-- make the result usable by a coding agent and by the owner.
+- the learner-facing adaptive path uses `recordNếpPracticeAttempt()` and the canonical `record_learning_attempt` RPC;
+- no new mastery evidence is written through legacy score-only attempt schemas;
+- learner state, Error Memory and Session Planner consume the same canonical evidence history;
+- reveal/support/modality/transfer invariants remain server/database authoritative;
+- raw transcripts are not persisted by default.
 
-This task must not change product behavior.
+This is primarily integration/convergence, not a new learning algorithm.
 
-### 3. Gold Day 1 lesson — after verification entry point
+### 3. Frontier voice transport V1
 
-Implement the preferred Day 1 design from `docs/curriculum/28-day-speaking-journey-contract.md`.
+Benchmark and integrate the best practical realtime voice path for the current Next.js application.
 
-Day 1 should cover only:
+Preferred first benchmark:
 
-- greeting;
-- name;
-- spelling a Vietnamese name;
-- one lightweight request to repeat;
-- one final spoken output using name and spelling.
+- official OpenAI Realtime/Agents SDK patterns because a maintained Next.js TypeScript reference implementation exists and integration distance is small;
+- LiveKit AgentsJS as the portability/production-infrastructure comparison when multi-provider routing or advanced realtime infrastructure justifies it;
+- local/browser VAD only when it improves turn handling beyond provider-native capabilities and browser support is acceptable.
 
-It must fit 10–15 minutes and must not absorb role, company, responsibility, all five questions, or full repair training.
+Required boundaries:
 
-Expected scope:
+- realtime model owns conversation latency and turn-taking, not mastery truth;
+- canonical server evaluation/evidence remains authoritative;
+- voice can be interrupted naturally;
+- typed fallback remains non-speaking evidence;
+- no raw audio/transcript analytics persistence by default;
+- cost/latency/reliability are measured.
 
-- `src/lib/data/units/unitA01.ts`;
-- direct targeted tests;
-- the smallest relevant lesson smoke assertion.
+### 4. Speech diagnostics and Vietnamese calibration
 
-Explicitly out of scope:
+Current `assessPronunciation()` correctly returns unavailable rather than fabricating a phoneme score. Replace that gate only after a real acoustic assessment path is benchmarked.
 
-- authentication;
-- database and RLS;
-- analytics infrastructure;
-- XP, streak, league, and FSRS rules;
-- major `UnitTemplate` refactor;
-- unrelated units.
+Evaluate available systems for:
 
-### 4. First-week journey — later
+- phoneme/word accuracy;
+- stress, rhythm, fluency and prosody where reliable;
+- intelligibility/comprehensibility relevance;
+- Vietnamese learner performance;
+- API latency/cost/privacy;
+- calibration against human raters on a bounded sample.
 
-After Day 1 is proven coherent, implement Days 2–7 as separate bounded outcomes and add checkpoint 1.
+Do not optimize for native-accent imitation.
 
-Do not build all 28 days in one pull request.
+### 5. Adaptive proving surface
 
-### 5. Pilot operations and learner evidence
+Turn `/adaptive-preview` from an engineering preview into a small learner-ready vertical slice driven by learner state.
 
-Recruit target learners, run baseline assessment, sell or manually administer the initial pilot, observe failure points, and build only repeated P0 blockers.
+The first slice should exercise:
 
-## Decisions already completed
+```text
+recognition/comprehension
+→ retrieval
+→ speech production
+→ concise feedback
+→ self-repair/retry
+→ changed-context transfer
+→ delayed retrieval
+```
 
-- `/login` metadata defect was fixed.
-- The pilot promise was aligned across the main funnel.
-- Baseline and final speaking assessment plus rubric were defined.
-- Minimal privacy-bounded pilot analytics were added and recovered correctly.
-- Supabase security findings were hardened.
-- The 28-day journey contract and Day 1 boundary were defined.
+The UI should emphasize the next useful action, not internal planner diagnostics.
 
-Do not reopen these decisions without new evidence.
+### 6. Real learner evidence
+
+Recruit and observe real target learners as soon as the bounded vertical slice is usable.
+
+Measure at minimum:
+
+- start and first independent attempt;
+- completion;
+- feedback → repair;
+- retry improvement;
+- changed-context transfer;
+- delayed retention;
+- learner time;
+- failure/drop-off reason.
+
+Use blinded or human-calibrated evaluation for claims that automated evidence cannot support yet.
+
+### 7. Planner/model evolution
+
+Do not jump directly to neural knowledge tracing or reinforcement learning.
+
+Progress only when data supports it:
+
+```text
+current deterministic planner
+→ calibrated rules
+→ probabilistic learner model/KT benchmark
+→ learning-gain prediction
+→ contextual adaptive policy if demonstrably better
+```
+
+A more complex model must beat the simpler baseline on learner-relevant evaluation.
+
+### 8. Frontier expansion
+
+After the core loop is validated, systematically close remaining Frontier Ledger items across:
+
+- listening decoding;
+- speech/pronunciation;
+- vocabulary/chunk memory;
+- grammar-in-use;
+- writing/reading where appropriate;
+- broader capability graph and levels;
+- self-regulation and transition to real-world use;
+- human/peer transfer;
+- assessment quality;
+- experimentation and causal measurement.
+
+Expansion is driven by the same north-star metric, not feature count.
+
+## Reuse-first rule
+
+Before custom implementation:
+
+1. inspect current AtoEnglish code;
+2. inspect maintained libraries/public implementations;
+3. verify license, maintenance, security, privacy, compatibility and cost;
+4. prefer adaptation when it shortens time to valid learner evidence;
+5. custom-build only where AtoEnglish needs a distinct learning/evidence mechanism or external solutions fail the requirement.
 
 ## Work selection rule
 
-A proposed task may enter the active queue only when it does at least one of the following:
+A proposed task enters the active queue when it does at least one of the following:
 
-1. directly advances the ordered queue above;
-2. fixes a production defect blocking the pilot journey;
-3. fixes a security, privacy, or data-integrity defect;
-4. removes a repeated development blocker observed in at least two real AtoEnglish tasks.
+1. closes a material Frontier Ledger gap;
+2. connects already-built learning infrastructure that is currently fragmented;
+3. fixes a learner, evidence-integrity, privacy, security or production blocker;
+4. produces trustworthy learner evidence needed to choose between competing approaches;
+5. removes a repeated development blocker that materially slows the frontier program.
 
-Every proposal must name the learner, product, or development blocker it resolves.
+Technical novelty alone is not sufficient.
 
-## Time allocation
+## Exit criteria for the current phase
 
-Until the first pilot is ready:
-
-- 80–90% of effort should improve AtoEnglish and the pilot journey;
-- no more than 10–20% should improve CycleWarden or development tooling;
-- tooling work must be justified by a current AtoEnglish blocker.
-
-## Exit criteria for this phase
-
-This phase is complete when the owner can take one approved AtoEnglish task through:
+The current phase is complete when a real learner can enter one bounded adaptive speaking slice and the system can reliably execute:
 
 ```text
-current priority
-→ bounded task contract
-→ approved scope
-→ coding agent implementation
-→ technical and product checks
-→ understandable review summary
-→ draft pull request
+learner state
+→ next-task selection
+→ natural voice interaction
+→ trusted attempt/evidence
+→ concise feedback
+→ repair/retry
+→ changed-context transfer
+→ delayed retrieval
+→ updated learner state
 ```
 
-without writing an ad hoc manifest, losing product context, changing unrelated systems, or automatically merging or deploying.
+with privacy boundaries intact and without relying on fabricated pronunciation/mastery claims.

--- a/docs/product/DO_NOT_BUILD.md
+++ b/docs/product/DO_NOT_BUILD.md
@@ -1,118 +1,183 @@
 # AtoEnglish do-not-build list
 
-**Updated:** 2026-07-24  
-**Applies until:** the focused 28-day pilot has learner, learning, and market evidence
+**Updated:** 2026-09-03  
+**Purpose:** prevent wasted complexity while AtoEnglish deliberately pushes toward the current learning-technology frontier.
 
-This document prevents technically attractive work from displacing the current product priority.
+This document no longer bans advanced technology merely because it is advanced. Realtime voice, speech diagnostics, adaptive planning and AI-assisted learning are allowed when they close a measurable learner-outcome gap and preserve evidence integrity.
 
-Items below are not necessarily bad ideas. They are deferred because they do not currently provide the shortest path to validating the first learner outcome.
+The rules below prevent AtoEnglish from confusing frontier development with indiscriminate feature accumulation.
 
-## Product breadth
+## Do not build parallel learning truth
 
-Do not build yet:
+Do not create another independent system for:
 
-- a complete rebuild or expansion of the A0–B2/C1 curriculum;
-- broad interview English, travel English, or general conversation tracks;
-- a native mobile application;
-- a curriculum CMS or visual lesson editor;
-- social feeds, friend systems, clubs, or multiplayer learning;
-- more leagues, badges, achievements, streak mechanics, or XP breadth;
-- a custom payment platform;
-- complex subscriptions, entitlement systems, or pricing experiments before paid demand exists.
+- learner mastery;
+- attempt history;
+- evidence events;
+- error memory;
+- session planning;
+- transfer/retention state;
+- FSRS-compatible memory scheduling.
 
-## AI and speaking technology
+Main already contains canonical foundations for these areas. Extend or replace them only through a bounded migration with explicit reasons and compatibility/rollback plans.
 
-Do not build yet:
+## Do not build technology for its own sake
 
-- an open-ended AI conversation tutor;
-- unrestricted chatbot practice detached from the current lesson;
-- a proprietary speech-recognition model;
-- phoneme-level pronunciation scoring infrastructure;
-- native-accent imitation scoring;
-- autonomous curriculum generation or publication;
-- storing raw audio, transcripts, names, employers, or learner free text in analytics.
+Do not add:
 
-Use controlled lesson tasks, existing browser capabilities, bounded feedback, immediate retry, and human assessment where they are sufficient.
+- AI agents that do not improve a specific learning loop;
+- multi-agent orchestration because it looks more advanced;
+- neural knowledge tracing without enough valid data to calibrate and beat a simpler baseline;
+- reinforcement learning/contextual bandits before reliable reward/evaluation data exists;
+- a custom ASR/TTS/foundation model when maintained external systems satisfy the requirement more safely/economically;
+- a microservice split without a measured runtime/ownership blocker;
+- a monorepo/package architecture without a real second deployment/reuse boundary;
+- speculative scale infrastructure before a measured bottleneck;
+- a second analytics or database platform without a concrete requirement the current stack cannot satisfy.
 
-## Architecture and infrastructure
+## Do not fake learning evidence
 
-Do not build yet:
+Never:
 
-- a major rewrite of `UnitTemplate`;
-- a microservice migration;
-- a new generic workflow engine;
-- infrastructure solely for hypothetical scale;
-- a second database or event platform;
-- a new design system unrelated to pilot blockers;
-- broad dependency upgrades mixed with product work;
-- generalized abstractions without two real use cases;
-- remote sandbox infrastructure for ordinary trusted repository work;
-- automated merge or production deployment by an agent.
+- equate completion with mastery;
+- count an answer-bearing reveal as independent retrieval/production/repair/transfer evidence;
+- count typed text fallback as speaking evidence;
+- derive pronunciation mastery from transcript matching alone;
+- report a phoneme/pronunciation/comprehensibility score without an acoustic evidence path and calibration appropriate to the claim;
+- manufacture prerequisite mastery to fill an adaptive queue;
+- let the browser declare correctness, evidence type, evaluator identity or target mastery when the server can resolve them canonically;
+- silently reinterpret missing evidence as failure or success when the correct state is unknown.
 
-Preserve the current modular monolith and extract only when a measured blocker requires it.
+## Do not turn AI into an unconstrained teacher
 
-## CycleWarden and developer tooling
+Do not expose a generic open-ended chatbot as the core learning experience with no task/evidence policy.
 
-Do not expand CycleWarden with:
+Realtime or generative AI must operate inside explicit boundaries such as:
 
-- generic multi-agent orchestration;
-- additional coding-agent adapters before the primary Codex flow is useful on AtoEnglish;
-- enterprise RBAC, SSO, compliance mappings, or organization governance;
-- general web-research or product-research platforms;
-- release and deployment automation;
-- outcome-learning or self-improvement engines;
-- new journals, records, digests, or abstractions without a current AtoEnglish blocker;
-- work that cannot be demonstrated on a real AtoEnglish task.
+- current capability/task;
+- allowed difficulty/language resources;
+- learner-state inputs;
+- support/reveal policy;
+- feedback budget;
+- transfer conditions;
+- privacy boundary;
+- trusted server-side evidence compilation.
 
-CycleWarden is an internal development supervisor for AtoEnglish in this phase, not a second product that competes for equal attention.
+Generated content must not become canonical curriculum or mastery truth solely because a model produced it.
 
-## Premature measurement
+## Do not optimize the wrong metric
 
-Do not treat these as primary proof of product value:
+Do not treat these as proof of learning effectiveness:
 
-- total registered accounts;
-- page views without speaking-task activation;
-- XP earned;
+- DAU/MAU alone;
+- time in app;
 - streak length;
-- lesson screens opened;
+- XP;
+- lessons/screens opened;
+- number of generated conversations;
+- number of AI tokens/minutes consumed;
 - repository test counts;
 - CI success;
-- positive comments about visual design without completion or speaking evidence.
+- visual-design preference without task success;
+- learner satisfaction without ability evidence.
 
-The important evidence is activation, return, journey completion, speaking improvement, support cost, payment, renewal, and referral.
+They may be useful operational metrics, but the product north star is durable transferable learning gain per learner minute.
 
-## Scope mixing
+## Do not overcorrect pronunciation toward nativeness
 
-Do not combine a lesson outcome with changes to:
+Do not build or market:
 
-- authentication or onboarding;
-- database schema or RLS;
-- analytics infrastructure;
-- XP, stars, streaks, leagues, achievements, or FSRS;
-- payment;
-- deployment;
-- broad architecture;
-- unrelated lessons.
+- native-accent imitation as the default goal;
+- a single opaque pronunciation percentage presented as ground truth;
+- punitive correction of harmless accent features that do not materially affect intelligibility/comprehensibility;
+- speech feedback that overwhelms the communication task.
 
-Create separate tasks with separate evidence.
+Prioritize high-impact intelligibility, comprehensibility, fluency and repair needs, with Vietnamese-specific calibration where possible.
 
-## Exception rule
+## Do not persist sensitive learner speech by default
 
-A deferred item may be reconsidered only when all of the following are documented:
+Do not persist raw audio, full transcripts, names, employers or free-form learner speech in analytics by default.
 
-1. the exact current AtoEnglish blocker;
-2. evidence that the blocker occurred in a real learner or development flow;
-3. why an existing simpler solution is insufficient;
-4. the smallest reversible implementation;
-5. acceptance criteria and rollback plan;
-6. the systems explicitly left out of scope.
+Prefer:
 
-Security, privacy, or data-integrity defects may bypass the normal product queue, but they still require bounded scope and verification.
+- transient processing;
+- derived structured evidence;
+- bounded error tags/signals;
+- explicit retention and access rules.
 
-## Default response to new ideas
+Richer speech data may be collected only under a separately reviewed research/calibration protocol with a clear reason, consent/notice as required, retention policy and deletion path.
 
-When a new feature idea appears, ask:
+## Do not copy external code blindly
 
-> Does this help a target learner start, complete, improve, pay for, or return to the current 28-day speaking journey?
+External/open-source reuse is encouraged, but never copy or vendor code without checking:
 
-If the answer is not supported by current evidence, record the idea and continue the active priority instead of implementing it.
+- license compatibility;
+- repository/activity/maintenance state;
+- security implications and dependency surface;
+- framework/runtime compatibility;
+- bundle/client cost;
+- privacy/data routing;
+- operational/API cost;
+- whether adaptation is actually cheaper than a small local implementation.
+
+Prefer official SDK/reference implementations when they directly match the task.
+
+## Do not broaden curriculum before the engine needs it
+
+Do not expand large curriculum breadth merely to create the appearance of completeness.
+
+New capabilities/content should be added when they:
+
+- exercise a missing learning mechanism;
+- serve a validated learner need;
+- are required for transfer/retention measurement;
+- extend a proven engine to the next meaningful learner outcome.
+
+The existing 50-unit catalog is an asset but not a mandate to preserve unit-first product behavior.
+
+## Do not mix unrelated risk domains in one change
+
+Keep separate pull requests for materially independent work such as:
+
+- product policy/docs;
+- canonical evidence/runtime convergence;
+- realtime voice dependency/infrastructure;
+- pronunciation/speech scoring;
+- database/RLS migrations;
+- analytics taxonomy;
+- curriculum expansion;
+- gamification;
+- deployment infrastructure.
+
+A task may cross boundaries only when the feature cannot function otherwise and the coupling, verification and rollback are explicit.
+
+## Do not auto-merge or auto-deploy frontier changes
+
+Agents may create branches, commits, tests and pull requests. The owner retains final merge/deployment authorization.
+
+Production behavior involving authentication, learner evidence, speech privacy, database schema, AI providers or scoring must have a reversible rollout path.
+
+## Current allowed frontier work
+
+The following are explicitly allowed when implemented as bounded, reversible slices:
+
+- converging legacy learning UI onto the canonical Nếp Attempt/Evidence runtime;
+- realtime WebRTC voice using maintained SDK/reference implementations;
+- conversation turn-taking and interruption handling;
+- acoustic pronunciation/speech diagnostics behind calibration gates;
+- Vietnamese-specific speech benchmarking/calibration;
+- improved listening/decoding practice;
+- Error Memory and remediation improvements;
+- transfer and delayed-retention practice;
+- explainable adaptive session planning;
+- external open-source/library reuse;
+- experiments that can measure learner outcome differences;
+- more advanced learner models after real data supports them.
+
+## Default decision rule
+
+For a proposed frontier feature ask:
+
+> What current learner/evidence limitation does this remove, what simpler existing option was considered, what outcome should improve, and how will we know whether it actually did?
+
+If those answers are weak, do not build it yet. If they are strong, build the smallest reversible version and measure it.

--- a/docs/product/FRONTIER_LEDGER.md
+++ b/docs/product/FRONTIER_LEDGER.md
@@ -1,0 +1,97 @@
+# AtoEnglish Frontier Ledger
+
+**Updated:** 2026-09-03  
+**Purpose:** finite inventory of material gaps between the current repository and the best practical English-learning system AtoEnglish can build with current science and technology.
+
+## Status definitions
+
+- `KNOWN_NOT_IMPLEMENTED` — useful mechanism is known but missing.
+- `AVAILABLE_NOT_INTEGRATED` — external technology/implementation exists but is not safely integrated.
+- `IMPLEMENTED_NOT_VALIDATED` — implementation exists, learner benefit/measurement still insufficient.
+- `VALIDATED` — claim has appropriate technical and learner evidence for its scope.
+- `CURRENTLY_UNSOLVED` — blocked by present science, measurement, data or practical technology.
+
+No internal implementation should be promoted to `VALIDATED` by repository tests alone.
+
+## Current frontier inventory
+
+| Area | Current repo state | Status | Next evidence/action |
+|---|---|---|---|
+| Canonical Attempt → Evidence → LearnerSkillState | Implemented with RPC-only writes, RLS and database tests | IMPLEMENTED_NOT_VALIDATED | Generate real learner history and verify state correlates with later task success |
+| Evidence integrity: reveal/support/modality | Server/DB gates implemented | IMPLEMENTED_NOT_VALIDATED | Exercise through learner-facing adaptive flow and audit persisted rows |
+| Privacy-safe oral observation | Derived speech observation can persist without raw transcript | IMPLEMENTED_NOT_VALIDATED | Validate end-to-end browser/server/DB boundary in real sessions |
+| Capability graph | Nếp V1 capability graph exists | IMPLEMENTED_NOT_VALIDATED | Expand only after vertical-slice evidence; test graph usefulness for planning |
+| Trusted Nếp practice execution | Server resolves canonical action/evaluator/evidence | IMPLEMENTED_NOT_VALIDATED | Make it the default proving runtime rather than a preview-only path |
+| Session Planner V1 | Deterministic planner uses learner state, history and Error Memory | IMPLEMENTED_NOT_VALIDATED | Collect enough attempts to calibrate weights/gates against later success |
+| Error Memory V1 | Structured recurring/remediated error logic exists | IMPLEMENTED_NOT_VALIDATED | Verify recurring errors predict useful remediation on real learners |
+| Remediation/re-probe | Explicit bounded mappings and re-probe cycle exist | IMPLEMENTED_NOT_VALIDATED | Measure repair success and recurrence reduction |
+| Changed-context transfer | Contract/DB invariants exist | IMPLEMENTED_NOT_VALIDATED | Create real unseen variants and measure transfer success |
+| Delayed retention | FSRS + Nếp retention targets/transfer windows exist | IMPLEMENTED_NOT_VALIDATED | Run 1/7/30-day retrieval and compare against prior evidence |
+| FSRS item scheduling | Durable ts-fsrs v5 state/history implemented | IMPLEMENTED_NOT_VALIDATED | Validate scheduling contribution to language retention; keep as subsystem |
+| Realtime natural voice | Current learner surfaces rely mainly on browser SpeechRecognition / speechSynthesis | AVAILABLE_NOT_INTEGRATED | Benchmark OpenAI Realtime/Agents SDK first; compare LiveKit AgentsJS if portability warrants it |
+| Turn detection/interruption | Browser single-turn recognition; realtime providers can do better | AVAILABLE_NOT_INTEGRATED | Measure latency, interruption handling, false turns and mobile reliability |
+| Acoustic pronunciation diagnostics | `assessPronunciation()` intentionally unavailable | AVAILABLE_NOT_INTEGRATED | Benchmark acoustic providers/models and human calibration; do not expose score before gate passes |
+| Vietnamese speech calibration | No trusted Vietnamese-learner calibration corpus/rater benchmark | KNOWN_NOT_IMPLEMENTED | Define bounded rater protocol + representative sample; compare provider outputs |
+| Intelligibility/comprehensibility model | Not represented as validated learner dimension | KNOWN_NOT_IMPLEMENTED | Human-calibrate candidate automated signals before adding state dimension |
+| Fluency/latency measurement | Attempt latency exists; richer spoken fluency not yet validated | KNOWN_NOT_IMPLEMENTED | Add privacy-safe timing/turn features and calibrate against task success/human ratings |
+| Listening-decoding engine | Existing audio/content exists but no frontier adaptive decoding model demonstrated | KNOWN_NOT_IMPLEMENTED | Build bounded fast/connected-speech decoding slice and measure listening transfer |
+| Dynamic context/task generation | Canonical tasks are mostly versioned/static | AVAILABLE_NOT_INTEGRATED | Add constrained generation behind task schema/QA, never direct model-authored mastery |
+| AI pedagogical supervisor | No frontier realtime tutor supervisor integrated | AVAILABLE_NOT_INTEGRATED | Use stronger reasoning model for bounded diagnosis/feedback/task variation; keep evidence authority deterministic/server-side where possible |
+| Learner-state uncertainty | V1 state channels are point values; uncertainty not a first-class calibrated model | KNOWN_NOT_IMPLEMENTED | Add only after enough repeated observations to estimate confidence usefully |
+| Knowledge tracing/probabilistic learner model | Not needed with sparse data | AVAILABLE_NOT_INTEGRATED | Benchmark pyKT/probabilistic baselines offline only after sufficient longitudinal data |
+| Learning-gain prediction | No trustworthy dataset yet | KNOWN_NOT_IMPLEMENTED | Define training/evaluation dataset after real longitudinal learner evidence exists |
+| Contextual adaptive policy/bandit | No reliable reward dataset yet | AVAILABLE_NOT_INTEGRATED | Defer until offline policy evaluation and safe exploration are possible |
+| Human-calibrated speaking assessment | Rubric exists, continuous calibration pipeline not established | KNOWN_NOT_IMPLEMENTED | Create blinded rater sample for automated-system calibration and outcome studies |
+| Real-world/human transfer | Not integrated into main learning loop | KNOWN_NOT_IMPLEMENTED | Add bounded missions/peer or human evaluation only after AI vertical slice works |
+| Experimentation/causal measurement | Analytics/CI foundations exist; learner volume insufficient | IMPLEMENTED_NOT_VALIDATED | Use simple randomized/controlled comparisons first; add platform only when operationally useful |
+| Self-regulation/fading support | Nếp support/reveal controls exist, long-term independence not validated | KNOWN_NOT_IMPLEMENTED | Track support reduction and independent success across time |
+| Broad reading/writing integration | Existing curriculum contains these skills but frontier adaptive integration is not established | KNOWN_NOT_IMPLEMENTED | Expand after spoken vertical loop demonstrates valid architecture |
+| Frontier research monitoring | Ad hoc research performed | KNOWN_NOT_IMPLEMENTED | Maintain source/evidence updates when material new research/technology appears |
+
+## External reuse candidates
+
+### OpenAI Realtime / Agents SDK
+
+- Official Next.js/TypeScript realtime-agents reference exists.
+- Strong fit for the current stack and shortest route to WebRTC, low-latency voice, interruption and tool/agent patterns.
+- Adoption rule: reuse transport/session/event patterns; do not let the realtime agent become mastery authority.
+
+### LiveKit AgentsJS
+
+- Candidate when provider portability, distributed realtime infrastructure, provider mixing or richer production voice operations become necessary.
+- Benchmark against the simpler official OpenAI path before accepting extra infrastructure.
+
+### Browser VAD / Silero-based libraries
+
+- Candidate only if provider-native turn detection is insufficient for the measured learner experience.
+- Must verify iOS/mobile/browser behavior before relying on it.
+
+### Knowledge tracing toolkits such as pyKT
+
+- Research/offline benchmark candidate, not an immediate runtime dependency.
+- Requires enough longitudinal AtoEnglish evidence and a task definition where prediction quality maps to learner outcome.
+
+### Experimentation platforms
+
+- GrowthBook or equivalent may be useful once traffic/sample size makes controlled product experiments routine.
+- Do not add an experimentation platform before simple assignment + outcome analysis becomes an actual operational bottleneck.
+
+## Current critical path
+
+```text
+product truth aligned
+→ canonical adaptive runtime becomes primary proving surface
+→ realtime voice benchmark/integration
+→ acoustic speech calibration path
+→ real learner attempts
+→ transfer + delayed retention measurement
+→ planner calibration
+→ more advanced learner modeling only when data supports it
+→ systematically close remaining ledger items
+```
+
+## Frontier-complete condition
+
+AtoEnglish is not `CURRENT FRONTIER COMPLETE` while a material item remains `KNOWN_NOT_IMPLEMENTED`, `AVAILABLE_NOT_INTEGRATED`, or `IMPLEMENTED_NOT_VALIDATED` without a documented decision that its expected learner value does not justify its cost/risk.
+
+When the remaining material limitations are genuinely `CURRENTLY_UNSOLVED`, the core product should stop accumulating speculative complexity and switch to monitoring new research/technology while continuing outcome validation and maintenance.

--- a/docs/product/PRODUCT_TRUTH.md
+++ b/docs/product/PRODUCT_TRUTH.md
@@ -1,151 +1,284 @@
 # AtoEnglish product truth
 
 **Status:** current product decision source  
-**Updated:** 2026-07-24  
-**Primary roadmap:** GitHub issue #20  
-**Journey contract:** `docs/curriculum/28-day-speaking-journey-contract.md`
+**Updated:** 2026-09-03  
+**Frontier rule:** use the best currently available learning science, language-learning research, product design, AI, speech, adaptive-learning and assessment technology when it can improve learner outcomes.
 
 ## What AtoEnglish is now
 
-AtoEnglish is a Vietnamese-first guided speaking product for adults who know some English but freeze when they need to speak at work.
+AtoEnglish is a Vietnamese-first adaptive English-learning system whose job is to make a learner measurably better at understanding and using English in the real world.
 
-The first product is not the complete A0–B2 curriculum already present in the repository. It is one focused, measurable 28-day work-speaking pilot.
+AtoEnglish is not defined by a 50-unit catalog, a named teaching method, a chatbot, FSRS, gamification, a CEFR label, or a fixed 28-day course. Those may be useful subsystems or bounded experiments. The product is the closed learning loop that continuously observes learner evidence, chooses the next useful learning action, helps the learner perform it, and verifies whether the ability survives reduced support, changed context and delay.
 
-## Target learner
+The long-term product goal is deliberately ambitious:
 
-The initial learner is:
+> Push AtoEnglish to the practical frontier of what current science and technology can do for English learning, then let learner outcomes determine whether it deserves to be considered the best English-learning product.
 
-- a Vietnamese adult beginner or false beginner;
-- able to recognize some common English but unable to retrieve it reliably while speaking;
-- likely to need English for a colleague, client, receptionist, interview, service, or workplace interaction;
-- willing to practice for 10–15 minutes per day;
-- better served by clear Vietnamese guidance and controlled speaking progression than by open-ended conversation.
+This is an engineering and research direction, not a marketing claim.
 
-The current target segment is a product hypothesis. Interviews, paid pilot participation, completion, and learning evidence must validate it.
+## Initial learner and proving ground
 
-## Product promise
+The first proving ground remains narrow enough to measure well:
 
-> In 28 days, practice 10–15 minutes per day to introduce yourself and your work, handle five predictable follow-up questions, and ask for repetition or slower speech.
+- Vietnamese adults who know some English but freeze when they need to speak;
+- beginner or false-beginner learners who recognize more language than they can retrieve;
+- learners who benefit from Vietnamese guidance, controlled difficulty and repeated real-use practice;
+- an initial emphasis on practical spoken interaction because speaking exposes retrieval, listening, repair and transfer failures clearly.
 
-This promise must remain consistent across landing, onboarding, dashboard, lessons, assessment, and support communication.
+A narrow proving ground is a validation strategy, not the permanent boundary of AtoEnglish. The system may expand to broader levels, skills and goals only when the underlying learning engine can support them without weakening measurement quality.
 
-## Final learner outcome
+## North-star outcome
 
-At the end of the pilot, the learner should be able to:
+The primary optimization target is:
 
-1. greet and close a short workplace interaction;
-2. state and spell their name;
-3. state their role;
-4. state their company or workplace type;
-5. state one responsibility;
-6. answer five predictable questions about their work;
-7. independently ask for repetition or slower speech when needed;
-8. deliver a 30–45 second work introduction without a full-script prompt.
+> **Durable Transferable Learning Gain per Minute**
 
-This is a narrow product outcome, not a CEFR certification claim.
+Meaning:
 
-## Learning model
+- **learning gain:** the learner can do more than before;
+- **durable:** the gain survives meaningful delay;
+- **transferable:** the learner succeeds in changed or unseen conditions;
+- **per minute:** learner time is treated as a scarce resource.
 
-Every meaningful lesson should move through a controlled progression:
+Engagement, streaks, XP, lesson completion, session length and retention are secondary unless they help produce durable transferable learning.
+
+## Definition of learned
+
+A correct answer is not automatically evidence that something was learned.
+
+A stronger claim requires progressively stronger evidence:
 
 ```text
-real situation
-→ short comprehensible model
-→ notice useful chunks
-→ controlled retrieval
-→ supported speaking
-→ reduced prompts
-→ changed situation
-→ concise feedback
-→ immediate retry
-→ later spaced retrieval
+recognition
+→ retrieval without reveal
+→ production
+→ self-repair after useful feedback
+→ success with less support
+→ changed-context transfer
+→ delayed retention
+→ real-world task success where practical
 ```
 
-Vocabulary, grammar, XP, streaks, and quizzes support this progression. They are not the final learner outcome.
+The product must preserve uncertainty when evidence is missing. Unknown is preferable to a fabricated mastery or pronunciation score.
 
-## Daily lesson contract
+## Core learning loop
 
-A daily lesson should:
+Every learner-facing system should ultimately serve this loop:
 
-- have one measurable can-do outcome;
-- fit a credible 10–15 minute session;
-- end in required spoken output;
-- use only the language needed for that task;
-- retrieve earlier chunks where relevant;
-- reduce support over time;
-- avoid showing the complete answer during the final performance;
-- give no more than one or two high-impact feedback points;
-- provide an immediate opportunity to speak again;
-- preserve an explicit fallback when browser speech capability is unavailable.
+```text
+observe
+→ infer learner state
+→ select next learning action
+→ create a meaningful task
+→ learner attempts before answer-bearing help
+→ evaluate available evidence
+→ give the smallest useful feedback
+→ learner self-repairs and retries
+→ vary context for transfer
+→ schedule delayed retrieval
+→ update learner state
+→ repeat
+```
+
+This loop may use deterministic rules, statistical models, AI reasoning, speech models, retrieval scheduling and human calibration. No component is allowed to override evidence integrity merely because it is more sophisticated.
+
+## Capability-first curriculum
+
+The curriculum is a graph of useful capabilities and supporting language resources, not one compulsory list of lessons.
+
+Examples of capabilities include:
+
+- greet and close an interaction;
+- introduce yourself;
+- ask for repetition or clarification;
+- confirm understanding;
+- ask and answer practical information;
+- express a need or problem;
+- sustain and repair an interaction.
+
+Vocabulary, chunks, grammar, pronunciation and listening representations support capabilities. They are not the sole course spine.
+
+A fixed journey may still be used when it is the best cold-start path or an experiment needs a controlled sequence. Once learner evidence exists, the planner may choose different practice for different learners.
+
+## Learner model
+
+AtoEnglish should maintain a rebuildable, evidence-backed learner model rather than a single level or completion percentage.
+
+At minimum it should distinguish independent evidence channels such as:
+
+- recognition/comprehension;
+- retrieval;
+- listening;
+- production;
+- repair;
+- transfer;
+- retention.
+
+As validated measurement becomes available, the learner model may add speech/intelligibility, fluency, latency, error patterns, condition-specific performance and uncertainty. New dimensions must have an observable evidence path.
+
+The immutable attempt/evidence history is more authoritative than a mutable learner-state snapshot.
+
+## AI role
+
+AI is a controlled learning component, not the product authority.
+
+AI may be used to:
+
+- converse naturally with low latency;
+- generate or vary scenarios under constraints;
+- diagnose likely learner problems;
+- select or propose remediation;
+- produce concise feedback;
+- create changed-context transfer tasks;
+- adapt language, speaker behavior and difficulty;
+- assist content QA and research synthesis.
+
+AI must not be allowed to:
+
+- invent mastery without evidence;
+- treat a typed fallback as speaking evidence;
+- treat ASR transcript matching as pronunciation assessment;
+- expose hidden answer/evaluator targets to the learner surface;
+- publish unconstrained generated curriculum without validation;
+- silently change the learning policy in production.
+
+## Speech and pronunciation
+
+AtoEnglish should use the strongest practical speech technology available when it improves learning, but claims must match evidence.
+
+The target is intelligible, comprehensible English for real communication, not forced imitation of a native accent.
+
+Speech capabilities may include realtime conversation, turn detection, acoustic analysis, phoneme/stress/prosody feedback and intelligibility estimation. Pronunciation scoring remains gated until the chosen system is calibrated well enough for the intended Vietnamese learner population and task.
+
+Raw audio/transcript persistence is not the default. Prefer transient processing and derived, privacy-safe evidence unless a separately approved research protocol requires richer data.
+
+## Retrieval and memory
+
+FSRS remains useful for item/chunk review timing. It is a subsystem, not the complete learning model.
+
+The system separately decides:
+
+- what capability or resource is weak;
+- what kind of evidence is missing;
+- how the learner should practice it;
+- which context should change;
+- when delayed retrieval should occur.
+
+## Planner evolution
+
+Planner sophistication must follow evidence availability.
+
+Preferred progression:
+
+1. explainable evidence-backed rules;
+2. calibrated heuristics from real learner data;
+3. probabilistic/knowledge-tracing models where they outperform simpler baselines;
+4. learning-gain prediction;
+5. contextual-bandit or other adaptive policy only when enough trustworthy data exists and offline/online evaluation supports it.
+
+Do not adopt a complex model merely because it is newer.
 
 ## Product experience
 
-The intended learner journey is:
+The learner should not need to manage the learning algorithm.
 
-```text
-clear promise
-→ start with minimal friction
-→ learn today's small speaking task
-→ perform the task
-→ receive understandable feedback
-→ retry
-→ see the next step
-→ return for spaced practice and the next daily outcome
-```
+The ideal surface increasingly answers one question:
 
-The product must make the speaking task more important than browsing curriculum breadth or collecting points.
+> What is the most useful thing for me to do next?
+
+The UI may be simple even when the engine is sophisticated. Browsing course catalogs, collecting points and configuring AI behavior must not displace the next useful learning action.
 
 ## Evidence hierarchy
 
-Decisions should distinguish four evidence levels:
+Decisions must distinguish:
 
-1. **Repository evidence:** code, tests, docs, routes, data, and current behavior.
-2. **Usability evidence:** a learner can reach and complete the intended flow.
-3. **Learning evidence:** baseline-to-checkpoint or baseline-to-final speaking performance improves.
-4. **Market evidence:** target learners pay, complete, renew, or refer others.
+1. **research evidence:** what current learning/language science suggests;
+2. **repository evidence:** what the implementation actually does;
+3. **usability evidence:** learners can reach and complete the flow;
+4. **learning evidence:** baseline-to-later ability improves under valid measurement;
+5. **transfer/retention evidence:** gains survive changed conditions and delay;
+6. **market evidence:** learners pay, return, renew or refer without masking weak learning outcomes.
 
-A technical check cannot substitute for learner or market evidence.
+Passing tests proves software consistency, not learner improvement.
 
-## Existing foundation
+## Frontier development rule
 
-The repository already contains substantial infrastructure:
+AtoEnglish follows a reuse-first frontier strategy:
 
-- Next.js application and responsive lesson surfaces;
-- Supabase authentication, progress, migrations, and RLS;
-- 50 registered A0–B2 curriculum units;
-- vocabulary, grammar, dialogue, translation, shadowing, speaking, quiz, and review sections;
-- FSRS, XP, streak, league, progress, and guest flows;
-- baseline/final speaking assessment and rubric;
-- privacy-bounded pilot analytics;
-- Vitest, content-standard checks, production build, and Playwright smoke coverage.
+1. use existing AtoEnglish code when it already satisfies the requirement;
+2. adopt or adapt maintained external libraries/open-source implementations when they are safer or faster than rebuilding;
+3. use current commercial/model APIs where they provide capabilities that cannot be reproduced economically;
+4. custom-build the parts that create AtoEnglish-specific learning advantage or evidence integrity;
+5. verify licenses, security, privacy, maintenance, compatibility, cost and learner value before adoption.
 
-This foundation is available but not equivalent to a validated product. The current bottleneck is proving one coherent learner outcome.
+The goal is not architectural novelty. The goal is to shorten the distance to the best achievable learner outcome.
 
-## Product boundaries
+## Frontier Ledger
 
-Until the pilot is validated:
+Every material frontier capability should be tracked in one of these states:
 
-- keep the existing 50 units available but do not treat breadth as proof of value;
-- build the 28-day journey in small, testable slices;
-- preserve the modular monolith;
-- use manual operations when they are cheaper and safer than building infrastructure;
-- collect only bounded analytics required to answer activation, completion, learning, and support questions;
-- do not store raw audio, transcripts, names, employers, or learner free text in analytics;
-- do not claim learner improvement until baseline and later performance evidence exists.
+- **KNOWN_NOT_IMPLEMENTED** — supported by useful evidence/technology but absent;
+- **AVAILABLE_NOT_INTEGRATED** — implementation exists externally but is not yet safely integrated;
+- **IMPLEMENTED_NOT_VALIDATED** — product capability exists but learner benefit is not yet demonstrated;
+- **VALIDATED** — implementation has sufficient technical and learner evidence for its claim;
+- **CURRENTLY_UNSOLVED** — blocked by current science, measurement, data or practical technology.
 
-## Success questions
+AtoEnglish may be considered **current-frontier complete** only when no material item remains in the first three states without an explicit decision and the remaining open problems are genuinely CURRENTLY_UNSOLVED or not worth their learner-time/cost tradeoff.
 
-AtoEnglish must be able to answer with evidence:
+## How “best” is proved
 
-- who starts the first speaking task;
-- who completes it;
-- who returns after seven days;
-- who completes the 28-day journey;
-- whether speaking performance improves;
-- which lesson or UX failures block learners;
-- how much human support each learner requires;
-- whether the target learner will pay, renew, or refer another learner.
+AtoEnglish must not declare itself the best because it has more features, newer models or stronger internal architecture.
+
+The claim can only emerge from repeated learner evidence such as:
+
+- unseen-task success;
+- independent production;
+- listening comprehension;
+- response latency;
+- successful communication repair;
+- comprehensibility/intelligibility;
+- transfer to new situations;
+- 1/7/30-day retention where appropriate;
+- improvement per minute of practice;
+- eventually external or blinded human evaluation for high-value speaking claims.
+
+Competitor benchmarking is useful as a technology/product reference, not the product objective.
+
+## Current foundation
+
+The repository already contains substantial reusable infrastructure, including:
+
+- Next.js/React/TypeScript application surfaces;
+- Supabase authentication, RLS and migrations;
+- canonical Attempt → Evidence → LearnerSkillState storage;
+- privacy-safe oral-observation rules;
+- Nếp capability contracts and trusted server-side evaluation;
+- Error Memory V1;
+- deterministic Session Planner V1 and adaptive practice preview;
+- mission engine, retry and transfer structures;
+- FSRS card scheduling;
+- existing curriculum/content assets;
+- testing, CI and production observability foundations.
+
+This code should be reused rather than replaced unless measured limitations justify replacement.
+
+## Immediate product direction
+
+The next work is not broad content expansion. It is closing the shortest gaps between the existing adaptive core and a high-quality learner loop:
+
+1. make repository product guidance match this frontier objective;
+2. verify and use the canonical adaptive/evidence runtime rather than legacy parallel paths;
+3. turn the adaptive preview into the primary proving surface for a small capability slice;
+4. benchmark and integrate realtime voice/turn-taking without surrendering server-authoritative learning evidence;
+5. establish a calibrated speech-diagnostics path before exposing pronunciation scores;
+6. collect real attempts and learner outcomes;
+7. improve planner/model policy only as data can justify it;
+8. maintain the Frontier Ledger so new work is selected by learner value rather than novelty.
 
 ## Product decision rule
 
-When choosing between building more breadth and improving the validated journey, choose the smallest change that increases the chance of obtaining trustworthy learner evidence.
+For every proposed change ask:
+
+> Does this use current evidence or technology to create a plausible, measurable improvement in durable transferable English ability per learner minute, and can we validate that improvement without corrupting learner evidence?
+
+If yes, make the smallest reversible implementation and test it. If no, do not build it merely because it is technically impressive.

--- a/src/app/actions/learning-attempts.ts
+++ b/src/app/actions/learning-attempts.ts
@@ -1,8 +1,14 @@
 "use server";
 
 import { headers } from "next/headers";
-import { createClient } from "@/lib/supabase/server";
-import { createRateLimiter } from "@/lib/security/rate-limit";
+import { z } from "zod";
+
+import { seedUnitVocabToSRS } from "@/app/actions/cards";
+import { completeUnit } from "@/app/actions/unit";
+import {
+  compileLegacyAttemptRpcArgs,
+  type LegacyAttemptRpcArgs,
+} from "@/lib/learning/legacy-attempt-adapter";
 import {
   LearningAttemptBatchSchema,
   type LearningAttemptBatchInput,
@@ -12,12 +18,29 @@ import {
   scoreTrialCheckpoint,
 } from "@/lib/lessons/trial-checkpoint";
 import { GOLD_MISSION_01 } from "@/lib/missions/gold-mission-01";
-import { seedUnitVocabToSRS } from "@/app/actions/cards";
-import { completeUnit } from "@/app/actions/unit";
-import { z } from "zod";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
 
 const attemptLimiter = createRateLimiter(60, 60_000, "learning-attempts");
 
+type RpcError = { message: string } | null;
+type RpcClient = {
+  rpc: (
+    fn: "record_learning_attempt",
+    args: LegacyAttemptRpcArgs,
+  ) => Promise<{ data: unknown; error: RpcError }>;
+};
+
+/**
+ * Compatibility boundary for pre-Nếp mission/checkpoint callers.
+ *
+ * The September learning-core migration replaced the old lesson/activity/score table shape with
+ * the canonical Attempt → Evidence → LearnerSkillState model and revoked direct authenticated
+ * inserts. Legacy callers do not carry enough canonical semantic identity to create trustworthy
+ * mastery evidence, so we preserve them as attempt-only history through the canonical RPC.
+ *
+ * New adaptive learning surfaces must use recordNếpPracticeAttempt() instead.
+ */
 export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
   const parsed = LearningAttemptBatchSchema.safeParse(input);
   if (!parsed.success) {
@@ -45,27 +68,28 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ." };
   }
 
-  const { error } = await supabase.from("learning_attempts").insert(
-    parsed.data.attempts.map((attempt) => ({
-      user_id: user.id,
-      session_id: parsed.data.sessionId,
-      lesson_id: parsed.data.lessonId,
-      activity_id: attempt.activityId,
-      modality: attempt.modality,
-      status: attempt.status,
-      score: attempt.score,
-      error_tags: attempt.errorTags,
-      evaluator: attempt.evaluator,
-      evaluator_version: attempt.evaluatorVersion,
-      latency_ms: attempt.latencyMs,
-    })),
-  );
+  const rpcClient = supabase as unknown as RpcClient;
+  let inserted = 0;
 
-  if (error) {
-    return { success: false as const, error: "Không thể lưu bằng chứng học tập." };
+  // This compatibility path is intentionally attempt-only, so a partial failure cannot mutate
+  // learner mastery state. Persist sequentially to make the returned inserted count explicit.
+  for (const attempt of parsed.data.attempts) {
+    const args = compileLegacyAttemptRpcArgs({
+      sessionId: parsed.data.sessionId,
+      lessonId: parsed.data.lessonId,
+      attempt,
+    });
+    const { error } = await rpcClient.rpc("record_learning_attempt", args);
+    if (error) {
+      return {
+        success: false as const,
+        error: `Không thể lưu attempt tương thích (${inserted}/${parsed.data.attempts.length}): ${error.message}`,
+      };
+    }
+    inserted += 1;
   }
 
-  return { success: true as const, inserted: parsed.data.attempts.length };
+  return { success: true as const, inserted };
 }
 
 const trialCheckpointClaimSchema = z
@@ -132,8 +156,8 @@ export async function claimTrialCheckpoint(input: unknown) {
     };
   }
 
-  // Reuse the existing FSRS deck for communicative chunks after mastery is verified.
-  // Raw audio and transcripts are not persisted here.
+  // Reuse the existing FSRS deck for communicative chunks after the legacy checkpoint gate passes.
+  // This remains separate from canonical Nếp capability mastery evidence.
   const reviewSeed = await seedUnitVocabToSRS({
     vocab: GOLD_MISSION_01.targetChunks.map((chunk) => ({
       word: chunk.english,

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -4,7 +4,9 @@ import { NextResponse } from "next/server";
 
 import {
   buildOpenAIRealtimeSessionConfig,
+  isOpenAIRealtimeMode,
   isPlausibleRealtimeSdpOffer,
+  type OpenAIRealtimeMode,
 } from "@/lib/realtime/openai-session";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
@@ -50,6 +52,15 @@ export async function POST(request: Request) {
     );
   }
 
+  const requestedMode = request.headers.get("x-atoenglish-realtime-mode");
+  const mode: OpenAIRealtimeMode = requestedMode === null ? "capture" : requestedMode;
+  if (!isOpenAIRealtimeMode(mode)) {
+    return NextResponse.json(
+      { success: false, error: "Realtime mode không hợp lệ." },
+      { status: 400 },
+    );
+  }
+
   const contentType = request.headers.get("content-type")?.split(";")[0]?.trim();
   if (contentType !== "application/sdp") {
     return NextResponse.json(
@@ -67,8 +78,14 @@ export async function POST(request: Request) {
   }
 
   const formData = new FormData();
-  formData.set("sdp", sdp);
-  formData.set("session", JSON.stringify(buildOpenAIRealtimeSessionConfig()));
+  formData.set("sdp", new Blob([sdp], { type: "application/sdp" }), "offer.sdp");
+  formData.set(
+    "session",
+    new Blob([JSON.stringify(buildOpenAIRealtimeSessionConfig(mode))], {
+      type: "application/json",
+    }),
+    "session.json",
+  );
 
   try {
     const upstream = await fetch(OPENAI_REALTIME_CALLS_URL, {

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  buildOpenAIRealtimeSessionConfig,
+  isPlausibleRealtimeSdpOffer,
+} from "@/lib/realtime/openai-session";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+const sessionLimiter = createRateLimiter(6, 60_000, "realtime-session");
+const OPENAI_REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
+
+function safetyIdentifier(userId: string) {
+  return createHash("sha256")
+    .update(`atoenglish-realtime:${userId}`)
+    .digest("hex");
+}
+
+export async function POST(request: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { success: false, error: "Realtime voice chưa được cấu hình trên server." },
+      { status: 503 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json(
+      { success: false, error: "Bạn cần đăng nhập để mở realtime voice." },
+      { status: 401 },
+    );
+  }
+
+  const rateCheck = await sessionLimiter.check(safetyIdentifier(user.id));
+  if (!rateCheck.success) {
+    return NextResponse.json(
+      { success: false, error: "Đã mở quá nhiều voice session. Thử lại sau." },
+      { status: 429 },
+    );
+  }
+
+  const contentType = request.headers.get("content-type")?.split(";")[0]?.trim();
+  if (contentType !== "application/sdp") {
+    return NextResponse.json(
+      { success: false, error: "Realtime session yêu cầu SDP offer." },
+      { status: 415 },
+    );
+  }
+
+  const sdp = await request.text();
+  if (!isPlausibleRealtimeSdpOffer(sdp)) {
+    return NextResponse.json(
+      { success: false, error: "SDP offer không hợp lệ." },
+      { status: 400 },
+    );
+  }
+
+  const formData = new FormData();
+  formData.set("sdp", sdp);
+  formData.set("session", JSON.stringify(buildOpenAIRealtimeSessionConfig()));
+
+  try {
+    const upstream = await fetch(OPENAI_REALTIME_CALLS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "OpenAI-Safety-Identifier": safetyIdentifier(user.id),
+      },
+      body: formData,
+      cache: "no-store",
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!upstream.ok) {
+      console.error("OpenAI realtime session creation failed", {
+        status: upstream.status,
+        requestId: upstream.headers.get("x-request-id"),
+      });
+      return NextResponse.json(
+        { success: false, error: "Không mở được realtime voice session." },
+        { status: 502 },
+      );
+    }
+
+    const answerSdp = await upstream.text();
+    if (!answerSdp.trim().startsWith("v=0")) {
+      console.error("OpenAI realtime returned a non-SDP response", {
+        requestId: upstream.headers.get("x-request-id"),
+      });
+      return NextResponse.json(
+        { success: false, error: "Realtime provider trả dữ liệu không hợp lệ." },
+        { status: 502 },
+      );
+    }
+
+    return new Response(answerSdp, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/sdp",
+        "Cache-Control": "no-store, max-age=0",
+      },
+    });
+  } catch (error) {
+    const timedOut = error instanceof DOMException && error.name === "TimeoutError";
+    console.error("OpenAI realtime session request failed", {
+      reason: timedOut ? "timeout" : "network",
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: timedOut
+          ? "Realtime provider phản hồi quá chậm."
+          : "Không kết nối được realtime provider.",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -90,6 +90,7 @@ export async function POST(request: Request) {
     const upstream = await fetch(OPENAI_REALTIME_CALLS_URL, {
       method: "POST",
       headers: {
+        Accept: "application/sdp",
         Authorization: `Bearer ${apiKey}`,
         "OpenAI-Safety-Identifier": safetyIdentifier(user.id),
       },

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -6,7 +6,6 @@ import {
   buildOpenAIRealtimeSessionConfig,
   isOpenAIRealtimeMode,
   isPlausibleRealtimeSdpOffer,
-  type OpenAIRealtimeMode,
 } from "@/lib/realtime/openai-session";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
@@ -52,14 +51,14 @@ export async function POST(request: Request) {
     );
   }
 
-  const requestedMode = request.headers.get("x-atoenglish-realtime-mode");
-  const mode: OpenAIRealtimeMode = requestedMode === null ? "capture" : requestedMode;
-  if (!isOpenAIRealtimeMode(mode)) {
+  const modeCandidate = request.headers.get("x-atoenglish-realtime-mode") ?? "capture";
+  if (!isOpenAIRealtimeMode(modeCandidate)) {
     return NextResponse.json(
       { success: false, error: "Realtime mode không hợp lệ." },
       { status: 400 },
     );
   }
+  const mode = modeCandidate;
 
   const contentType = request.headers.get("content-type")?.split(";")[0]?.trim();
   if (contentType !== "application/sdp") {

--- a/src/features/adaptive-practice/AdaptivePracticePreview.tsx
+++ b/src/features/adaptive-practice/AdaptivePracticePreview.tsx
@@ -12,11 +12,15 @@ import {
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getNếpAdaptivePracticeQueue } from "@/app/actions/adaptive-practice";
 import { recordNếpPracticeAttempt } from "@/app/actions/learning-evidence";
 import type { NếpPracticeEnvelope } from "@/lib/nep/practice-execution.v1";
+import {
+  connectRealtimeVoice,
+  type RealtimeVoiceConnection,
+} from "@/lib/realtime/webrtc-client";
 
 type SurfacePhase =
   | "idle"
@@ -28,6 +32,7 @@ type SurfacePhase =
   | "error";
 
 type SaveState = "idle" | "saving" | "evidence" | "attempt" | "not-saved" | "error";
+type SpeechTransport = "realtime" | "browser" | null;
 
 type RecognitionCtor = new () => {
   lang: string;
@@ -48,6 +53,15 @@ function recognitionCtor(): RecognitionCtor | null {
   return browserWindow.SpeechRecognition ?? browserWindow.webkitSpeechRecognition ?? null;
 }
 
+function realtimeVoiceSupported() {
+  return (
+    typeof window !== "undefined" &&
+    typeof RTCPeerConnection !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    Boolean(navigator.mediaDevices?.getUserMedia)
+  );
+}
+
 function saveLabel(state: SaveState) {
   if (state === "saving") return "Đang lưu attempt…";
   if (state === "evidence") return "Attempt + mastery evidence đã được ghi.";
@@ -65,23 +79,47 @@ export function AdaptivePracticePreview() {
   const [answerSource, setAnswerSource] = useState<"speech" | "text" | null>(null);
   const [supportUsed, setSupportUsed] = useState(false);
   const [listening, setListening] = useState(false);
+  const [speechTransport, setSpeechTransport] = useState<SpeechTransport>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [evaluationSuccess, setEvaluationSuccess] = useState<boolean | null>(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const attemptStartedAt = useRef<number | null>(null);
+  const realtimeConnectionRef = useRef<RealtimeVoiceConnection | null>(null);
+  const realtimeCaptureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioElementRef = useRef<HTMLAudioElement | null>(null);
 
   const practice = practices[index] ?? null;
   const saving = saveState === "saving";
-  const speechAvailable = typeof window !== "undefined" && recognitionCtor() !== null;
+  const speechAvailable = realtimeVoiceSupported() || recognitionCtor() !== null;
   const persistedLabel = saveLabel(saveState);
 
+  const stopRealtimeCapture = () => {
+    if (realtimeCaptureTimeoutRef.current) {
+      clearTimeout(realtimeCaptureTimeoutRef.current);
+      realtimeCaptureTimeoutRef.current = null;
+    }
+    realtimeConnectionRef.current?.close();
+    realtimeConnectionRef.current = null;
+  };
+
+  useEffect(() => {
+    return () => {
+      if (realtimeCaptureTimeoutRef.current) {
+        clearTimeout(realtimeCaptureTimeoutRef.current);
+      }
+      realtimeConnectionRef.current?.close();
+    };
+  }, []);
+
   const resetResponse = () => {
+    stopRealtimeCapture();
     setAnswer("");
     setAnswerSource(null);
     setSupportUsed(false);
     setListening(false);
+    setSpeechTransport(null);
     setFeedback(null);
     setEvaluationSuccess(null);
     setSaveState("idle");
@@ -122,13 +160,9 @@ export function AdaptivePracticePreview() {
     setSaveState("idle");
   };
 
-  const startSpeech = () => {
-    if (!practice || saving || submitted) return;
+  const startBrowserSpeech = (fallbackMessage?: string) => {
     const Recognition = recognitionCtor();
-    if (!Recognition) {
-      setFeedback("Browser này không hỗ trợ speech recognition. Có thể dùng text fallback, nhưng text không tạo speaking evidence.");
-      return;
-    }
+    if (!Recognition) return false;
 
     const recognition = new Recognition();
     recognition.lang = "en-US";
@@ -138,6 +172,7 @@ export function AdaptivePracticePreview() {
       setAnswer(event.results[0]?.[0]?.transcript ?? "");
       setAnswerSource("speech");
       setListening(false);
+      setSpeechTransport("browser");
       setFeedback(null);
       setEvaluationSuccess(null);
       setSaveState("idle");
@@ -147,8 +182,93 @@ export function AdaptivePracticePreview() {
       setFeedback("Không lấy được transcript. Thử mic lại hoặc dùng text fallback.");
     };
     recognition.onend = () => setListening(false);
+
+    setSpeechTransport("browser");
     setListening(true);
+    if (fallbackMessage) setFeedback(fallbackMessage);
     recognition.start();
+    return true;
+  };
+
+  const startSpeech = async () => {
+    if (!practice || saving || submitted || listening) return;
+
+    setFeedback(null);
+    setEvaluationSuccess(null);
+    setSaveState("idle");
+
+    if (!realtimeVoiceSupported()) {
+      if (!startBrowserSpeech()) {
+        setFeedback(
+          "Browser này không hỗ trợ realtime voice hoặc speech recognition. Có thể dùng text fallback, nhưng text không tạo speaking evidence.",
+        );
+      }
+      return;
+    }
+
+    stopRealtimeCapture();
+    setSpeechTransport("realtime");
+    setListening(true);
+    setFeedback("Đang mở realtime speech capture…");
+
+    try {
+      if (!audioElementRef.current) {
+        audioElementRef.current = document.createElement("audio");
+      }
+
+      const connection = await connectRealtimeVoice({
+        audioElement: audioElementRef.current,
+        mode: "capture",
+        onSignal: (signal) => {
+          if (signal.kind === "learner-transcript") {
+            const transcript = signal.transcript.trim();
+            stopRealtimeCapture();
+            setListening(false);
+            setSpeechTransport("realtime");
+
+            if (!transcript) {
+              setFeedback("Realtime không nghe rõ câu vừa nói. Thử lại một lần nữa.");
+              return;
+            }
+
+            setAnswer(transcript);
+            setAnswerSource("speech");
+            setFeedback(null);
+            setEvaluationSuccess(null);
+            setSaveState("idle");
+            return;
+          }
+
+          if (signal.kind === "provider-error") {
+            stopRealtimeCapture();
+            setListening(false);
+            setFeedback("Realtime voice gặp lỗi. Có thể thử lại hoặc dùng text fallback.");
+          }
+        },
+        onStateChange: (state) => {
+          if (state === "connected") {
+            setFeedback("Realtime đang nghe. Nói tự nhiên và kết thúc câu khi sẵn sàng.");
+          }
+        },
+      });
+
+      realtimeConnectionRef.current = connection;
+      realtimeCaptureTimeoutRef.current = setTimeout(() => {
+        stopRealtimeCapture();
+        setListening(false);
+        setFeedback("Không nhận được câu nói sau 25 giây. Thử mic lại khi sẵn sàng.");
+      }, 25_000);
+    } catch (captureError) {
+      stopRealtimeCapture();
+      setListening(false);
+      const message = captureError instanceof Error ? captureError.message : "Realtime voice chưa dùng được.";
+      const browserFallback = startBrowserSpeech(
+        `Realtime chưa dùng được (${message}). Đã chuyển sang speech recognition của browser.`,
+      );
+      if (!browserFallback) {
+        setFeedback(`${message} Có thể dùng text fallback, nhưng text không tạo speaking evidence.`);
+      }
+    }
   };
 
   const submit = async () => {
@@ -295,11 +415,11 @@ export function AdaptivePracticePreview() {
               ) : practice.modality === "speech" ? (
                 <>
                   <div className="flex flex-wrap items-center gap-3">
-                    <button type="button" onClick={startSpeech} disabled={listening || saving || submitted} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? "Đang nghe…" : "Nói bằng mic"}</button>
-                    {!speechAvailable && <span className="text-xs text-[#8a5b00]">Browser không hỗ trợ speech recognition.</span>}
+                    <button type="button" onClick={startSpeech} disabled={listening || saving || submitted} className="flex items-center gap-2 rounded-full bg-[#171713] px-5 py-3 text-sm font-semibold text-white disabled:opacity-40"><Mic2 className="size-4" /> {listening ? (speechTransport === "realtime" ? "Realtime đang nghe…" : "Đang nghe…") : "Nói bằng mic"}</button>
+                    {!speechAvailable && <span className="text-xs text-[#8a5b00]">Browser không hỗ trợ speech capture.</span>}
                   </div>
-                  <textarea value={answer} disabled={saving || submitted} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setFeedback(null); setEvaluationSuccess(null); setSaveState("idle"); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60 disabled:opacity-50" />
-                  <p className="mt-2 text-xs leading-5 text-black/40">Gõ text chỉ là fallback để kiểm language coverage; không được tính speaking evidence.</p>
+                  <textarea value={answer} disabled={saving || submitted} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); setSpeechTransport(null); setFeedback(null); setEvaluationSuccess(null); setSaveState("idle"); }} placeholder="Transcript hoặc text fallback…" className="mt-4 min-h-24 w-full resize-none rounded-2xl border border-black/10 bg-[#faf9f5] p-4 outline-none focus:border-[#2d6a4f]/60 disabled:opacity-50" />
+                  <p className="mt-2 text-xs leading-5 text-black/40">{answerSource === "speech" && speechTransport === "realtime" ? "Transcript từ Realtime được dùng tạm thời để đánh giá language coverage; không phải điểm phát âm và không persist raw transcript." : answerSource === "speech" ? "Transcript từ browser speech recognition; không phải điểm phát âm." : "Gõ text chỉ là fallback để kiểm language coverage; không được tính speaking evidence."}</p>
                 </>
               ) : (
                 <textarea value={answer} disabled={saving || submitted} onChange={(event) => { setAnswer(event.target.value); setAnswerSource("text"); }} className="min-h-24 w-full rounded-2xl border border-black/10 p-4" />
@@ -346,7 +466,7 @@ export function AdaptivePracticePreview() {
         )}
 
         <footer className="mt-auto pt-6 text-center text-[11px] leading-5 text-black/35">
-          <Headphones className="mr-1 inline size-3" /> Planner chọn task; server đánh giá; DB quyết định evidence. Transcript thô không được persist. Text fallback ≠ speaking evidence.
+          <Headphones className="mr-1 inline size-3" /> Planner chọn task; server đánh giá; DB quyết định evidence. Realtime/browser transcript chỉ là language signal; text fallback ≠ speaking evidence.
         </footer>
       </div>
     </main>

--- a/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
+++ b/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { compileLegacyAttemptRpcArgs } from "@/lib/learning/legacy-attempt-adapter";
+
+const baseAttempt = {
+  activityId: "unit-a0-1:checkpoint:q1",
+  status: "scored" as const,
+  score: 100,
+  errorTags: [],
+  evaluator: "deterministic-answer-key",
+  evaluatorVersion: "2.0.0",
+  latencyMs: 1200,
+};
+
+describe("compileLegacyAttemptRpcArgs", () => {
+  it("preserves a legacy checkpoint as attempt-only canonical history", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        modality: "checkpoint",
+      },
+    });
+
+    expect(result.p_knowledge_item_id).toBe(
+      "legacy:unit-a0-1:checkpoint:q1",
+    );
+    expect(result.p_response_modality).toBe("choice");
+    expect(result.p_correct).toBe(true);
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_evidence_target_id).toBeNull();
+    expect(result.p_capability_id).toBeNull();
+    expect(result.p_metadata).toMatchObject({
+      compatibilitySource: "legacy-learning-attempt-v1",
+      lessonId: "unit-a0-1",
+      legacyScore: 100,
+    });
+  });
+
+  it("does not turn a partial mission score into binary correctness or mastery evidence", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        activityId: "unit-a0-1:mission:mission-meet-new-colleague",
+        modality: "speaking",
+        score: 75,
+        errorTags: ["missing_intent:ask_name"],
+        evaluator: "deterministic-intent-match",
+      },
+    });
+
+    expect(result.p_response_modality).toBe("speech");
+    expect(result.p_correct).toBeNull();
+    expect(result.p_response_text).toBeNull();
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_metadata.legacyErrorTags).toEqual([
+      "missing_intent:ask_name",
+    ]);
+  });
+
+  it("does not infer an observable response modality for legacy listening-only activity metadata", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        activityId: "unit-a0-1:listening:1",
+        modality: "listening",
+        score: 0,
+      },
+    });
+
+    expect(result.p_response_modality).toBe("none");
+    expect(result.p_correct).toBe(false);
+    expect(result.p_evidence_type).toBeNull();
+  });
+});

--- a/src/lib/learning/legacy-attempt-adapter.ts
+++ b/src/lib/learning/legacy-attempt-adapter.ts
@@ -1,0 +1,117 @@
+import type { LearningAttemptItem } from "@/lib/lessons/learning-attempt";
+
+export type CanonicalResponseModality =
+  | "choice"
+  | "text"
+  | "speech"
+  | "gesture"
+  | "none";
+
+export type LegacyAttemptRpcArgs = {
+  p_knowledge_item_id: string;
+  p_capability_id: null;
+  p_session_id: string;
+  p_exercise_type: string;
+  p_response_modality: CanonicalResponseModality;
+  p_prompt_id: string;
+  p_context_id: null;
+  p_response_text: null;
+  p_correct: boolean | null;
+  p_latency_ms: number | null;
+  p_hint_count: 0;
+  p_reveal_used: false;
+  p_support_level: 0;
+  p_metadata: {
+    compatibilitySource: "legacy-learning-attempt-v1";
+    lessonId: string;
+    activityId: string;
+    legacyModality: LearningAttemptItem["modality"];
+    legacyStatus: LearningAttemptItem["status"];
+    legacyScore: number | null;
+    legacyErrorTags: string[];
+    legacyEvaluator: string;
+    legacyEvaluatorVersion: string;
+  };
+  p_evidence_type: null;
+  p_evidence_target_id: null;
+  p_evidence_success: null;
+  p_evidence_confidence: null;
+  p_evidence_context_id: null;
+  p_evaluator: null;
+  p_evidence_metadata: Record<string, never>;
+};
+
+function responseModalityForLegacyAttempt(
+  modality: LearningAttemptItem["modality"],
+): CanonicalResponseModality {
+  switch (modality) {
+    case "speaking":
+    case "shadowing":
+      return "speech";
+    case "writing":
+      return "text";
+    case "quiz":
+    case "checkpoint":
+      return "choice";
+    case "vocabulary":
+    case "grammar":
+    case "listening":
+    case "reading":
+      return "none";
+  }
+}
+
+function binaryCorrectness(score: number | null): boolean | null {
+  if (score === 100) return true;
+  if (score === 0) return false;
+  return null;
+}
+
+/**
+ * Compatibility bridge for pre-Nếp lesson/mission callers.
+ *
+ * These callers do not carry enough canonical semantic identity to create trustworthy mastery
+ * evidence. Preserve their observations as immutable attempts through the canonical RPC, but do
+ * not fabricate capability/evidence events or mutate learner_skill_states.
+ */
+export function compileLegacyAttemptRpcArgs(input: {
+  sessionId: string;
+  lessonId: string;
+  attempt: LearningAttemptItem;
+}): LegacyAttemptRpcArgs {
+  const { sessionId, lessonId, attempt } = input;
+
+  return {
+    p_knowledge_item_id: `legacy:${attempt.activityId}`,
+    p_capability_id: null,
+    p_session_id: sessionId,
+    p_exercise_type: `legacy:${attempt.modality}`,
+    p_response_modality: responseModalityForLegacyAttempt(attempt.modality),
+    p_prompt_id: attempt.activityId,
+    p_context_id: null,
+    p_response_text: null,
+    p_correct: attempt.status === "scored" ? binaryCorrectness(attempt.score) : null,
+    p_latency_ms: attempt.latencyMs,
+    p_hint_count: 0,
+    p_reveal_used: false,
+    p_support_level: 0,
+    p_metadata: {
+      compatibilitySource: "legacy-learning-attempt-v1",
+      lessonId,
+      activityId: attempt.activityId,
+      legacyModality: attempt.modality,
+      legacyStatus: attempt.status,
+      legacyScore: attempt.score,
+      legacyErrorTags: attempt.errorTags,
+      legacyEvaluator: attempt.evaluator,
+      legacyEvaluatorVersion: attempt.evaluatorVersion,
+    },
+    p_evidence_type: null,
+    p_evidence_target_id: null,
+    p_evidence_success: null,
+    p_evidence_confidence: null,
+    p_evidence_context_id: null,
+    p_evaluator: null,
+    p_evidence_metadata: {},
+  };
+}

--- a/src/lib/realtime/__tests__/events.test.ts
+++ b/src/lib/realtime/__tests__/events.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOpenAIRealtimeServerEvent } from "@/lib/realtime/events";
+
+describe("parseOpenAIRealtimeServerEvent", () => {
+  it("maps learner transcription without inventing a score", () => {
+    expect(
+      parseOpenAIRealtimeServerEvent({
+        type: "conversation.item.input_audio_transcription.completed",
+        item_id: "item-1",
+        transcript: "  Could you say that again?  ",
+      }),
+    ).toEqual({
+      kind: "learner-transcript",
+      itemId: "item-1",
+      transcript: "Could you say that again?",
+    });
+  });
+
+  it("maps completed assistant audio transcript", () => {
+    expect(
+      parseOpenAIRealtimeServerEvent({
+        type: "response.output_audio_transcript.done",
+        item_id: "assistant-item",
+        response_id: "response-1",
+        transcript: "Sure. What do you do for work?",
+      }),
+    ).toEqual({
+      kind: "assistant-transcript",
+      itemId: "assistant-item",
+      responseId: "response-1",
+      transcript: "Sure. What do you do for work?",
+    });
+  });
+
+  it("maps provider errors without throwing", () => {
+    expect(
+      parseOpenAIRealtimeServerEvent({
+        type: "error",
+        error: { code: "invalid_request", message: "Bad event" },
+      }),
+    ).toEqual({
+      kind: "provider-error",
+      code: "invalid_request",
+      message: "Bad event",
+    });
+  });
+
+  it("accepts serialized events and ignores irrelevant or malformed input", () => {
+    expect(
+      parseOpenAIRealtimeServerEvent(
+        JSON.stringify({ type: "session.created", session: { id: "sess-1" } }),
+      ),
+    ).toEqual({ kind: "session-ready", sessionId: "sess-1" });
+
+    expect(parseOpenAIRealtimeServerEvent("not-json")).toBeNull();
+    expect(parseOpenAIRealtimeServerEvent({ type: "rate_limits.updated" })).toBeNull();
+  });
+});

--- a/src/lib/realtime/__tests__/openai-session.test.ts
+++ b/src/lib/realtime/__tests__/openai-session.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_REALTIME_SDP_BYTES,
+  OPENAI_REALTIME_MODEL,
+  buildOpenAIRealtimeSessionConfig,
+  isPlausibleRealtimeSdpOffer,
+} from "@/lib/realtime/openai-session";
+
+describe("realtime session policy", () => {
+  it("uses semantic VAD and keeps mastery authority outside the voice model", () => {
+    const config = buildOpenAIRealtimeSessionConfig();
+
+    expect(config.model).toBe(OPENAI_REALTIME_MODEL);
+    expect(config.audio.input.turn_detection).toEqual({
+      type: "semantic_vad",
+      eagerness: "low",
+      create_response: true,
+      interrupt_response: true,
+    });
+    expect(config.instructions).toContain("Do not grade, score, declare mastery");
+    expect(config.instructions).toContain("trusted server evaluates learning evidence separately");
+  });
+
+  it("accepts a normal audio SDP offer", () => {
+    expect(
+      isPlausibleRealtimeSdpOffer(
+        [
+          "v=0",
+          "o=- 1 1 IN IP4 127.0.0.1",
+          "s=-",
+          "t=0 0",
+          "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+        ].join("\r\n"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects malformed and oversized SDP", () => {
+    expect(isPlausibleRealtimeSdpOffer("hello")).toBe(false);
+    expect(
+      isPlausibleRealtimeSdpOffer(
+        `v=0\nm=audio 9 UDP/TLS/RTP/SAVPF 111\n${"x".repeat(MAX_REALTIME_SDP_BYTES)}`,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/realtime/__tests__/openai-session.test.ts
+++ b/src/lib/realtime/__tests__/openai-session.test.ts
@@ -4,22 +4,38 @@ import {
   MAX_REALTIME_SDP_BYTES,
   OPENAI_REALTIME_MODEL,
   buildOpenAIRealtimeSessionConfig,
+  isOpenAIRealtimeMode,
   isPlausibleRealtimeSdpOffer,
 } from "@/lib/realtime/openai-session";
 
 describe("realtime session policy", () => {
-  it("uses semantic VAD and keeps mastery authority outside the voice model", () => {
+  it("defaults to capture-only semantic VAD for canonical Nếp practice", () => {
     const config = buildOpenAIRealtimeSessionConfig();
 
     expect(config.model).toBe(OPENAI_REALTIME_MODEL);
     expect(config.audio.input.turn_detection).toEqual({
       type: "semantic_vad",
       eagerness: "low",
-      create_response: true,
-      interrupt_response: true,
+      create_response: false,
+      interrupt_response: false,
     });
+    expect(config.instructions).toContain("capture-only");
     expect(config.instructions).toContain("Do not grade, score, declare mastery");
+  });
+
+  it("enables model responses only in explicit conversation mode", () => {
+    const config = buildOpenAIRealtimeSessionConfig("conversation");
+
+    expect(config.audio.input.turn_detection.create_response).toBe(true);
+    expect(config.audio.input.turn_detection.interrupt_response).toBe(true);
+    expect(config.instructions).toContain("realtime English speaking partner");
     expect(config.instructions).toContain("trusted server evaluates learning evidence separately");
+  });
+
+  it("validates supported transport modes", () => {
+    expect(isOpenAIRealtimeMode("capture")).toBe(true);
+    expect(isOpenAIRealtimeMode("conversation")).toBe(true);
+    expect(isOpenAIRealtimeMode("anything-else")).toBe(false);
   });
 
   it("accepts a normal audio SDP offer", () => {

--- a/src/lib/realtime/events.ts
+++ b/src/lib/realtime/events.ts
@@ -1,0 +1,112 @@
+type JsonRecord = Record<string, unknown>;
+
+export type AtoEnglishRealtimeSignal =
+  | {
+      kind: "session-ready";
+      sessionId: string | null;
+    }
+  | {
+      kind: "learner-transcript";
+      transcript: string;
+      itemId: string | null;
+    }
+  | {
+      kind: "assistant-transcript";
+      transcript: string;
+      itemId: string | null;
+      responseId: string | null;
+    }
+  | {
+      kind: "response-done";
+      responseId: string | null;
+    }
+  | {
+      kind: "provider-error";
+      code: string | null;
+      message: string;
+    };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: JsonRecord, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function decodeEvent(raw: unknown): JsonRecord | null {
+  if (isRecord(raw)) return raw;
+  if (typeof raw !== "string") return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert the small subset of OpenAI Realtime server events that AtoEnglish needs into a
+ * provider-independent signal contract.
+ *
+ * Input transcription is diagnostic language evidence only. OpenAI documents the transcript as a
+ * rough guide to the audio; this parser deliberately exposes no pronunciation score or mastery
+ * interpretation.
+ */
+export function parseOpenAIRealtimeServerEvent(
+  raw: unknown,
+): AtoEnglishRealtimeSignal | null {
+  const event = decodeEvent(raw);
+  if (!event) return null;
+
+  const type = stringField(event, "type");
+  if (!type) return null;
+
+  if (type === "session.created") {
+    const session = isRecord(event.session) ? event.session : null;
+    return {
+      kind: "session-ready",
+      sessionId: session ? stringField(session, "id") : null,
+    };
+  }
+
+  if (type === "conversation.item.input_audio_transcription.completed") {
+    return {
+      kind: "learner-transcript",
+      transcript: stringField(event, "transcript")?.trim() ?? "",
+      itemId: stringField(event, "item_id"),
+    };
+  }
+
+  if (type === "response.output_audio_transcript.done") {
+    return {
+      kind: "assistant-transcript",
+      transcript: stringField(event, "transcript")?.trim() ?? "",
+      itemId: stringField(event, "item_id"),
+      responseId: stringField(event, "response_id"),
+    };
+  }
+
+  if (type === "response.done") {
+    const response = isRecord(event.response) ? event.response : null;
+    return {
+      kind: "response-done",
+      responseId: response ? stringField(response, "id") : null,
+    };
+  }
+
+  if (type === "error") {
+    const providerError = isRecord(event.error) ? event.error : null;
+    return {
+      kind: "provider-error",
+      code: providerError ? stringField(providerError, "code") : null,
+      message:
+        (providerError ? stringField(providerError, "message") : null) ??
+        "Realtime provider reported an unknown error.",
+    };
+  }
+
+  return null;
+}

--- a/src/lib/realtime/openai-session.ts
+++ b/src/lib/realtime/openai-session.ts
@@ -4,6 +4,8 @@ export const OPENAI_REALTIME_VOICE = "marin" as const;
 
 export const MAX_REALTIME_SDP_BYTES = 64 * 1024;
 
+export type OpenAIRealtimeMode = "capture" | "conversation";
+
 export type OpenAIRealtimeSessionConfig = {
   type: "realtime";
   model: typeof OPENAI_REALTIME_MODEL;
@@ -18,8 +20,8 @@ export type OpenAIRealtimeSessionConfig = {
       turn_detection: {
         type: "semantic_vad";
         eagerness: "low";
-        create_response: true;
-        interrupt_response: true;
+        create_response: boolean;
+        interrupt_response: boolean;
       };
     };
     output: {
@@ -31,24 +33,35 @@ export type OpenAIRealtimeSessionConfig = {
 /**
  * Transport-level policy only.
  *
- * Canonical Nếp actions remain the authority for what the learner should practice and what counts
- * as evidence. The realtime model is deliberately prohibited from declaring mastery or producing
- * pronunciation scores. Task-specific instructions can be layered on later from server-resolved
- * canonical practice metadata.
+ * `capture` is the safe default for canonical Nếp practice: Realtime performs microphone transport,
+ * semantic turn detection and input transcription but does not generate a model response.
+ * `conversation` is reserved for a later server-resolved tutor layer that can inject the current
+ * canonical task context without giving the model mastery authority.
  */
-export function buildOpenAIRealtimeSessionConfig(): OpenAIRealtimeSessionConfig {
+export function buildOpenAIRealtimeSessionConfig(
+  mode: OpenAIRealtimeMode = "capture",
+): OpenAIRealtimeSessionConfig {
+  const conversation = mode === "conversation";
+
   return {
     type: "realtime",
     model: OPENAI_REALTIME_MODEL,
-    instructions: [
-      "You are AtoEnglish's realtime English speaking partner.",
-      "Keep each reply concise and natural, normally one short conversational turn.",
-      "Let the learner finish speaking; beginners may pause while formulating an answer.",
-      "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
-      "Do not reveal hidden answer keys or invent learner progress.",
-      "AtoEnglish's trusted server evaluates learning evidence separately.",
-    ].join(" "),
-    max_output_tokens: 128,
+    instructions: conversation
+      ? [
+          "You are AtoEnglish's realtime English speaking partner.",
+          "Keep each reply concise and natural, normally one short conversational turn.",
+          "Let the learner finish speaking; beginners may pause while formulating an answer.",
+          "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
+          "Do not reveal hidden answer keys or invent learner progress.",
+          "AtoEnglish's trusted server evaluates learning evidence separately.",
+        ].join(" ")
+      : [
+          "This session is capture-only for AtoEnglish learning evidence.",
+          "Do not produce a conversational response.",
+          "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
+          "AtoEnglish's trusted server evaluates the transient input transcript separately.",
+        ].join(" "),
+    max_output_tokens: conversation ? 128 : 1,
     audio: {
       input: {
         transcription: {
@@ -58,8 +71,8 @@ export function buildOpenAIRealtimeSessionConfig(): OpenAIRealtimeSessionConfig 
         turn_detection: {
           type: "semantic_vad",
           eagerness: "low",
-          create_response: true,
-          interrupt_response: true,
+          create_response: conversation,
+          interrupt_response: conversation,
         },
       },
       output: {
@@ -67,6 +80,10 @@ export function buildOpenAIRealtimeSessionConfig(): OpenAIRealtimeSessionConfig 
       },
     },
   };
+}
+
+export function isOpenAIRealtimeMode(value: string | null): value is OpenAIRealtimeMode {
+  return value === "capture" || value === "conversation";
 }
 
 export function isPlausibleRealtimeSdpOffer(sdp: string): boolean {

--- a/src/lib/realtime/openai-session.ts
+++ b/src/lib/realtime/openai-session.ts
@@ -1,0 +1,78 @@
+export const OPENAI_REALTIME_MODEL = "gpt-realtime-2.1" as const;
+export const OPENAI_REALTIME_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe" as const;
+export const OPENAI_REALTIME_VOICE = "marin" as const;
+
+export const MAX_REALTIME_SDP_BYTES = 64 * 1024;
+
+export type OpenAIRealtimeSessionConfig = {
+  type: "realtime";
+  model: typeof OPENAI_REALTIME_MODEL;
+  instructions: string;
+  max_output_tokens: number;
+  audio: {
+    input: {
+      transcription: {
+        model: typeof OPENAI_REALTIME_TRANSCRIPTION_MODEL;
+        language: "en";
+      };
+      turn_detection: {
+        type: "semantic_vad";
+        eagerness: "low";
+        create_response: true;
+        interrupt_response: true;
+      };
+    };
+    output: {
+      voice: typeof OPENAI_REALTIME_VOICE;
+    };
+  };
+};
+
+/**
+ * Transport-level policy only.
+ *
+ * Canonical Nếp actions remain the authority for what the learner should practice and what counts
+ * as evidence. The realtime model is deliberately prohibited from declaring mastery or producing
+ * pronunciation scores. Task-specific instructions can be layered on later from server-resolved
+ * canonical practice metadata.
+ */
+export function buildOpenAIRealtimeSessionConfig(): OpenAIRealtimeSessionConfig {
+  return {
+    type: "realtime",
+    model: OPENAI_REALTIME_MODEL,
+    instructions: [
+      "You are AtoEnglish's realtime English speaking partner.",
+      "Keep each reply concise and natural, normally one short conversational turn.",
+      "Let the learner finish speaking; beginners may pause while formulating an answer.",
+      "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
+      "Do not reveal hidden answer keys or invent learner progress.",
+      "AtoEnglish's trusted server evaluates learning evidence separately.",
+    ].join(" "),
+    max_output_tokens: 128,
+    audio: {
+      input: {
+        transcription: {
+          model: OPENAI_REALTIME_TRANSCRIPTION_MODEL,
+          language: "en",
+        },
+        turn_detection: {
+          type: "semantic_vad",
+          eagerness: "low",
+          create_response: true,
+          interrupt_response: true,
+        },
+      },
+      output: {
+        voice: OPENAI_REALTIME_VOICE,
+      },
+    },
+  };
+}
+
+export function isPlausibleRealtimeSdpOffer(sdp: string): boolean {
+  const bytes = new TextEncoder().encode(sdp).byteLength;
+  if (bytes <= 0 || bytes > MAX_REALTIME_SDP_BYTES) return false;
+
+  const normalized = sdp.replace(/\r\n/g, "\n").trim();
+  return normalized.startsWith("v=0") && normalized.includes("\nm=audio ");
+}

--- a/src/lib/realtime/webrtc-client.ts
+++ b/src/lib/realtime/webrtc-client.ts
@@ -84,7 +84,6 @@ export async function connectRealtimeVoice(
 
   try {
     options.audioElement.autoplay = true;
-    options.audioElement.playsInline = true;
 
     peerConnection.addEventListener("track", (event) => {
       const stream = event.streams[0] ?? new MediaStream([event.track]);

--- a/src/lib/realtime/webrtc-client.ts
+++ b/src/lib/realtime/webrtc-client.ts
@@ -2,6 +2,7 @@ import {
   parseOpenAIRealtimeServerEvent,
   type AtoEnglishRealtimeSignal,
 } from "@/lib/realtime/events";
+import type { OpenAIRealtimeMode } from "@/lib/realtime/openai-session";
 
 export type RealtimeVoiceConnectionState =
   | "connecting"
@@ -11,6 +12,7 @@ export type RealtimeVoiceConnectionState =
 
 export interface ConnectRealtimeVoiceOptions {
   audioElement: HTMLAudioElement;
+  mode?: OpenAIRealtimeMode;
   onSignal?: (signal: AtoEnglishRealtimeSignal) => void;
   onRawEvent?: (event: unknown) => void;
   onStateChange?: (state: RealtimeVoiceConnectionState) => void;
@@ -140,7 +142,10 @@ export async function connectRealtimeVoice(
 
     const sessionResponse = await fetch("/api/realtime/session", {
       method: "POST",
-      headers: { "Content-Type": "application/sdp" },
+      headers: {
+        "Content-Type": "application/sdp",
+        "X-AtoEnglish-Realtime-Mode": options.mode ?? "capture",
+      },
       body: localSdp,
       credentials: "same-origin",
       cache: "no-store",

--- a/src/lib/realtime/webrtc-client.ts
+++ b/src/lib/realtime/webrtc-client.ts
@@ -1,0 +1,178 @@
+import {
+  parseOpenAIRealtimeServerEvent,
+  type AtoEnglishRealtimeSignal,
+} from "@/lib/realtime/events";
+
+export type RealtimeVoiceConnectionState =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "failed";
+
+export interface ConnectRealtimeVoiceOptions {
+  audioElement: HTMLAudioElement;
+  onSignal?: (signal: AtoEnglishRealtimeSignal) => void;
+  onRawEvent?: (event: unknown) => void;
+  onStateChange?: (state: RealtimeVoiceConnectionState) => void;
+}
+
+export interface RealtimeVoiceConnection {
+  peerConnection: RTCPeerConnection;
+  dataChannel: RTCDataChannel;
+  microphoneStream: MediaStream;
+  send: (event: Record<string, unknown>) => boolean;
+  close: () => void;
+}
+
+function providerErrorMessage(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+  const error = (payload as Record<string, unknown>).error;
+  return typeof error === "string" && error.trim().length > 0 ? error : null;
+}
+
+async function readSessionError(response: Response): Promise<string> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      return (
+        providerErrorMessage((await response.json()) as unknown) ??
+        "Không mở được realtime voice session."
+      );
+    } catch {
+      return "Không mở được realtime voice session.";
+    }
+  }
+  return "Không mở được realtime voice session.";
+}
+
+/**
+ * Minimal native-WebRTC transport for AtoEnglish realtime voice.
+ *
+ * The browser sends only its SDP offer to AtoEnglish. The OpenAI API key remains server-side in
+ * `/api/realtime/session`. Realtime transcript events are surfaced transiently to the caller; this
+ * module does not persist raw audio or transcript text.
+ */
+export async function connectRealtimeVoice(
+  options: ConnectRealtimeVoiceOptions,
+): Promise<RealtimeVoiceConnection> {
+  if (typeof window === "undefined" || typeof navigator === "undefined") {
+    throw new Error("Realtime voice chỉ chạy trong browser.");
+  }
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error("Browser này không hỗ trợ microphone capture cần cho realtime voice.");
+  }
+
+  options.onStateChange?.("connecting");
+
+  const peerConnection = new RTCPeerConnection();
+  const dataChannel = peerConnection.createDataChannel("oai-events");
+  let microphoneStream: MediaStream | null = null;
+  let closed = false;
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    dataChannel.close();
+    peerConnection.getSenders().forEach((sender) => sender.track?.stop());
+    microphoneStream?.getTracks().forEach((track) => track.stop());
+    peerConnection.close();
+    options.audioElement.srcObject = null;
+    options.onStateChange?.("disconnected");
+  };
+
+  try {
+    options.audioElement.autoplay = true;
+    options.audioElement.playsInline = true;
+
+    peerConnection.addEventListener("track", (event) => {
+      const stream = event.streams[0] ?? new MediaStream([event.track]);
+      options.audioElement.srcObject = stream;
+      void options.audioElement.play().catch(() => {
+        // The caller can offer an explicit playback gesture if the browser blocks autoplay.
+      });
+    });
+
+    peerConnection.addEventListener("connectionstatechange", () => {
+      if (peerConnection.connectionState === "connected") {
+        options.onStateChange?.("connected");
+      } else if (
+        peerConnection.connectionState === "failed" ||
+        peerConnection.connectionState === "closed"
+      ) {
+        options.onStateChange?.(
+          peerConnection.connectionState === "failed" ? "failed" : "disconnected",
+        );
+      }
+    });
+
+    dataChannel.addEventListener("message", (message) => {
+      let event: unknown = message.data;
+      if (typeof message.data === "string") {
+        try {
+          event = JSON.parse(message.data) as unknown;
+        } catch {
+          return;
+        }
+      }
+
+      options.onRawEvent?.(event);
+      const signal = parseOpenAIRealtimeServerEvent(event);
+      if (signal) options.onSignal?.(signal);
+    });
+
+    microphoneStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      video: false,
+    });
+
+    for (const track of microphoneStream.getAudioTracks()) {
+      peerConnection.addTrack(track, microphoneStream);
+    }
+
+    const offer = await peerConnection.createOffer({ offerToReceiveAudio: true });
+    await peerConnection.setLocalDescription(offer);
+    const localSdp = peerConnection.localDescription?.sdp;
+    if (!localSdp) throw new Error("Không tạo được SDP offer cho realtime voice.");
+
+    const sessionResponse = await fetch("/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/sdp" },
+      body: localSdp,
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+
+    if (!sessionResponse.ok) {
+      throw new Error(await readSessionError(sessionResponse));
+    }
+
+    const answerSdp = await sessionResponse.text();
+    if (!answerSdp.trim().startsWith("v=0")) {
+      throw new Error("Realtime provider trả SDP answer không hợp lệ.");
+    }
+
+    await peerConnection.setRemoteDescription({ type: "answer", sdp: answerSdp });
+
+    const send = (event: Record<string, unknown>) => {
+      if (dataChannel.readyState !== "open") return false;
+      dataChannel.send(JSON.stringify(event));
+      return true;
+    };
+
+    return {
+      peerConnection,
+      dataChannel,
+      microphoneStream,
+      send,
+      close,
+    };
+  } catch (error) {
+    options.onStateChange?.("failed");
+    close();
+    throw error;
+  }
+}


### PR DESCRIPTION
## Goal
Replace browser-only speech capture on the authenticated Nếp adaptive surface with a Realtime-first path while preserving canonical evidence authority and browser fallback.

## Reuse-first source
The transport design adapts the minimal native WebRTC pattern from OpenAI's MIT-licensed `openai-realtime-agents` reference implementation, but uses the current 2026 unified `POST /v1/realtime/calls` contract and `gpt-realtime-2.1` rather than copying the demo's legacy preview endpoint/model. The raw request shape was cross-checked against the current OpenAI Node SDK: multipart `sdp` (`application/sdp`) + `session` (`application/json`) with `Accept: application/sdp`.

## Architecture
- browser creates a native `RTCPeerConnection`, microphone track and `oai-events` data channel;
- browser sends only its SDP offer to authenticated `/api/realtime/session`;
- `OPENAI_API_KEY` remains server-only;
- server rate-limits per privacy-preserving hashed user ID and sends `OpenAI-Safety-Identifier`;
- session uses semantic VAD with low eagerness for learners who pause while formulating speech;
- input transcript events are transient language signals only;
- raw audio/transcript are not persisted by the transport;
- transcript is never presented as pronunciation scoring.

## Two modes
`capture` is the default and the only mode used by `/adaptive-preview` in this PR. It enables transcription and semantic turn detection but disables automatic model responses.

`conversation` is defined for the next tutor slice, but is not learner-facing yet. It must receive server-resolved canonical task context before activation.

## Learner behavior
For speech practice:
1. try Realtime capture;
2. on completed learner transcript, pass the text transiently to existing `recordNếpPracticeAttempt()` with `responseSource=speech`;
3. if Realtime cannot open, automatically fall back to browser SpeechRecognition when available;
4. if learner edits the transcript, source becomes `text`, so it cannot manufacture speaking evidence.

## Evidence boundary
No change to Session Planner, trusted evaluator, Attempt → Evidence → LearnerSkillState rules, Error Memory, FSRS, or DB schema. The Realtime model cannot grade, declare mastery, or create evidence.

## Files
- `.env.example`
- `src/app/api/realtime/session/route.ts`
- `src/features/adaptive-practice/AdaptivePracticePreview.tsx`
- `src/lib/realtime/events.ts`
- `src/lib/realtime/openai-session.ts`
- `src/lib/realtime/webrtc-client.ts`
- realtime parser/session-policy tests

## External configuration
Requires server-only `OPENAI_API_KEY` in the deployment environment for Realtime. If absent, the route fails closed with 503 and adaptive speech falls back to browser recognition. No secret is committed.

## Verification
Temporary main-target CI PR #90 ran the repository Verify workflow for final head `81c21401be159ea473f7fae97567716e46293bf0` (run #395):
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅
- full fresh PostgreSQL migration replay ✅
- database lint ✅
- pgTAP / RLS suite ✅

An earlier run correctly caught an invalid DOM assumption (`playsInline` on `HTMLAudioElement`); the transport was fixed before final verification. CI-only PR #90 was then closed without merge.

Live OpenAI provider smoke remains an environment/deployment gate because the new key is not committed or exposed to CI.

## Rollback
Close this stacked PR without merge; base `frontier/canonical-runtime-v1` remains unchanged.