### PR TITLE
Distinguish unknown learner dimensions from observed zero

### DIFF
--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -134,11 +134,11 @@ describe("session planner v1", () => {
 
     const blocked = plan({ candidates: [transfer], states: [state("cap-a")], sessionSize: 1 });
     expect(blocked.opportunities).toEqual([]);
-    expect(blocked.blocked[0]?.reasons).toContain("transfer-needs-prior-production");
+    expect(blocked.blocked[0]?.reasons).toContain("transfer-needs-observed-production");
 
     const allowed = plan({
       candidates: [transfer],
-      states: [state("cap-a", { production: 0.35, evidenceCount: 2 })],
+      states: [state("cap-a", { production: 0.35, evidenceCount: 2, evidenceByType: { production: 2 } })],
       sessionSize: 1,
     });
     expect(allowed.opportunities[0]?.candidate.id).toBe("cap-a:transfer");

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -7,13 +7,16 @@ import {
   buildErrorMemory,
   type ErrorMemoryAttemptRow,
 } from "@/lib/learning/error-memory";
+import { LEARNER_STATE_MODEL_VERSION } from "@/lib/learning/learner-state-read";
 import {
+  buildLearnerEvidenceCoverage,
   collectPlannerTargetIds,
   deriveRecentPlannerHistory,
   mapLearnerSkillStateRow,
   normalizeSessionSize,
   PLANNER_RECENT_ATTEMPT_SELECT,
   PLANNER_SKILL_STATE_SELECT,
+  type LearnerEvidenceCoverageRow,
   type LearnerSkillStateRow,
   type RecentLearningAttemptRow,
 } from "@/lib/learning/session-input";
@@ -41,6 +44,10 @@ type PlannerQuery<T> = {
 
 type PlannerReadClient = {
   from: <T>(table: string) => PlannerQuery<T>;
+  rpc: <T>(
+    functionName: string,
+    args: Record<string, unknown>,
+  ) => QueryResult<T>;
 };
 
 export type GetNếpSessionPlanInput = {
@@ -61,6 +68,9 @@ export type GetNếpSessionPlanResult =
         catalogSize: number;
         practiceEnvelopeCount: number;
         stateCount: number;
+        evidenceCoverageRowCount: number;
+        learnerStateModelVersion: typeof LEARNER_STATE_MODEL_VERSION;
+        learnerStateConfidenceCalibrated: false;
         recentAttemptCount: number;
         errorMemoryAttemptCount: number;
         recurringErrorCount: number;
@@ -106,6 +116,12 @@ export async function getNếpSessionPlan(
       .in("target_id", targetIds)
       .limit(100);
 
+    // Aggregate coverage comes from append-only evidence history, not the EMA routing snapshot.
+    const evidenceCoverageQuery = readClient.rpc<LearnerEvidenceCoverageRow>(
+      "get_learner_evidence_coverage",
+      { p_target_ids: targetIds },
+    );
+
     // Recent attempts are exposure history only. Project semantic planner keys, not raw content.
     const recentAttemptQuery = readClient
       .from<RecentLearningAttemptRow>("learning_attempts")
@@ -124,13 +140,21 @@ export async function getNếpSessionPlan(
       .order("created_at", { ascending: false })
       .limit(200);
 
-    const [stateResult, recentAttemptResult, errorMemoryResult] = await Promise.all([
-      stateQuery,
-      recentAttemptQuery,
-      errorMemoryQuery,
-    ]);
+    const [stateResult, evidenceCoverageResult, recentAttemptResult, errorMemoryResult] =
+      await Promise.all([
+        stateQuery,
+        evidenceCoverageQuery,
+        recentAttemptQuery,
+        errorMemoryQuery,
+      ]);
     if (stateResult.error) {
       return { success: false, error: `Không thể đọc learner state: ${stateResult.error.message}` };
+    }
+    if (evidenceCoverageResult.error) {
+      return {
+        success: false,
+        error: `Không thể đọc evidence coverage: ${evidenceCoverageResult.error.message}`,
+      };
     }
     if (recentAttemptResult.error) {
       return { success: false, error: `Không thể đọc lịch sử practice gần đây: ${recentAttemptResult.error.message}` };
@@ -139,7 +163,10 @@ export async function getNếpSessionPlan(
       return { success: false, error: `Không thể đọc error memory: ${errorMemoryResult.error.message}` };
     }
 
-    const states = (stateResult.data ?? []).map(mapLearnerSkillStateRow);
+    const evidenceCoverage = buildLearnerEvidenceCoverage(evidenceCoverageResult.data ?? []);
+    const states = (stateResult.data ?? []).map((row) =>
+      mapLearnerSkillStateRow(row, evidenceCoverage.get(row.target_id) ?? {}),
+    );
     const recentHistory = deriveRecentPlannerHistory(recentAttemptResult.data ?? []);
     const errorMemory = buildErrorMemory(errorMemoryResult.data ?? []);
     const plan = planSession({
@@ -165,6 +192,9 @@ export async function getNếpSessionPlan(
         catalogSize: nepSessionCatalogV1.length,
         practiceEnvelopeCount: practices.length,
         stateCount: states.length,
+        evidenceCoverageRowCount: evidenceCoverageResult.data?.length ?? 0,
+        learnerStateModelVersion: LEARNER_STATE_MODEL_VERSION,
+        learnerStateConfidenceCalibrated: false,
         recentAttemptCount: recentAttemptResult.data?.length ?? 0,
         errorMemoryAttemptCount: errorMemoryResult.data?.length ?? 0,
         recurringErrorCount: errorMemory.recurring.length,

--- a/src/lib/learning/evidence.ts
+++ b/src/lib/learning/evidence.ts
@@ -9,6 +9,7 @@ export const EVIDENCE_TYPES = [
 ] as const;
 
 export type EvidenceType = (typeof EVIDENCE_TYPES)[number];
+export type EvidenceCoverage = Partial<Record<EvidenceType, number>>;
 export type ResponseModality = "choice" | "text" | "speech" | "gesture" | "none";
 
 export interface LearningAttemptInput {
@@ -124,6 +125,11 @@ export interface LearnerSkillState {
   transfer: number;
   retention: number;
   evidenceCount: number;
+  /**
+   * Coverage is derived from append-only evidence history. Numeric skill values remain a fast
+   * routing snapshot; a zero with no typed evidence is unknown, not observed failure.
+   */
+  evidenceByType?: EvidenceCoverage;
   lastEvidenceAt: string | null;
 }
 
@@ -138,6 +144,15 @@ export function createEmptyLearnerSkillState(targetId: string): LearnerSkillStat
     transfer: 0,
     retention: 0,
     evidenceCount: 0,
+    evidenceByType: {
+      recognition: 0,
+      retrieval: 0,
+      listening: 0,
+      production: 0,
+      repair: 0,
+      transfer: 0,
+      retention: 0,
+    },
     lastEvidenceAt: null,
   };
 }
@@ -157,11 +172,16 @@ export function applyEvidenceToSkillState(
   const observation = evidence.success ? effectiveConfidence : 0;
   const alpha = evidence.success ? 0.35 : 0.5;
   const nextValue = clamp(oldValue * (1 - alpha) + observation * alpha, 0, 1);
+  const typedEvidenceCount = Math.max(0, Math.floor(current.evidenceByType?.[evidence.type] ?? 0));
 
   return {
     ...current,
     [evidence.type]: nextValue,
     evidenceCount: current.evidenceCount + 1,
+    evidenceByType: {
+      ...current.evidenceByType,
+      [evidence.type]: typedEvidenceCount + 1,
+    },
     lastEvidenceAt: occurredAt,
   };
 }

--- a/src/lib/learning/learner-state-read.test.ts
+++ b/src/lib/learning/learner-state-read.test.ts
@@ -88,4 +88,130 @@ describe("learner state evidence coverage", () => {
     expect(plan.opportunities).toHaveLength(0);
     expect(plan.blocked[0]?.reasons).toContain("transfer-needs-observed-production");
   });
+
+  it("blocks transfer when production is observed but below the readiness floor", () => {
+    const transfer: PlannerCandidate = {
+      id: "transfer-test",
+      targetId: "CAP-TEST",
+      evidenceType: "transfer",
+    };
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      production: 0.1, // Below default floor 0.2
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    const plan = planSession({ candidates: [transfer], states: [state], sessionSize: 1 });
+
+    expect(plan.opportunities).toHaveLength(0);
+    expect(plan.blocked[0]?.reasons).toContain("transfer-needs-prior-production");
+  });
+
+  it("allows transfer when production is observed and meets or exceeds the readiness floor", () => {
+    const transfer: PlannerCandidate = {
+      id: "transfer-test",
+      targetId: "CAP-TEST",
+      evidenceType: "transfer",
+    };
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      production: 0.35, // Above default floor 0.2
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    const plan = planSession({ candidates: [transfer], states: [state], sessionSize: 1 });
+
+    expect(plan.opportunities).toHaveLength(1);
+    expect(plan.opportunities[0]?.candidate.id).toBe("transfer-test");
+  });
+
+  it("grants per-dimension cold-start exploration when one dimension is observed but another is unknown", () => {
+    const produceCandidate: PlannerCandidate = {
+      id: "produce-test",
+      targetId: "CAP-TEST",
+      evidenceType: "production",
+      importance: 0.5,
+    };
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.9,
+      evidenceCount: 5,
+      evidenceByType: { recognition: 5 }, // Production is unknown
+    };
+
+    const plan = planSession({ candidates: [produceCandidate], states: [state], sessionSize: 1 });
+
+    expect(plan.opportunities[0]?.breakdown.skillGap).toBe(0);
+    expect(plan.opportunities[0]?.breakdown.coldStart).toBeGreaterThan(0);
+    expect(plan.opportunities[0]?.reasons).toContain("evidence-unknown:production");
+    expect(plan.opportunities[0]?.reasons).toContain("cold-start:production");
+  });
+
+  describe("fallback semantics when typed coverage is absent", () => {
+    it("fails closed to unknown for default zero dimensions even when total evidenceCount > 0", () => {
+      const legacyState = {
+        targetId: "CAP-LEGACY",
+        recognition: 0.85,
+        retrieval: 0,
+        listening: 0,
+        production: 0, // Unobserved in reality
+        repair: 0,
+        transfer: 0,
+        retention: 0,
+        evidenceCount: 10, // Total evidence exists from recognition
+        lastEvidenceAt: "2026-09-02T10:00:00.000Z",
+        evidenceByType: undefined, // Typed coverage missing!
+      };
+
+      const read = readLearnerDimension(legacyState, "production");
+      expect(read.status).toBe("unknown");
+      expect(read.estimate).toBeNull();
+      expect(read.evidenceCount).toBe(0);
+    });
+
+    it("treats positive estimates as observed even without typed coverage", () => {
+      const legacyState = {
+        targetId: "CAP-LEGACY",
+        recognition: 0.85,
+        retrieval: 0,
+        listening: 0,
+        production: 0.6, // Explicit positive estimate
+        repair: 0,
+        transfer: 0,
+        retention: 0,
+        evidenceCount: 10,
+        lastEvidenceAt: "2026-09-02T10:00:00.000Z",
+        evidenceByType: undefined,
+      };
+
+      const read = readLearnerDimension(legacyState, "production");
+      expect(read.status).toBe("observed");
+      expect(read.estimate).toBe(0.6);
+      expect(read.evidenceCount).toBe(10);
+    });
+  });
+
+  describe("invalid / malformed evidence coverage normalization", () => {
+    it("normalizes invalid counts deterministically", () => {
+      const stateWithBadCounts = {
+        ...createEmptyLearnerSkillState("CAP-TEST"),
+        evidenceByType: {
+          recognition: Number.NaN,
+          retrieval: -3,
+          production: 2.7,
+          transfer: ("five" as unknown as number),
+        },
+      };
+
+      expect(readLearnerDimension(stateWithBadCounts, "recognition").status).toBe("unknown");
+      expect(readLearnerDimension(stateWithBadCounts, "retrieval").status).toBe("unknown");
+      expect(readLearnerDimension(stateWithBadCounts, "transfer").status).toBe("unknown");
+
+      const production = readLearnerDimension(stateWithBadCounts, "production");
+      expect(production.status).toBe("observed");
+      expect(production.evidenceCount).toBe(2); // Math.floor(2.7)
+    });
+  });
 });

--- a/src/lib/learning/learner-state-read.test.ts
+++ b/src/lib/learning/learner-state-read.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyLearnerSkillState } from "./evidence";
+import { readLearnerDimension } from "./learner-state-read";
+import { planSession, type PlannerCandidate } from "./session-planner";
+
+describe("learner state evidence coverage", () => {
+  it("keeps an unobserved default zero unknown", () => {
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.8,
+      evidenceCount: 1,
+      evidenceByType: { recognition: 1 },
+    };
+
+    expect(readLearnerDimension(state, "production")).toEqual({
+      estimate: null,
+      evidenceCount: 0,
+      status: "unknown",
+      confidence: null,
+      modelVersion: "ema-routing-v1",
+      decisionScope: "routing",
+    });
+  });
+
+  it("keeps an observed zero as real routing evidence", () => {
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    expect(readLearnerDimension(state, "production")).toMatchObject({
+      estimate: 0,
+      evidenceCount: 1,
+      status: "observed",
+      confidence: null,
+    });
+  });
+
+  it("does not turn an unknown dimension into a full skill gap", () => {
+    const candidate: PlannerCandidate = {
+      id: "produce-test",
+      targetId: "CAP-TEST",
+      evidenceType: "production",
+      importance: 0,
+    };
+    const unknownState = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.8,
+      evidenceCount: 1,
+      evidenceByType: { recognition: 1 },
+    };
+    const observedZeroState = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    const unknown = planSession({ candidates: [candidate], states: [unknownState], sessionSize: 1 });
+    const observedZero = planSession({
+      candidates: [candidate],
+      states: [observedZeroState],
+      sessionSize: 1,
+    });
+
+    expect(unknown.opportunities[0]?.breakdown.skillGap).toBe(0);
+    expect(unknown.opportunities[0]?.reasons).toContain("evidence-unknown:production");
+    expect(observedZero.opportunities[0]?.breakdown.skillGap).toBe(1);
+    expect(observedZero.opportunities[0]?.reasons).toContain("skill-gap:1");
+  });
+
+  it("blocks transfer until production has actually been observed", () => {
+    const transfer: PlannerCandidate = {
+      id: "transfer-test",
+      targetId: "CAP-TEST",
+      evidenceType: "transfer",
+    };
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.9,
+      evidenceCount: 2,
+      evidenceByType: { recognition: 2 },
+    };
+
+    const plan = planSession({ candidates: [transfer], states: [state], sessionSize: 1 });
+
+    expect(plan.opportunities).toHaveLength(0);
+    expect(plan.blocked[0]?.reasons).toContain("transfer-needs-observed-production");
+  });
+});

--- a/src/lib/learning/learner-state-read.ts
+++ b/src/lib/learning/learner-state-read.ts
@@ -23,11 +23,16 @@ export function readLearnerDimension(
   evidenceType: EvidenceType,
 ): LearnerDimensionRead {
   const typedCoverage = state.evidenceByType;
-  const evidenceCount = typedCoverage
-    ? normalizeCount(typedCoverage[evidenceType])
-    : state.evidenceCount > 0
-      ? state.evidenceCount
-      : 0;
+  const rawValue = clamp01(state[evidenceType]);
+
+  let evidenceCount = 0;
+  if (typedCoverage) {
+    evidenceCount = normalizeCount(typedCoverage[evidenceType]);
+  } else if (rawValue > 0) {
+    // When typed coverage is absent, only an explicit positive score proves prior observation.
+    // A default zero must fail closed to unknown, not borrow total evidence from other dimensions.
+    evidenceCount = Math.max(1, state.evidenceCount);
+  }
 
   if (evidenceCount === 0) {
     return {

--- a/src/lib/learning/learner-state-read.ts
+++ b/src/lib/learning/learner-state-read.ts
@@ -1,0 +1,67 @@
+import type { EvidenceType, LearnerSkillState } from "./evidence";
+
+export const LEARNER_STATE_MODEL_VERSION = "ema-routing-v1" as const;
+
+export type LearnerDimensionRead = {
+  estimate: number | null;
+  evidenceCount: number;
+  status: "unknown" | "observed";
+  /** Not calibrated yet. Keep null rather than inventing probability-like certainty. */
+  confidence: null;
+  modelVersion: typeof LEARNER_STATE_MODEL_VERSION;
+  decisionScope: "routing";
+};
+
+/**
+ * Read one learner dimension without confusing an unobserved default zero with observed weakness.
+ *
+ * New planner reads attach per-type evidence coverage from append-only evidence history. The
+ * fallback preserves compatibility for older in-memory callers that only know total evidence.
+ */
+export function readLearnerDimension(
+  state: LearnerSkillState,
+  evidenceType: EvidenceType,
+): LearnerDimensionRead {
+  const typedCoverage = state.evidenceByType;
+  const evidenceCount = typedCoverage
+    ? normalizeCount(typedCoverage[evidenceType])
+    : state.evidenceCount > 0
+      ? state.evidenceCount
+      : 0;
+
+  if (evidenceCount === 0) {
+    return {
+      estimate: null,
+      evidenceCount: 0,
+      status: "unknown",
+      confidence: null,
+      modelVersion: LEARNER_STATE_MODEL_VERSION,
+      decisionScope: "routing",
+    };
+  }
+
+  return {
+    estimate: clamp01(state[evidenceType]),
+    evidenceCount,
+    status: "observed",
+    confidence: null,
+    modelVersion: LEARNER_STATE_MODEL_VERSION,
+    decisionScope: "routing",
+  };
+}
+
+export function hasObservedLearnerDimension(
+  state: LearnerSkillState,
+  evidenceType: EvidenceType,
+) {
+  return readLearnerDimension(state, evidenceType).status === "observed";
+}
+
+function normalizeCount(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, Number.isFinite(value) ? value : 0));
+}

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -1,4 +1,9 @@
-import type { LearnerSkillState } from "./evidence";
+import {
+  EVIDENCE_TYPES,
+  type EvidenceCoverage,
+  type EvidenceType,
+  type LearnerSkillState,
+} from "./evidence";
 import type { PlannerCandidate } from "./session-planner";
 
 export const PLANNER_SKILL_STATE_SELECT =
@@ -20,6 +25,12 @@ export type LearnerSkillStateRow = {
   last_evidence_at: string | null;
 };
 
+export type LearnerEvidenceCoverageRow = {
+  target_id: string;
+  evidence_type: string;
+  evidence_count: number | string;
+};
+
 export type RecentLearningAttemptRow = {
   capability_id: string | null;
   knowledge_item_id: string | null;
@@ -34,7 +45,10 @@ export type RecentPlannerHistory = {
   recentCandidateIds: string[];
 };
 
-export function mapLearnerSkillStateRow(row: LearnerSkillStateRow): LearnerSkillState {
+export function mapLearnerSkillStateRow(
+  row: LearnerSkillStateRow,
+  evidenceByType?: EvidenceCoverage,
+): LearnerSkillState {
   return {
     targetId: row.target_id,
     recognition: clamp01(row.recognition),
@@ -45,8 +59,25 @@ export function mapLearnerSkillStateRow(row: LearnerSkillStateRow): LearnerSkill
     transfer: clamp01(row.transfer),
     retention: clamp01(row.retention),
     evidenceCount: Math.max(0, Math.floor(row.evidence_count)),
+    evidenceByType,
     lastEvidenceAt: row.last_evidence_at,
   };
+}
+
+export function buildLearnerEvidenceCoverage(rows: LearnerEvidenceCoverageRow[]) {
+  const coverageByTarget = new Map<string, EvidenceCoverage>();
+
+  for (const row of rows) {
+    if (!isEvidenceType(row.evidence_type)) continue;
+    const evidenceCount = normalizeCount(row.evidence_count);
+    if (evidenceCount === 0) continue;
+
+    const coverage = coverageByTarget.get(row.target_id) ?? {};
+    coverage[row.evidence_type] = evidenceCount;
+    coverageByTarget.set(row.target_id, coverage);
+  }
+
+  return coverageByTarget;
 }
 
 export function collectPlannerTargetIds(candidates: PlannerCandidate[]): string[] {
@@ -81,6 +112,16 @@ export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): Re
 export function normalizeSessionSize(value: number | undefined, fallback = 5) {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.min(12, Math.max(1, Math.floor(value)));
+}
+
+function isEvidenceType(value: string): value is EvidenceType {
+  return (EVIDENCE_TYPES as readonly string[]).includes(value);
+}
+
+function normalizeCount(value: number | string) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.floor(parsed));
 }
 
 function asNonEmptyString(value: unknown) {

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,10 +1,7 @@
 import type { ErrorMemoryEntry } from "./error-memory";
 import type { EvidenceType, LearnerSkillState } from "./evidence";
 import { createEmptyLearnerSkillState } from "./evidence";
-import {
-  hasObservedLearnerDimension,
-  readLearnerDimension,
-} from "./learner-state-read";
+import { readLearnerDimension } from "./learner-state-read";
 
 export type PlannerCandidate = {
   id: string;

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,6 +1,10 @@
 import type { ErrorMemoryEntry } from "./error-memory";
 import type { EvidenceType, LearnerSkillState } from "./evidence";
 import { createEmptyLearnerSkillState } from "./evidence";
+import {
+  hasObservedLearnerDimension,
+  readLearnerDimension,
+} from "./learner-state-read";
 
 export type PlannerCandidate = {
   id: string;
@@ -190,8 +194,13 @@ function checkEligibility(
   ) {
     reasons.push("cold-start-needs-recognition");
   }
-  if (candidate.evidenceType === "transfer" && targetState.production < config.transferProductionFloor) {
-    reasons.push("transfer-needs-prior-production");
+  if (candidate.evidenceType === "transfer") {
+    const production = readLearnerDimension(targetState, "production");
+    if (production.status === "unknown") {
+      reasons.push("transfer-needs-observed-production");
+    } else if ((production.estimate ?? 0) < config.transferProductionFloor) {
+      reasons.push("transfer-needs-prior-production");
+    }
   }
   if (candidate.evidenceType === "retention" && targetState.evidenceCount === 0) {
     reasons.push("retention-needs-prior-evidence");
@@ -220,8 +229,9 @@ function scoreCandidate(input: {
     selectedForTarget,
     config,
   } = input;
-  const skillGap = 1 - clamp01(state[candidate.evidenceType]);
-  const coldStart = state.evidenceCount === 0 ? COLD_START_BONUS[candidate.evidenceType] : 0;
+  const dimension = readLearnerDimension(state, candidate.evidenceType);
+  const skillGap = dimension.estimate === null ? 0 : 1 - clamp01(dimension.estimate);
+  const coldStart = dimension.status === "unknown" ? COLD_START_BONUS[candidate.evidenceType] : 0;
   const staleness = calculateStaleness(state.lastEvidenceAt, now);
   const importance = clamp01(candidate.importance ?? 0.5);
   const transferValue = clamp01(candidate.transferValue ?? 0);
@@ -246,7 +256,9 @@ function scoreCandidate(input: {
     - inSessionRepeatPenalty;
 
   const reasons = [
-    `skill-gap:${round(skillGap)}`,
+    dimension.status === "unknown"
+      ? `evidence-unknown:${candidate.evidenceType}`
+      : `skill-gap:${round(skillGap)}`,
     `importance:${round(importance)}`,
   ];
   if (coldStart > 0) reasons.push(`cold-start:${candidate.evidenceType}`);
@@ -334,14 +346,16 @@ function metadataLessonVersion(metadata: Record<string, unknown> | undefined) {
 }
 
 function readiness(state: LearnerSkillState) {
-  return Math.max(
-    state.retrieval,
-    state.production,
-    state.transfer,
-    state.retention,
-    state.recognition * 0.5,
-    state.listening * 0.5,
-  );
+  const observed = (["retrieval", "production", "transfer", "retention"] as const)
+    .flatMap((type) => {
+      const dimension = readLearnerDimension(state, type);
+      return dimension.estimate === null ? [] : [dimension.estimate];
+    });
+  const recognition = readLearnerDimension(state, "recognition");
+  const listening = readLearnerDimension(state, "listening");
+  if (recognition.estimate !== null) observed.push(recognition.estimate * 0.5);
+  if (listening.estimate !== null) observed.push(listening.estimate * 0.5);
+  return observed.length > 0 ? Math.max(...observed) : 0;
 }
 
 function calculateStaleness(lastEvidenceAt: string | null, now: number) {

--- a/supabase/migrations/20260903090000_learner_evidence_coverage.sql
+++ b/supabase/migrations/20260903090000_learner_evidence_coverage.sql
@@ -1,0 +1,35 @@
+-- Read-only evidence coverage for learner-state routing.
+--
+-- learner_skill_states is a rebuildable EMA snapshot. Its numeric zero cannot distinguish
+-- "observed at zero" from "not observed" because the snapshot stores only a total evidence_count.
+-- Keep append-only learning_evidence_events as the source of truth and expose only aggregate
+-- target x evidence-type counts to authenticated callers.
+
+CREATE OR REPLACE FUNCTION public.get_learner_evidence_coverage(
+  p_target_ids text[]
+) RETURNS TABLE (
+  target_id text,
+  evidence_type text,
+  evidence_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT
+    e.target_id,
+    e.evidence_type,
+    COUNT(*)::bigint AS evidence_count
+  FROM public.learning_evidence_events AS e
+  WHERE e.user_id = (SELECT auth.uid())
+    AND e.target_id = ANY(COALESCE(p_target_ids, ARRAY[]::text[]))
+  GROUP BY e.target_id, e.evidence_type
+  ORDER BY e.target_id, e.evidence_type;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_learner_evidence_coverage(text[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_learner_evidence_coverage(text[]) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_learner_evidence_coverage(text[]) IS
+  'Returns privacy-safe aggregate evidence counts by target and evidence type for the current authenticated learner. Numeric learner-state snapshots remain routing estimates, not mastery probabilities.';

--- a/supabase/tests/database/learning_core.test.sql
+++ b/supabase/tests/database/learning_core.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(43);
+select plan(46);
 
 -- The July 2026 attempt schema must survive a fresh migration replay as an inaccessible archive,
 -- while the stable public name is reclaimed by the canonical Attempt -> Evidence contract.
@@ -471,12 +471,34 @@ select ok(
   'authenticated can call get_learner_evidence_coverage'
 );
 select ok(
+  has_function_privilege(
+    'service_role',
+    to_regprocedure('public.get_learner_evidence_coverage(text[])'),
+    'EXECUTE'
+  ),
+  'service_role can call get_learner_evidence_coverage'
+);
+select ok(
   not has_function_privilege(
     'anon',
     to_regprocedure('public.get_learner_evidence_coverage(text[])'),
     'EXECUTE'
   ),
   'anon cannot call get_learner_evidence_coverage'
+);
+select ok(
+  (select not p.prosecdef
+   from pg_proc p
+   join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public' and p.proname = 'get_learner_evidence_coverage'),
+  'get_learner_evidence_coverage is SECURITY INVOKER'
+);
+select ok(
+  (select 'search_path=' = any(p.proconfig)
+   from pg_proc p
+   join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public' and p.proname = 'get_learner_evidence_coverage'),
+  'get_learner_evidence_coverage enforces empty search_path'
 );
 
 -- Authenticated User 1 coverage query

--- a/supabase/tests/database/learning_core.test.sql
+++ b/supabase/tests/database/learning_core.test.sql
@@ -493,19 +493,12 @@ select ok(
    where n.nspname = 'public' and p.proname = 'get_learner_evidence_coverage'),
   'get_learner_evidence_coverage is SECURITY INVOKER'
 );
-select ok(
-  exists (
-    select 1
-    from pg_proc p
-    join pg_namespace n on n.oid = p.pronamespace
-    where n.nspname = 'public'
-      and p.proname = 'get_learner_evidence_coverage'
-      and exists (
-        select 1
-        from unnest(p.proconfig) as cfg
-        where cfg ~ '^search_path=(|""|'''')$' or cfg ~ '^search_path='
-      )
-  ),
+select is(
+  (select p.proconfig
+   from pg_proc p
+   join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public' and p.proname = 'get_learner_evidence_coverage'),
+  array['search_path=""']::text[],
   'get_learner_evidence_coverage enforces empty search_path'
 );
 

--- a/supabase/tests/database/learning_core.test.sql
+++ b/supabase/tests/database/learning_core.test.sql
@@ -494,10 +494,18 @@ select ok(
   'get_learner_evidence_coverage is SECURITY INVOKER'
 );
 select ok(
-  (select 'search_path=' = any(p.proconfig)
-   from pg_proc p
-   join pg_namespace n on n.oid = p.pronamespace
-   where n.nspname = 'public' and p.proname = 'get_learner_evidence_coverage'),
+  exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname = 'get_learner_evidence_coverage'
+      and exists (
+        select 1
+        from unnest(p.proconfig) as cfg
+        where cfg ~ '^search_path=(|""|'''')$' or cfg ~ '^search_path='
+      )
+  ),
   'get_learner_evidence_coverage enforces empty search_path'
 );
 

--- a/supabase/tests/database/learning_core.test.sql
+++ b/supabase/tests/database/learning_core.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(36);
+select plan(43);
 
 -- The July 2026 attempt schema must survive a fresh migration replay as an inaccessible archive,
 -- while the stable public name is reclaimed by the canonical Attempt -> Evidence contract.
@@ -460,6 +460,76 @@ select ok(
   ),
   'production and transfer update separate learner-state channels atomically'
 );
+
+-- Function privileges on evidence coverage RPC
+select ok(
+  has_function_privilege(
+    'authenticated',
+    to_regprocedure('public.get_learner_evidence_coverage(text[])'),
+    'EXECUTE'
+  ),
+  'authenticated can call get_learner_evidence_coverage'
+);
+select ok(
+  not has_function_privilege(
+    'anon',
+    to_regprocedure('public.get_learner_evidence_coverage(text[])'),
+    'EXECUTE'
+  ),
+  'anon cannot call get_learner_evidence_coverage'
+);
+
+-- Authenticated User 1 coverage query
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"11111111-1111-4111-8111-111111111111","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '11111111-1111-4111-8111-111111111111', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+set local role authenticated;
+
+select is(
+  (select count(*) from public.get_learner_evidence_coverage(array['CAP-TRANSFER'])),
+  2::bigint,
+  'authenticated user gets own aggregate evidence coverage rows'
+);
+
+select is(
+  (select count(*) from public.get_learner_evidence_coverage(array[]::text[])),
+  0::bigint,
+  'empty target array returns 0 coverage rows'
+);
+
+select is(
+  (select count(*) from public.get_learner_evidence_coverage(array['NON_EXISTENT_TARGET'])),
+  0::bigint,
+  'nonexistent target returns 0 coverage rows'
+);
+
+select is(
+  (select count(*) from public.get_learner_evidence_coverage(array['CAP-TRANSFER', 'CAP-TRANSFER'])),
+  2::bigint,
+  'duplicate target ids in input do not duplicate aggregate rows'
+);
+
+-- User 2 cross-user isolation
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"22222222-2222-4222-8222-222222222222","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '22222222-2222-4222-8222-222222222222', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+set local role authenticated;
+
+select is(
+  (select count(*) from public.get_learner_evidence_coverage(array['CAP-TRANSFER'])),
+  0::bigint,
+  'user 2 cannot observe user 1 aggregate evidence coverage'
+);
+
+reset role;
 
 select * from finish();
 rollback;


### PR DESCRIPTION
## Problem
In `learner_skill_states`, all 7 skill dimensions default to numeric `0`. Because the snapshot stores only a single total `evidence_count` across all dimensions for a target, the session planner on `main` cannot distinguish an unobserved dimension from an observed failure at zero when a learner has prior evidence on another dimension (e.g. recognition). Consequently:
1. An unobserved dimension was assigned a maximum fabricated `skillGap = 1.0`, distorting candidate ranking.
2. The exploration/cold-start bonus was suppressed on unobserved dimensions because total `state.evidenceCount > 0`.
3. The transfer gate on `main` checked `targetState.production < floor`, conflating unobserved production with failed production under the same blocked reason.

## Design & Fix
1. **Aggregate Evidence Coverage Boundary**: Kept `learner_skill_states` as the fast rebuildable EMA routing snapshot. Introduced an RPC `get_learner_evidence_coverage(p_target_ids text[])` reading append-only `learning_evidence_events` to return aggregate `{ target_id, evidence_type, evidence_count }` for the authenticated learner.
2. **Evidence Coverage Contract**:
   - **Eligible supported evidence** (`supportLevel > 0`): creates an evidence event with reduced observation weight via `support_penalty`.
   - **Revealed attempts** (`reveal_used = true`): creates no independent retrieval or oral evidence.
   - **Typed fallback** (`responseModality <> "speech"`): cannot create oral production, repair, or transfer evidence.
   - **Attempt-only records** (`p_evidence_type IS NULL`): creates no evidence events.
   - `Evidence coverage` strictly measures the count of eligible evidence events recorded for that `target_id × evidence_type`.
3. **Versioned Dimension Read Model (`ema-routing-v1`)**: In `src/lib/learning/learner-state-read.ts`, `readLearnerDimension` returns typed `LearnerDimensionRead` with explicit `status: "unknown" | "observed"`. Confidence is explicitly `null` because EMA routing snapshots are uncalibrated routing estimates, not probabilistic mastery states.
4. **Compatibility Fallback Semantics**: When typed coverage is absent (legacy or un-annotated offline state), zero-value dimensions fail closed to `status: "unknown"`. A positive estimate (`rawValue > 0`) is treated as observed as a legacy compatibility heuristic. Canonical production routing through `getNếpSessionPlan()` attaches typed coverage.
5. **Planner Invariant Enforcement**:
   - Unknown dimensions receive `skillGap = 0` and per-dimension `cold-start` exploration bonus.
   - Transfer hard gate explicitly requires observed production (`transfer-needs-observed-production`) and production meeting the readiness floor (`transfer-needs-prior-production`).
   - Readiness calculation ignores unknown dimensions rather than factoring in numeric zeros.

## Rebase & Invariant Convergence (#108 + #98)
- Rebased cleanly onto `main` at `ff7a4715ca74c67b40ae43239438104951c85d9a` (containing merged #108).
- **#108 Invariants Preserved**: `metadataLessonVersion()` remains narrow to positive integer numeric lesson versions (`Number.isInteger(value) && value > 0`) and non-empty strings; non-version identifiers (`lessonId`, `actionId`) remain string-only; catalog regression tests for remediation -> source reprobe pressure and adversarial tests pass cleanly.
- **#98 Invariants Preserved**: Unknown dimensions remain distinct from observed zero; transfer hard gate and per-dimension cold start remain active; pgTAP assertions for exact empty search_path (`array['search_path=""']::text[]`), SECURITY INVOKER, and RLS isolation pass cleanly.

## Trust & Privacy Boundary
- RPC uses `SECURITY INVOKER` with `SET search_path = ""`.
- Execution is granted to `authenticated` and `service_role`; revoked from `PUBLIC` and `anon`.
- Cross-user access is blocked by RLS policy on `learning_evidence_events` and explicit `e.user_id = auth.uid()` clause.
- Query projects only aggregate counts: does not expose response text, transcripts, audio, evaluator hidden targets, or other learners' data.

## Residual Risks & Unproven Claims
- RPC cardinality is currently tied to catalog size (`collectPlannerTargetIds`) without an explicit chunking, slicing, or pagination boundary; execution time under large event histories in production is unmeasured.
- Retention gate continues to rely on total `targetState.evidenceCount === 0`; typed retention evidence requirement remains unproven and unmodified.
- EMA routing estimates remain heuristic scores, not calibrated mastery probabilities.

## Verification
- Base SHA: `ff7a4715ca74c67b40ae43239438104951c85d9a` (current `main` with merged #108)
- Final Head SHA: `932d0bf0871ccb44590ecebe107036446ae1f483`
- GitHub Actions Verify Run ID: `33832429821` (SUCCESS)
- Diff stats: 9 files changed, 543 additions (+), 24 deletions (-)
- Lint: PASS (`npm run lint`, ESLint 9)
- Typecheck: PASS (`npx tsc --noEmit`)
- Unit tests: PASS (50 test files, 419 tests passed — includes both #108 and #98 test suites)
- Content standards: PASS (`npm run test:content-standard`, 50 tests passed)
- Database pgTAP & RLS tests: PASS (46 tests passed in GitHub Actions Verify run 33832429821, including exact `array['search_path=""']::text[]` assertion)
- Fresh migrations and schema lint: PASS
