### PR TITLE
Bind realtime tutor to canonical Nếp task context

### DIFF
--- a/docs/frontier/REALTIME_TUTOR_CONTEXT_V1.md
+++ b/docs/frontier/REALTIME_TUTOR_CONTEXT_V1.md
@@ -1,0 +1,52 @@
+# Realtime Tutor Context V1
+
+## Purpose
+
+Allow AtoEnglish Realtime to act as a bounded conversation partner for canonical Nếp speech tasks without giving the model authority over curriculum, scoring, mastery, or hidden evaluator targets.
+
+## Trust boundary
+
+The browser may send only task identity:
+
+- `lessonId`
+- `lessonVersion`
+- `actionId`
+
+The server resolves the current lesson/action again from the canonical Nếp registry. Browser-authored prompts are not accepted as tutor instructions.
+
+## Eligible actions
+
+V1 context compilation allows only speech actions whose kind is:
+
+- `produce`
+- `repair`
+- `transfer`
+
+`retrieve` is deliberately excluded because an interactive partner can accidentally assist independent recall.
+
+## Information excluded from the model prompt
+
+The tutor context does not include:
+
+- `targetSignals`
+- `requiredSignalGroups`
+- evidence type
+- evaluator identity
+- mastery state
+- hidden answer keys
+
+The trusted server continues to compile and persist learning attempts independently.
+
+## Fail-closed behavior
+
+`conversation` mode cannot create a Realtime session unless the server can resolve a valid eligible canonical task and build task-specific instructions. Missing, stale, malformed, or unsupported identities return an error before the provider call.
+
+`capture` remains the safe default and does not require a task identity.
+
+## Transport behavior
+
+For conversation mode, the WebRTC client sends the canonical task identifiers as request headers alongside the SDP offer. Once the data channel opens it sends a bare `response.create` event so the provider begins from the server-authored session instructions; the browser does not supply a roleplay prompt.
+
+## Evidence authority
+
+Realtime transcripts remain transient input signals. The model must not grade, score pronunciation, declare mastery, or invent progress. Attempt → Evidence → LearnerSkillState remains server-authoritative.

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -62,7 +62,9 @@ export async function POST(request: Request) {
   const mode = modeCandidate;
 
   const conversationInstructions =
-    mode === "conversation" ? resolveRealtimeConversationInstructions(request.headers) : undefined;
+    mode === "conversation"
+      ? (resolveRealtimeConversationInstructions(request.headers) ?? undefined)
+      : undefined;
   if (mode === "conversation" && !conversationInstructions) {
     return NextResponse.json(
       {

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -7,6 +7,7 @@ import {
   isOpenAIRealtimeMode,
   isPlausibleRealtimeSdpOffer,
 } from "@/lib/realtime/openai-session";
+import { resolveRealtimeConversationInstructions } from "@/lib/realtime/session-task";
 import { createRateLimiter } from "@/lib/security/rate-limit";
 import { createClient } from "@/lib/supabase/server";
 
@@ -60,6 +61,18 @@ export async function POST(request: Request) {
   }
   const mode = modeCandidate;
 
+  const conversationInstructions =
+    mode === "conversation" ? resolveRealtimeConversationInstructions(request.headers) : undefined;
+  if (mode === "conversation" && !conversationInstructions) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Realtime conversation chỉ mở cho task Nếp hợp lệ được resolve trên server.",
+      },
+      { status: 400 },
+    );
+  }
+
   const contentType = request.headers.get("content-type")?.split(";")[0]?.trim();
   if (contentType !== "application/sdp") {
     return NextResponse.json(
@@ -80,9 +93,10 @@ export async function POST(request: Request) {
   formData.set("sdp", new Blob([sdp], { type: "application/sdp" }), "offer.sdp");
   formData.set(
     "session",
-    new Blob([JSON.stringify(buildOpenAIRealtimeSessionConfig(mode))], {
-      type: "application/json",
-    }),
+    new Blob(
+      [JSON.stringify(buildOpenAIRealtimeSessionConfig(mode, conversationInstructions))],
+      { type: "application/json" },
+    ),
     "session.json",
   );
 

--- a/src/lib/realtime/__tests__/nep-tutor-context.test.ts
+++ b/src/lib/realtime/__tests__/nep-tutor-context.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNếpRealtimeTutorInstructions,
+  resolveNếpRealtimeTutorContext,
+} from "@/lib/realtime/nep-tutor-context";
+
+describe("Nếp realtime tutor context", () => {
+  it("resolves a canonical production action using learner-safe roleplay context", () => {
+    const context = resolveNếpRealtimeTutorContext({
+      lessonId: "nep-first-meeting",
+      lessonVersion: 1,
+      actionId: "produce",
+    });
+
+    expect(context).not.toBeNull();
+    expect(context).toMatchObject({
+      lessonId: "nep-first-meeting",
+      lessonVersion: 1,
+      actionId: "produce",
+      actionKind: "produce",
+      partnerCue: "Hi, I'm Maya. What's your name?",
+      changedContext: false,
+    });
+    expect(context).not.toHaveProperty("targetSignals");
+    expect(context).not.toHaveProperty("requiredSignalGroups");
+    expect(context).not.toHaveProperty("assessment");
+  });
+
+  it("allows repair and changed-context transfer but rejects retrieval and unknown actions", () => {
+    expect(
+      resolveNếpRealtimeTutorContext({
+        lessonId: "nep-first-meeting",
+        lessonVersion: 1,
+        actionId: "repair",
+      }),
+    ).toMatchObject({ actionKind: "repair" });
+
+    expect(
+      resolveNếpRealtimeTutorContext({
+        lessonId: "nep-first-meeting",
+        lessonVersion: 1,
+        actionId: "transfer",
+      }),
+    ).toMatchObject({ actionKind: "transfer", changedContext: true });
+
+    expect(
+      resolveNếpRealtimeTutorContext({
+        lessonId: "nep-first-meeting",
+        lessonVersion: 1,
+        actionId: "retrieve",
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveNếpRealtimeTutorContext({
+        lessonId: "nep-first-meeting",
+        lessonVersion: 1,
+        actionId: "missing",
+      }),
+    ).toBeNull();
+  });
+
+  it("instructs the model to act as a partner without teaching or grading", () => {
+    const context = resolveNếpRealtimeTutorContext({
+      lessonId: "nep-first-meeting",
+      lessonVersion: 1,
+      actionId: "repair",
+    });
+    expect(context).not.toBeNull();
+    if (!context) return;
+
+    const instructions = buildNếpRealtimeTutorInstructions(context);
+    expect(instructions).toContain("roleplay partner, not the teacher or grader");
+    expect(instructions).toContain(context.partnerCue);
+    expect(instructions).toContain("never read bracketed text aloud");
+    expect(instructions).toContain("Do not correct, coach, reveal an ideal answer");
+    expect(instructions).toContain("trusted server evaluates the captured learner response separately");
+  });
+});

--- a/src/lib/realtime/__tests__/nep-tutor-context.test.ts
+++ b/src/lib/realtime/__tests__/nep-tutor-context.test.ts
@@ -5,17 +5,19 @@ import {
   resolveNếpRealtimeTutorContext,
 } from "@/lib/realtime/nep-tutor-context";
 
+const lessonId = "LESSON-CAP002-FIRST-MEETING-V1";
+
 describe("Nếp realtime tutor context", () => {
   it("resolves a canonical production action using learner-safe roleplay context", () => {
     const context = resolveNếpRealtimeTutorContext({
-      lessonId: "nep-first-meeting",
+      lessonId,
       lessonVersion: 1,
       actionId: "produce",
     });
 
     expect(context).not.toBeNull();
     expect(context).toMatchObject({
-      lessonId: "nep-first-meeting",
+      lessonId,
       lessonVersion: 1,
       actionId: "produce",
       actionKind: "produce",
@@ -30,7 +32,7 @@ describe("Nếp realtime tutor context", () => {
   it("allows repair and changed-context transfer but rejects retrieval and unknown actions", () => {
     expect(
       resolveNếpRealtimeTutorContext({
-        lessonId: "nep-first-meeting",
+        lessonId,
         lessonVersion: 1,
         actionId: "repair",
       }),
@@ -38,7 +40,7 @@ describe("Nếp realtime tutor context", () => {
 
     expect(
       resolveNếpRealtimeTutorContext({
-        lessonId: "nep-first-meeting",
+        lessonId,
         lessonVersion: 1,
         actionId: "transfer",
       }),
@@ -46,7 +48,7 @@ describe("Nếp realtime tutor context", () => {
 
     expect(
       resolveNếpRealtimeTutorContext({
-        lessonId: "nep-first-meeting",
+        lessonId,
         lessonVersion: 1,
         actionId: "retrieve",
       }),
@@ -54,7 +56,7 @@ describe("Nếp realtime tutor context", () => {
 
     expect(
       resolveNếpRealtimeTutorContext({
-        lessonId: "nep-first-meeting",
+        lessonId,
         lessonVersion: 1,
         actionId: "missing",
       }),
@@ -63,7 +65,7 @@ describe("Nếp realtime tutor context", () => {
 
   it("instructs the model to act as a partner without teaching or grading", () => {
     const context = resolveNếpRealtimeTutorContext({
-      lessonId: "nep-first-meeting",
+      lessonId,
       lessonVersion: 1,
       actionId: "repair",
     });

--- a/src/lib/realtime/__tests__/openai-session.test.ts
+++ b/src/lib/realtime/__tests__/openai-session.test.ts
@@ -23,12 +23,25 @@ describe("realtime session policy", () => {
     expect(config.instructions).toContain("Do not grade, score, declare mastery");
   });
 
-  it("enables model responses only in explicit conversation mode", () => {
-    const config = buildOpenAIRealtimeSessionConfig("conversation");
+  it("fails closed when conversation mode has no canonical server instructions", () => {
+    expect(() => buildOpenAIRealtimeSessionConfig("conversation")).toThrow(
+      "canonical server-resolved task instructions",
+    );
+    expect(() => buildOpenAIRealtimeSessionConfig("conversation", "   ")).toThrow(
+      "canonical server-resolved task instructions",
+    );
+  });
+
+  it("enables responses only when conversation mode has canonical task instructions", () => {
+    const config = buildOpenAIRealtimeSessionConfig(
+      "conversation",
+      "Roleplay the current first-meeting task. Keep the next turn short.",
+    );
 
     expect(config.audio.input.turn_detection.create_response).toBe(true);
     expect(config.audio.input.turn_detection.interrupt_response).toBe(true);
-    expect(config.instructions).toContain("realtime English speaking partner");
+    expect(config.instructions).toContain("server-resolved roleplay context");
+    expect(config.instructions).toContain("Roleplay the current first-meeting task");
     expect(config.instructions).toContain("trusted server evaluates learning evidence separately");
   });
 

--- a/src/lib/realtime/__tests__/session-task.test.ts
+++ b/src/lib/realtime/__tests__/session-task.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRealtimeConversationInstructions } from "@/lib/realtime/session-task";
+
+function headersFor(actionId: string) {
+  return new Headers({
+    "X-AtoEnglish-Lesson-Id": "LESSON-CAP002-FIRST-MEETING-V1",
+    "X-AtoEnglish-Lesson-Version": "1",
+    "X-AtoEnglish-Action-Id": actionId,
+  });
+}
+
+describe("realtime canonical task resolution", () => {
+  it("resolves an eligible speech roleplay from the canonical Nếp registry", () => {
+    const instructions = resolveRealtimeConversationInstructions(headersFor("produce"));
+
+    expect(instructions).toContain("Current interaction type: produce");
+    expect(instructions).toContain("Hi, I'm Maya. What's your name?");
+    expect(instructions).toContain("conversation partner");
+  });
+
+  it("rejects retrieval so conversation cannot assist independent recall", () => {
+    expect(resolveRealtimeConversationInstructions(headersFor("retrieve"))).toBeNull();
+  });
+
+  it("rejects stale, malformed and incomplete task identities", () => {
+    expect(
+      resolveRealtimeConversationInstructions(
+        new Headers({
+          "X-AtoEnglish-Lesson-Id": "LESSON-CAP002-FIRST-MEETING-V1",
+          "X-AtoEnglish-Lesson-Version": "999",
+          "X-AtoEnglish-Action-Id": "produce",
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      resolveRealtimeConversationInstructions(
+        new Headers({
+          "X-AtoEnglish-Lesson-Id": "LESSON-CAP002-FIRST-MEETING-V1",
+          "X-AtoEnglish-Lesson-Version": "not-a-number",
+          "X-AtoEnglish-Action-Id": "produce",
+        }),
+      ),
+    ).toBeNull();
+    expect(resolveRealtimeConversationInstructions(new Headers())).toBeNull();
+  });
+
+  it("does not leak canonical evaluator internals into model instructions", () => {
+    const instructions = resolveRealtimeConversationInstructions(headersFor("transfer"));
+
+    expect(instructions).not.toContain("targetSignals");
+    expect(instructions).not.toContain("requiredSignalGroups");
+    expect(instructions).not.toContain("evidenceType");
+    expect(instructions).not.toContain("nep-target-signal-v1");
+  });
+});

--- a/src/lib/realtime/nep-tutor-context.ts
+++ b/src/lib/realtime/nep-tutor-context.ts
@@ -1,0 +1,85 @@
+import { resolveNếpAction } from "@/lib/nep/practice-execution.v1";
+import type { LessonActionKind } from "@/lib/nep/lesson-contract";
+
+const REALTIME_TUTOR_ACTION_KINDS = new Set<LessonActionKind>([
+  "produce",
+  "repair",
+  "transfer",
+]);
+
+export type NếpRealtimeTutorIdentity = {
+  lessonId: string;
+  lessonVersion: number;
+  actionId: string;
+};
+
+export type NếpRealtimeTutorContext = NếpRealtimeTutorIdentity & {
+  mission: string;
+  learnerCanDo: string;
+  actionKind: "produce" | "repair" | "transfer";
+  instruction: string;
+  partnerCue: string;
+  changedContext: boolean;
+};
+
+/**
+ * Resolve a browser-supplied task identity back to canonical Nếp content on the server.
+ *
+ * Deliberately excludes targetSignals, requiredSignalGroups, evidence type and evaluator metadata.
+ * The realtime model is a conversation partner, not a grader and not a source of mastery truth.
+ */
+export function resolveNếpRealtimeTutorContext(
+  identity: NếpRealtimeTutorIdentity,
+): NếpRealtimeTutorContext | null {
+  const resolved = resolveNếpAction(
+    identity.lessonId,
+    identity.lessonVersion,
+    identity.actionId,
+  );
+  if (!resolved) return null;
+
+  const { lesson, action } = resolved;
+  if (
+    action.modality !== "speech" ||
+    !REALTIME_TUTOR_ACTION_KINDS.has(action.kind) ||
+    !action.prompt
+  ) {
+    return null;
+  }
+
+  return {
+    lessonId: lesson.id,
+    lessonVersion: lesson.version,
+    actionId: action.id,
+    mission: lesson.mission,
+    learnerCanDo: lesson.learnerCanDo,
+    actionKind: action.kind as NếpRealtimeTutorContext["actionKind"],
+    instruction: action.instruction,
+    partnerCue: action.prompt,
+    changedContext: action.changedContext ?? false,
+  };
+}
+
+/**
+ * Build roleplay instructions from learner-visible/canonical task context only.
+ * Hidden answer keys never need to enter the voice-model prompt.
+ */
+export function buildNếpRealtimeTutorInstructions(
+  context: NếpRealtimeTutorContext,
+): string {
+  return [
+    "You are AtoEnglish's realtime English roleplay partner, not the teacher or grader.",
+    `Mission: ${context.mission}`,
+    `Learner can-do target: ${context.learnerCanDo}`,
+    `Current interaction type: ${context.actionKind}${context.changedContext ? " in a changed transfer context" : ""}.`,
+    `Task instruction: ${context.instruction}`,
+    `Partner cue: ${context.partnerCue}`,
+    "When the session asks you to respond before the learner has spoken, begin the roleplay with one short natural English turn based on the partner cue.",
+    "If the partner cue contains brackets or stage directions, act them out naturally; never read bracketed text aloud.",
+    "Then listen. Let a beginner pause while formulating an answer.",
+    "After the learner's turn, respond as the conversation partner in at most one short sentence, then stop and wait.",
+    "If the learner asks you to repeat or slow down, do so naturally without teaching the target phrase.",
+    "Do not correct, coach, reveal an ideal answer, explain grammar, score pronunciation, praise correctness, or declare mastery.",
+    "Do not invent learner progress. AtoEnglish's trusted server evaluates the captured learner response separately.",
+  ].join(" ");
+}

--- a/src/lib/realtime/openai-session.ts
+++ b/src/lib/realtime/openai-session.ts
@@ -30,37 +30,36 @@ export type OpenAIRealtimeSessionConfig = {
   };
 };
 
+const CAPTURE_ONLY_INSTRUCTIONS = [
+  "This session is capture-only for AtoEnglish learning evidence.",
+  "Do not produce a conversational response.",
+  "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
+  "AtoEnglish's trusted server evaluates the transient input transcript separately.",
+].join(" ");
+
 /**
- * Transport-level policy only.
+ * Transport-level policy.
  *
- * `capture` is the safe default for canonical Nếp practice: Realtime performs microphone transport,
- * semantic turn detection and input transcription but does not generate a model response.
- * `conversation` is reserved for a later server-resolved tutor layer that can inject the current
- * canonical task context without giving the model mastery authority.
+ * `capture` can be created without task context. `conversation` fails closed unless the server has
+ * already resolved a canonical Nếp task and supplied task-specific roleplay instructions.
  */
 export function buildOpenAIRealtimeSessionConfig(
   mode: OpenAIRealtimeMode = "capture",
+  conversationInstructions?: string,
 ): OpenAIRealtimeSessionConfig {
   const conversation = mode === "conversation";
+  const instructions = conversation
+    ? conversationInstructions?.trim()
+    : CAPTURE_ONLY_INSTRUCTIONS;
+
+  if (conversation && !instructions) {
+    throw new Error("Realtime conversation requires canonical task instructions.");
+  }
 
   return {
     type: "realtime",
     model: OPENAI_REALTIME_MODEL,
-    instructions: conversation
-      ? [
-          "You are AtoEnglish's realtime English speaking partner.",
-          "Keep each reply concise and natural, normally one short conversational turn.",
-          "Let the learner finish speaking; beginners may pause while formulating an answer.",
-          "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
-          "Do not reveal hidden answer keys or invent learner progress.",
-          "AtoEnglish's trusted server evaluates learning evidence separately.",
-        ].join(" ")
-      : [
-          "This session is capture-only for AtoEnglish learning evidence.",
-          "Do not produce a conversational response.",
-          "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
-          "AtoEnglish's trusted server evaluates the transient input transcript separately.",
-        ].join(" "),
+    instructions: instructions ?? CAPTURE_ONLY_INSTRUCTIONS,
     max_output_tokens: conversation ? 128 : 1,
     audio: {
       input: {

--- a/src/lib/realtime/openai-session.ts
+++ b/src/lib/realtime/openai-session.ts
@@ -37,29 +37,39 @@ const CAPTURE_ONLY_INSTRUCTIONS = [
   "AtoEnglish's trusted server evaluates the transient input transcript separately.",
 ].join(" ");
 
+const CONVERSATION_GUARDRAILS = [
+  "You are operating inside an AtoEnglish canonical learning task.",
+  "Stay inside the server-resolved roleplay context below.",
+  "Do not grade, score, declare mastery, or claim pronunciation accuracy.",
+  "Do not reveal hidden answer keys or invent learner progress.",
+  "AtoEnglish's trusted server evaluates learning evidence separately.",
+].join(" ");
+
 /**
- * Transport-level policy.
+ * Transport-level policy only.
  *
- * `capture` can be created without task context. `conversation` fails closed unless the server has
- * already resolved a canonical Nếp task and supplied task-specific roleplay instructions.
+ * `capture` is the safe default for canonical Nếp practice: Realtime performs microphone transport,
+ * semantic turn detection and input transcription but does not generate a model response.
+ * `conversation` is fail-closed: the caller must provide task-specific instructions that were
+ * resolved on the trusted server from canonical Nếp content.
  */
 export function buildOpenAIRealtimeSessionConfig(
   mode: OpenAIRealtimeMode = "capture",
   conversationInstructions?: string,
 ): OpenAIRealtimeSessionConfig {
   const conversation = mode === "conversation";
-  const instructions = conversation
-    ? conversationInstructions?.trim()
-    : CAPTURE_ONLY_INSTRUCTIONS;
+  const taskInstructions = conversationInstructions?.trim();
 
-  if (conversation && !instructions) {
-    throw new Error("Realtime conversation requires canonical task instructions.");
+  if (conversation && !taskInstructions) {
+    throw new Error("Realtime conversation requires canonical server-resolved task instructions.");
   }
 
   return {
     type: "realtime",
     model: OPENAI_REALTIME_MODEL,
-    instructions: instructions ?? CAPTURE_ONLY_INSTRUCTIONS,
+    instructions: conversation
+      ? `${CONVERSATION_GUARDRAILS} ${taskInstructions}`
+      : CAPTURE_ONLY_INSTRUCTIONS,
     max_output_tokens: conversation ? 128 : 1,
     audio: {
       input: {

--- a/src/lib/realtime/session-task.ts
+++ b/src/lib/realtime/session-task.ts
@@ -1,0 +1,36 @@
+import {
+  buildNếpRealtimeTutorInstructions,
+  resolveNếpRealtimeTutorContext,
+} from "@/lib/realtime/nep-tutor-context";
+
+const MAX_LESSON_ID_LENGTH = 160;
+const MAX_ACTION_ID_LENGTH = 120;
+
+function boundedHeader(headers: Headers, name: string, maxLength: number): string | null {
+  const value = headers.get(name)?.trim();
+  if (!value || value.length > maxLength) return null;
+  return value;
+}
+
+/**
+ * Convert an untrusted browser task identity into trusted conversation instructions.
+ *
+ * Only identifiers cross the browser/server boundary. Lesson mission, prompt and roleplay policy are
+ * resolved again from the canonical Nếp registry on the server. Invalid, unsupported or stale task
+ * identities fail closed.
+ */
+export function resolveRealtimeConversationInstructions(headers: Headers): string | null {
+  const lessonId = boundedHeader(headers, "x-atoenglish-lesson-id", MAX_LESSON_ID_LENGTH);
+  const actionId = boundedHeader(headers, "x-atoenglish-action-id", MAX_ACTION_ID_LENGTH);
+  const lessonVersionRaw = boundedHeader(headers, "x-atoenglish-lesson-version", 8);
+
+  if (!lessonId || !actionId || !lessonVersionRaw) return null;
+
+  const lessonVersion = Number(lessonVersionRaw);
+  if (!Number.isInteger(lessonVersion) || lessonVersion <= 0) return null;
+
+  const context = resolveNếpRealtimeTutorContext({ lessonId, lessonVersion, actionId });
+  if (!context) return null;
+
+  return buildNếpRealtimeTutorInstructions(context);
+}

--- a/src/lib/realtime/webrtc-client.ts
+++ b/src/lib/realtime/webrtc-client.ts
@@ -2,6 +2,7 @@ import {
   parseOpenAIRealtimeServerEvent,
   type AtoEnglishRealtimeSignal,
 } from "@/lib/realtime/events";
+import type { NếpRealtimeTutorIdentity } from "@/lib/realtime/nep-tutor-context";
 import type { OpenAIRealtimeMode } from "@/lib/realtime/openai-session";
 
 export type RealtimeVoiceConnectionState =
@@ -13,6 +14,7 @@ export type RealtimeVoiceConnectionState =
 export interface ConnectRealtimeVoiceOptions {
   audioElement: HTMLAudioElement;
   mode?: OpenAIRealtimeMode;
+  taskIdentity?: NếpRealtimeTutorIdentity;
   onSignal?: (signal: AtoEnglishRealtimeSignal) => void;
   onRawEvent?: (event: unknown) => void;
   onStateChange?: (state: RealtimeVoiceConnectionState) => void;
@@ -50,9 +52,9 @@ async function readSessionError(response: Response): Promise<string> {
 /**
  * Minimal native-WebRTC transport for AtoEnglish realtime voice.
  *
- * The browser sends only its SDP offer to AtoEnglish. The OpenAI API key remains server-side in
- * `/api/realtime/session`. Realtime transcript events are surfaced transiently to the caller; this
- * module does not persist raw audio or transcript text.
+ * The browser sends only its SDP offer and, for conversation mode, canonical task identifiers to
+ * AtoEnglish. The server resolves the actual roleplay instructions. Realtime transcript events are
+ * surfaced transiently to the caller; this module does not persist raw audio or transcript text.
  */
 export async function connectRealtimeVoice(
   options: ConnectRealtimeVoiceOptions,
@@ -62,6 +64,11 @@ export async function connectRealtimeVoice(
   }
   if (!navigator.mediaDevices?.getUserMedia) {
     throw new Error("Browser này không hỗ trợ microphone capture cần cho realtime voice.");
+  }
+
+  const mode = options.mode ?? "capture";
+  if (mode === "conversation" && !options.taskIdentity) {
+    throw new Error("Realtime conversation cần canonical Nếp task identity.");
   }
 
   options.onStateChange?.("connecting");
@@ -106,6 +113,12 @@ export async function connectRealtimeVoice(
       }
     });
 
+    dataChannel.addEventListener("open", () => {
+      if (mode === "conversation") {
+        dataChannel.send(JSON.stringify({ type: "response.create" }));
+      }
+    });
+
     dataChannel.addEventListener("message", (message) => {
       let event: unknown = message.data;
       if (typeof message.data === "string") {
@@ -139,12 +152,22 @@ export async function connectRealtimeVoice(
     const localSdp = peerConnection.localDescription?.sdp;
     if (!localSdp) throw new Error("Không tạo được SDP offer cho realtime voice.");
 
+    const sessionHeaders = new Headers({
+      "Content-Type": "application/sdp",
+      "X-AtoEnglish-Realtime-Mode": mode,
+    });
+    if (mode === "conversation" && options.taskIdentity) {
+      sessionHeaders.set("X-AtoEnglish-Lesson-Id", options.taskIdentity.lessonId);
+      sessionHeaders.set(
+        "X-AtoEnglish-Lesson-Version",
+        String(options.taskIdentity.lessonVersion),
+      );
+      sessionHeaders.set("X-AtoEnglish-Action-Id", options.taskIdentity.actionId);
+    }
+
     const sessionResponse = await fetch("/api/realtime/session", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/sdp",
-        "X-AtoEnglish-Realtime-Mode": options.mode ?? "capture",
-      },
+      headers: sessionHeaders,
       body: localSdp,
       credentials: "same-origin",
       cache: "no-store",


### PR DESCRIPTION
## Goal
Allow Realtime conversation mode only when the trusted server can resolve an eligible canonical Nếp speech task. Browser-authored roleplay prompts are not accepted.

## Trust boundary
The browser sends only `lessonId`, `lessonVersion`, and `actionId` alongside the SDP offer. The server resolves the lesson/action again from the canonical Nếp registry and compiles model instructions from learner-visible mission/instruction/prompt context.

## Eligible V1 actions
- `produce`
- `repair`
- `transfer`

`retrieve` is deliberately rejected so an interactive model cannot assist independent recall.

## Hidden evaluator data excluded
Realtime tutor instructions do not include `targetSignals`, `requiredSignalGroups`, evidence type, evaluator identity, mastery state, or hidden answer keys.

## Fail-closed rules
- `conversation` without canonical server-resolved instructions throws at session-policy level.
- missing/stale/malformed/unsupported task identity returns 400 before the provider call.
- `capture` remains the safe default and needs no task identity.

## WebRTC behavior
Conversation mode requires a task identity in the client contract. After the data channel opens, the client emits a bare `response.create`; the roleplay content still comes only from server-authored session instructions.

## Scope
This PR does not yet switch the adaptive learner UI from capture to conversation. It establishes and verifies the server/transport contract first so learner-facing activation remains a separate rollback unit.

## Verification
Temporary main-target CI PR #92 ran the full repository Verify workflow for final head `2d101b8a1557e5bbc5ac83a50bf464baaa53130a` (run #397):
- lint ✅
- TypeScript ✅
- unit tests ✅
- content standards ✅
- fresh PostgreSQL migration replay ✅
- database lint ✅
- pgTAP / RLS ✅

Run #396 previously caught one strict-nullability mismatch at the route boundary; it was fixed before final verification. CI-only PR #92 was closed without merge.

## Rollback
Close this stacked PR; `frontier/realtime-voice-transport-v1` remains unchanged.