### PR TITLE
Add offline learner-model benchmark V1

### DIFF
--- a/docs/frontier/LEARNER_MODEL_BENCHMARK_V1.md
+++ b/docs/frontier/LEARNER_MODEL_BENCHMARK_V1.md
@@ -1,0 +1,149 @@
+# Learner Model Benchmark V1
+
+## Purpose
+
+This benchmark answers one narrow question before AtoEnglish changes learner-model routing:
+
+> Does a candidate model predict future independent transfer or delayed retention better than the current EMA-style history baseline on held-out learners?
+
+It is an **offline research harness**. It does not run in the learner-facing Next.js runtime, does not write Supabase state, and does not mutate mastery/proficiency.
+
+## Target outcome
+
+A row becomes an evaluation label only when it is one of:
+
+- independent `transfer` evidence with `supportLevel = 0` and `changedContext = true`, or
+- independent `retention` evidence with `supportLevel = 0` and `delayDays >= 1`.
+
+The prediction is always computed before that outcome is applied to the learner's history.
+
+## Learner-level holdout
+
+Learner identities are deterministically partitioned into train and test sets. A learner can appear in exactly one partition. Candidate parameters are fit only from train learners and metrics are reported on test learners.
+
+This V1 intentionally prioritizes a strict learner-level holdout over a random row split because row-level splitting would leak learner history across train/test.
+
+## Models
+
+### `ema-history-v1`
+
+Reference baseline. It mirrors AtoEnglish's current asymmetric EMA observation update:
+
+- success alpha: `0.35`
+- failure alpha: `0.5`
+- supported success receives the same `0.1 × supportLevel`, capped at `0.5`, observation penalty
+- an unobserved outcome dimension predicts neutral `0.5`, not zero
+
+This is a benchmark predictor, not a claim that the current EMA snapshot is a calibrated mastery probability.
+
+### `bkt-grid-v1`
+
+A small standard Bayesian Knowledge Tracing comparator. `initialKnown`, `learn`, `guess`, and `slip` are selected by deterministic grid search on training learners only. V1 uses one latent state per learner × target across evidence opportunities.
+
+This is deliberately simple: BKT must earn complexity by predicting the held-out target outcome better than the baseline.
+
+### `lkt-logistic-v1`
+
+A lightweight LKT-style logistic comparator fitted only on train evaluation outcomes. Its features are derived exclusively from evidence available before the evaluation event:
+
+- smoothed prior success rate
+- bounded opportunity count
+- recency
+- independent success rate
+- transfer success rate
+- last observed success
+- support-free opportunity rate
+
+It is implemented in TypeScript to keep this research slice reproducible inside the existing repository toolchain. This does not claim feature parity with the R LKT package.
+
+### `lkt-logistic-aoa-v1`
+
+Uses the fitted LKT-style logistic model, then averages its prediction trajectory across prior learning opportunities.
+
+**AOA is an aggregation strategy, not a standalone learner model.**
+
+## Metrics
+
+Each model reports:
+
+- log loss — primary predictive metric
+- Brier score
+- expected calibration error (10 probability bins)
+- AUROC when the held-out set has both outcome classes
+
+A candidate can only become `eligible-for-shadow-validation` when real held-out data contains enough outcomes, log loss improves by at least `0.002`, Brier score does not regress, and calibration does not materially regress.
+
+That status is **not** permission to replace the production learner model. It only justifies a separate shadow-validation step.
+
+## Synthetic fixture rule
+
+`--synthetic` exists only to test the benchmark plumbing. Synthetic results always receive `synthetic-only` and can never justify adoption regardless of their metrics.
+
+## Privacy-safe input contract
+
+The CLI accepts only this structured JSON shape:
+
+```json
+{
+  "datasetId": "hashed-export-2026-09-03",
+  "synthetic": false,
+  "records": [
+    {
+      "learnerKey": "pseudonymous-key",
+      "targetId": "CAP-002",
+      "evidenceType": "production",
+      "success": true,
+      "confidence": 1,
+      "supportLevel": 0,
+      "independent": true,
+      "changedContext": false,
+      "delayDays": null,
+      "occurredAt": "2026-09-01T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+The parser rejects unsupported fields and explicitly rejects privacy-sensitive payload-shaped fields including `responseText`, `response_text`, transcript, audio, prompt text, metadata, email, and name.
+
+`learnerKey` must be a pseudonymous export key. Do not export raw email, name, transcript, audio, or free text into benchmark files.
+
+V1 deliberately has **no Supabase query/export command**. A future real-data export must be a separately reviewed privacy boundary.
+
+## Running
+
+Synthetic pipeline smoke:
+
+```bash
+npx tsx scripts/run-learner-model-benchmark.ts --synthetic
+```
+
+Privacy-safe JSON dataset:
+
+```bash
+npx tsx scripts/run-learner-model-benchmark.ts /path/to/privacy-safe-benchmark.json
+```
+
+The command prints a JSON report to stdout and performs no database writes.
+
+## Promotion boundary
+
+No benchmark model may directly:
+
+- set mastery/proficiency,
+- write `learner_skill_states`,
+- create learning evidence,
+- change adaptive routing in production,
+- infer pronunciation quality from transcript,
+- promote itself because synthetic metrics look good.
+
+The intended sequence is:
+
+```text
+benchmark harness
+  -> privacy-safe historical export
+  -> held-out comparison
+  -> shadow validation
+  -> controlled experiment
+  -> routing change only if durable transfer/retention outcomes improve
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:content-standard": "vitest run src/__tests__/lesson-content-standard.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "benchmark:learner-model": "tsx scripts/run-learner-model-benchmark.ts",
+    "benchmark:learner-model:synthetic": "tsx scripts/run-learner-model-benchmark.ts --synthetic",
     "e2e": "dotenv -e .env.local -- playwright test",
     "e2e:a11y": "dotenv -e .env.local -- playwright test e2e/accessibility-smoke.spec.ts",
     "e2e:time-to-lesson": "dotenv -e .env.local -- playwright test e2e/time-to-lesson.spec.ts",

--- a/scripts/run-learner-model-benchmark.ts
+++ b/scripts/run-learner-model-benchmark.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  createSyntheticLearnerModelBenchmarkDataset,
+  runLearnerModelBenchmark,
+} from "../src/lib/learning/benchmark/learner-model-benchmark";
+
+async function loadDataset(argument: string | undefined) {
+  if (!argument || argument === "--synthetic") {
+    return createSyntheticLearnerModelBenchmarkDataset();
+  }
+  const raw = await readFile(argument, "utf8");
+  return JSON.parse(raw) as unknown;
+}
+
+async function main() {
+  const dataset = await loadDataset(process.argv[2]);
+  const report = runLearnerModelBenchmark(dataset);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Learner-model benchmark failed: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/src/__tests__/session-planner.test.ts
+++ b/src/__tests__/session-planner.test.ts
@@ -133,11 +133,11 @@ describe("session planner v1", () => {
 
     const blocked = plan({ candidates: [transfer], states: [state("cap-a")], sessionSize: 1 });
     expect(blocked.opportunities).toEqual([]);
-    expect(blocked.blocked[0]?.reasons).toContain("transfer-needs-prior-production");
+    expect(blocked.blocked[0]?.reasons).toContain("transfer-needs-observed-production");
 
     const allowed = plan({
       candidates: [transfer],
-      states: [state("cap-a", { production: 0.35, evidenceCount: 2 })],
+      states: [state("cap-a", { production: 0.35, evidenceCount: 2, evidenceByType: { production: 2 } })],
       sessionSize: 1,
     });
     expect(allowed.opportunities[0]?.candidate.id).toBe("cap-a:transfer");

--- a/src/app/actions/session-planner.ts
+++ b/src/app/actions/session-planner.ts
@@ -7,13 +7,16 @@ import {
   buildErrorMemory,
   type ErrorMemoryAttemptRow,
 } from "@/lib/learning/error-memory";
+import { LEARNER_STATE_MODEL_VERSION } from "@/lib/learning/learner-state-read";
 import {
+  buildLearnerEvidenceCoverage,
   collectPlannerTargetIds,
   deriveRecentPlannerHistory,
   mapLearnerSkillStateRow,
   normalizeSessionSize,
   PLANNER_RECENT_ATTEMPT_SELECT,
   PLANNER_SKILL_STATE_SELECT,
+  type LearnerEvidenceCoverageRow,
   type LearnerSkillStateRow,
   type RecentLearningAttemptRow,
 } from "@/lib/learning/session-input";
@@ -41,6 +44,10 @@ type PlannerQuery<T> = {
 
 type PlannerReadClient = {
   from: <T>(table: string) => PlannerQuery<T>;
+  rpc: <T>(
+    functionName: string,
+    args: Record<string, unknown>,
+  ) => QueryResult<T>;
 };
 
 export type GetNếpSessionPlanInput = {
@@ -61,6 +68,9 @@ export type GetNếpSessionPlanResult =
         catalogSize: number;
         practiceEnvelopeCount: number;
         stateCount: number;
+        evidenceCoverageRowCount: number;
+        learnerStateModelVersion: typeof LEARNER_STATE_MODEL_VERSION;
+        learnerStateConfidenceCalibrated: false;
         recentAttemptCount: number;
         errorMemoryAttemptCount: number;
         recurringErrorCount: number;
@@ -106,6 +116,12 @@ export async function getNếpSessionPlan(
       .in("target_id", targetIds)
       .limit(100);
 
+    // Aggregate coverage comes from append-only evidence history, not the EMA routing snapshot.
+    const evidenceCoverageQuery = readClient.rpc<LearnerEvidenceCoverageRow>(
+      "get_learner_evidence_coverage",
+      { p_target_ids: targetIds },
+    );
+
     // Recent attempts are exposure history only. Project semantic planner keys, not raw content.
     const recentAttemptQuery = readClient
       .from<RecentLearningAttemptRow>("learning_attempts")
@@ -124,13 +140,21 @@ export async function getNếpSessionPlan(
       .order("created_at", { ascending: false })
       .limit(200);
 
-    const [stateResult, recentAttemptResult, errorMemoryResult] = await Promise.all([
-      stateQuery,
-      recentAttemptQuery,
-      errorMemoryQuery,
-    ]);
+    const [stateResult, evidenceCoverageResult, recentAttemptResult, errorMemoryResult] =
+      await Promise.all([
+        stateQuery,
+        evidenceCoverageQuery,
+        recentAttemptQuery,
+        errorMemoryQuery,
+      ]);
     if (stateResult.error) {
       return { success: false, error: `Không thể đọc learner state: ${stateResult.error.message}` };
+    }
+    if (evidenceCoverageResult.error) {
+      return {
+        success: false,
+        error: `Không thể đọc evidence coverage: ${evidenceCoverageResult.error.message}`,
+      };
     }
     if (recentAttemptResult.error) {
       return { success: false, error: `Không thể đọc lịch sử practice gần đây: ${recentAttemptResult.error.message}` };
@@ -139,7 +163,10 @@ export async function getNếpSessionPlan(
       return { success: false, error: `Không thể đọc error memory: ${errorMemoryResult.error.message}` };
     }
 
-    const states = (stateResult.data ?? []).map(mapLearnerSkillStateRow);
+    const evidenceCoverage = buildLearnerEvidenceCoverage(evidenceCoverageResult.data ?? []);
+    const states = (stateResult.data ?? []).map((row) =>
+      mapLearnerSkillStateRow(row, evidenceCoverage.get(row.target_id) ?? {}),
+    );
     const recentHistory = deriveRecentPlannerHistory(recentAttemptResult.data ?? []);
     const errorMemory = buildErrorMemory(errorMemoryResult.data ?? []);
     const plan = planSession({
@@ -165,6 +192,9 @@ export async function getNếpSessionPlan(
         catalogSize: nepSessionCatalogV1.length,
         practiceEnvelopeCount: practices.length,
         stateCount: states.length,
+        evidenceCoverageRowCount: evidenceCoverageResult.data?.length ?? 0,
+        learnerStateModelVersion: LEARNER_STATE_MODEL_VERSION,
+        learnerStateConfidenceCalibrated: false,
         recentAttemptCount: recentAttemptResult.data?.length ?? 0,
         errorMemoryAttemptCount: errorMemoryResult.data?.length ?? 0,
         recurringErrorCount: errorMemory.recurring.length,

--- a/src/lib/learning/benchmark/learner-model-benchmark.test.ts
+++ b/src/lib/learning/benchmark/learner-model-benchmark.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEvaluationExamples,
+  calculateMetrics,
+  createSyntheticLearnerModelBenchmarkDataset,
+  parseLearnerModelBenchmarkDataset,
+  predictEmaHistory,
+  runLearnerModelBenchmark,
+  splitBenchmarkLearners,
+  type BenchmarkEvidenceRecord,
+} from "./learner-model-benchmark";
+
+function baseRecord(overrides: Partial<BenchmarkEvidenceRecord> = {}): BenchmarkEvidenceRecord {
+  return {
+    learnerKey: "learner-a",
+    targetId: "CAP-001",
+    evidenceType: "production",
+    success: true,
+    confidence: 1,
+    supportLevel: 0,
+    independent: true,
+    changedContext: false,
+    delayDays: null,
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("learner model benchmark v1", () => {
+  it("rejects raw response or transcript-shaped fields at the dataset boundary", () => {
+    const unsafe = {
+      datasetId: "unsafe",
+      synthetic: false,
+      records: [
+        {
+          ...baseRecord(),
+          responseText: "My name is...",
+        },
+        baseRecord({ learnerKey: "learner-b" }),
+      ],
+    };
+
+    expect(() => parseLearnerModelBenchmarkDataset(unsafe)).toThrow(/forbidden privacy-sensitive field: responseText/);
+  });
+
+  it("creates deterministic learner-level holdout with no identity overlap", () => {
+    const dataset = createSyntheticLearnerModelBenchmarkDataset();
+    const first = splitBenchmarkLearners(dataset.records, 0.2);
+    const second = splitBenchmarkLearners(dataset.records, 0.2);
+
+    expect(first).toEqual(second);
+    expect(first.trainLearners.length).toBeGreaterThan(0);
+    expect(first.testLearners.length).toBeGreaterThan(0);
+    expect(first.trainLearners.some((learner) => first.testLearners.includes(learner))).toBe(false);
+  });
+
+  it("does not let a future outcome alter features for an earlier evaluation", () => {
+    const records: BenchmarkEvidenceRecord[] = [
+      baseRecord(),
+      baseRecord({
+        evidenceType: "transfer",
+        changedContext: true,
+        occurredAt: "2026-01-02T00:00:00.000Z",
+      }),
+      baseRecord({
+        evidenceType: "retention",
+        delayDays: 7,
+        occurredAt: "2026-01-09T00:00:00.000Z",
+      }),
+    ];
+    const mutatedFuture = records.map((record, index) => index === 2 ? { ...record, success: false } : record);
+
+    const originalFirst = buildEvaluationExamples(records)[0];
+    const mutatedFirst = buildEvaluationExamples(mutatedFuture)[0];
+
+    expect(originalFirst?.features).toEqual(mutatedFirst?.features);
+    expect(originalFirst?.trajectoryFeatures).toEqual(mutatedFirst?.trajectoryFeatures);
+  });
+
+  it("mirrors the current asymmetric EMA update for observed dimensions", () => {
+    const records: BenchmarkEvidenceRecord[] = [
+      baseRecord(),
+      baseRecord({
+        evidenceType: "transfer",
+        success: true,
+        changedContext: true,
+        occurredAt: "2026-01-02T00:00:00.000Z",
+      }),
+      baseRecord({
+        evidenceType: "transfer",
+        success: false,
+        changedContext: true,
+        occurredAt: "2026-01-03T00:00:00.000Z",
+      }),
+      baseRecord({ learnerKey: "learner-b", occurredAt: "2026-01-01T00:00:00.000Z" }),
+    ];
+
+    const predictions = predictEmaHistory(records, new Set(["learner-a"]));
+    expect(predictions).toHaveLength(2);
+    expect(predictions[0]?.probability).toBeCloseTo(0.5, 8);
+    expect(predictions[1]?.probability).toBeCloseTo(0.35, 8);
+  });
+
+  it("computes calibrated prediction metrics with AUROC when both classes exist", () => {
+    const metrics = calculateMetrics([
+      {
+        learnerKey: "a",
+        targetId: "CAP-1",
+        evidenceType: "transfer",
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        actual: 1,
+        probability: 0.9,
+      },
+      {
+        learnerKey: "b",
+        targetId: "CAP-1",
+        evidenceType: "transfer",
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        actual: 0,
+        probability: 0.1,
+      },
+    ]);
+
+    expect(metrics.count).toBe(2);
+    expect(metrics.auroc).toBe(1);
+    expect(metrics.brierScore).toBeCloseTo(0.01, 8);
+    expect(metrics.logLoss).toBeGreaterThan(0);
+  });
+
+  it("runs all comparators deterministically but never promotes a synthetic fixture", () => {
+    const dataset = createSyntheticLearnerModelBenchmarkDataset();
+    const first = runLearnerModelBenchmark(dataset);
+    const second = runLearnerModelBenchmark(dataset);
+
+    expect(first).toEqual(second);
+    expect(first.trainOutcomeCount).toBeGreaterThan(0);
+    expect(first.testOutcomeCount).toBeGreaterThan(0);
+    expect(first.models.map((model) => model.modelId)).toEqual([
+      "ema-history-v1",
+      "bkt-grid-v1",
+      "lkt-logistic-v1",
+      "lkt-logistic-aoa-v1",
+    ]);
+    expect(first.models[0]?.gate.status).toBe("baseline");
+    for (const model of first.models.slice(1)) {
+      expect(model.metrics?.count).toBe(first.testOutcomeCount);
+      expect(model.gate.status).toBe("synthetic-only");
+    }
+  });
+});

--- a/src/lib/learning/benchmark/learner-model-benchmark.ts
+++ b/src/lib/learning/benchmark/learner-model-benchmark.ts
@@ -1,0 +1,735 @@
+export const BENCHMARK_EVIDENCE_TYPES = [
+  "recognition",
+  "retrieval",
+  "listening",
+  "production",
+  "repair",
+  "transfer",
+  "retention",
+] as const;
+
+export type BenchmarkEvidenceType = (typeof BENCHMARK_EVIDENCE_TYPES)[number];
+
+export type BenchmarkEvidenceRecord = {
+  learnerKey: string;
+  targetId: string;
+  evidenceType: BenchmarkEvidenceType;
+  success: boolean;
+  confidence: number;
+  supportLevel: number;
+  independent: boolean;
+  changedContext: boolean;
+  delayDays: number | null;
+  occurredAt: string;
+};
+
+export type LearnerModelBenchmarkDataset = {
+  datasetId: string;
+  synthetic: boolean;
+  records: BenchmarkEvidenceRecord[];
+};
+
+export type BenchmarkPrediction = {
+  learnerKey: string;
+  targetId: string;
+  evidenceType: "transfer" | "retention";
+  occurredAt: string;
+  actual: 0 | 1;
+  probability: number;
+};
+
+export type BenchmarkMetrics = {
+  count: number;
+  positives: number;
+  negatives: number;
+  logLoss: number;
+  brierScore: number;
+  expectedCalibrationError: number;
+  auroc: number | null;
+};
+
+export type LearnerSplit = {
+  trainLearners: string[];
+  testLearners: string[];
+};
+
+export type BenchmarkModelResult = {
+  modelId: "ema-history-v1" | "bkt-grid-v1" | "lkt-logistic-v1" | "lkt-logistic-aoa-v1";
+  metrics: BenchmarkMetrics | null;
+  gate: {
+    status:
+      | "baseline"
+      | "synthetic-only"
+      | "insufficient-data"
+      | "eligible-for-shadow-validation"
+      | "does-not-beat-baseline";
+    reason: string;
+  };
+};
+
+export type LearnerModelBenchmarkReport = {
+  benchmarkVersion: "learner-model-benchmark-v1";
+  datasetId: string;
+  synthetic: boolean;
+  targetOutcome: "independent-changed-context-transfer-or-delayed-retention";
+  split: LearnerSplit;
+  trainOutcomeCount: number;
+  testOutcomeCount: number;
+  models: BenchmarkModelResult[];
+  notes: string[];
+};
+
+type HistoryState = {
+  total: number;
+  successes: number;
+  independentTotal: number;
+  independentSuccesses: number;
+  transferTotal: number;
+  transferSuccesses: number;
+  supportFreeTotal: number;
+  lastSuccess: 0 | 1 | null;
+  lastOccurredAt: string | null;
+  emaByEvidenceType: Partial<Record<BenchmarkEvidenceType, number>>;
+  trajectoryFeatures: number[][];
+};
+
+type EvaluationExample = {
+  record: BenchmarkEvidenceRecord;
+  actual: 0 | 1;
+  features: number[];
+  trajectoryFeatures: number[][];
+};
+
+type BktParameters = {
+  initialKnown: number;
+  learn: number;
+  guess: number;
+  slip: number;
+};
+
+const ALLOWED_DATASET_KEYS = new Set(["datasetId", "synthetic", "records"]);
+const ALLOWED_RECORD_KEYS = new Set([
+  "learnerKey",
+  "targetId",
+  "evidenceType",
+  "success",
+  "confidence",
+  "supportLevel",
+  "independent",
+  "changedContext",
+  "delayDays",
+  "occurredAt",
+]);
+const FORBIDDEN_PAYLOAD_KEYS = new Set([
+  "responseText",
+  "response_text",
+  "transcript",
+  "audio",
+  "audioUrl",
+  "prompt",
+  "promptText",
+  "metadata",
+  "email",
+  "name",
+]);
+const MIN_REAL_TEST_OUTCOMES = 20;
+const MIN_LOG_LOSS_IMPROVEMENT = 0.002;
+const MAX_ECE_REGRESSION = 0.01;
+const FEATURE_COUNT = 8;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertExactKeys(value: Record<string, unknown>, allowed: Set<string>, label: string) {
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_PAYLOAD_KEYS.has(key)) {
+      throw new Error(`${label} contains forbidden privacy-sensitive field: ${key}`);
+    }
+    if (!allowed.has(key)) {
+      throw new Error(`${label} contains unsupported field: ${key}`);
+    }
+  }
+}
+
+function assertBoundedIdentifier(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || value.length < 1 || value.length > 160) {
+    throw new Error(`${label} must be a non-empty string of at most 160 characters`);
+  }
+}
+
+function isBenchmarkEvidenceType(value: unknown): value is BenchmarkEvidenceType {
+  return typeof value === "string" && (BENCHMARK_EVIDENCE_TYPES as readonly string[]).includes(value);
+}
+
+function assertFiniteUnitInterval(value: unknown, label: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`${label} must be a finite number between 0 and 1`);
+  }
+}
+
+function parseRecord(value: unknown, index: number): BenchmarkEvidenceRecord {
+  if (!isPlainObject(value)) {
+    throw new Error(`records[${index}] must be an object`);
+  }
+  assertExactKeys(value, ALLOWED_RECORD_KEYS, `records[${index}]`);
+  assertBoundedIdentifier(value.learnerKey, `records[${index}].learnerKey`);
+  assertBoundedIdentifier(value.targetId, `records[${index}].targetId`);
+  if (!isBenchmarkEvidenceType(value.evidenceType)) {
+    throw new Error(`records[${index}].evidenceType is unsupported`);
+  }
+  if (typeof value.success !== "boolean") {
+    throw new Error(`records[${index}].success must be boolean`);
+  }
+  assertFiniteUnitInterval(value.confidence, `records[${index}].confidence`);
+  if (!Number.isInteger(value.supportLevel) || (value.supportLevel as number) < 0 || (value.supportLevel as number) > 20) {
+    throw new Error(`records[${index}].supportLevel must be an integer between 0 and 20`);
+  }
+  if (typeof value.independent !== "boolean" || typeof value.changedContext !== "boolean") {
+    throw new Error(`records[${index}] must declare independent and changedContext booleans`);
+  }
+  if (value.delayDays !== null && (typeof value.delayDays !== "number" || !Number.isFinite(value.delayDays) || value.delayDays < 0)) {
+    throw new Error(`records[${index}].delayDays must be null or a non-negative number`);
+  }
+  if (typeof value.occurredAt !== "string" || !Number.isFinite(Date.parse(value.occurredAt))) {
+    throw new Error(`records[${index}].occurredAt must be a valid timestamp`);
+  }
+
+  return {
+    learnerKey: value.learnerKey,
+    targetId: value.targetId,
+    evidenceType: value.evidenceType,
+    success: value.success,
+    confidence: value.confidence,
+    supportLevel: value.supportLevel as number,
+    independent: value.independent,
+    changedContext: value.changedContext,
+    delayDays: value.delayDays as number | null,
+    occurredAt: new Date(value.occurredAt).toISOString(),
+  };
+}
+
+export function parseLearnerModelBenchmarkDataset(value: unknown): LearnerModelBenchmarkDataset {
+  if (!isPlainObject(value)) {
+    throw new Error("Benchmark dataset must be an object");
+  }
+  assertExactKeys(value, ALLOWED_DATASET_KEYS, "dataset");
+  assertBoundedIdentifier(value.datasetId, "dataset.datasetId");
+  if (typeof value.synthetic !== "boolean") {
+    throw new Error("dataset.synthetic must be boolean");
+  }
+  if (!Array.isArray(value.records) || value.records.length === 0) {
+    throw new Error("dataset.records must contain at least one record");
+  }
+
+  const records = value.records.map(parseRecord);
+  const learnerCount = new Set(records.map((record) => record.learnerKey)).size;
+  if (learnerCount < 2) {
+    throw new Error("Benchmark requires at least two learners for learner-level holdout");
+  }
+
+  return { datasetId: value.datasetId, synthetic: value.synthetic, records };
+}
+
+function stableHash(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function splitBenchmarkLearners(records: BenchmarkEvidenceRecord[], testFraction = 0.2): LearnerSplit {
+  if (!(testFraction > 0 && testFraction < 1)) {
+    throw new Error("testFraction must be between 0 and 1");
+  }
+  const learners = [...new Set(records.map((record) => record.learnerKey))].sort((left, right) => {
+    const hashDelta = stableHash(left) - stableHash(right);
+    return hashDelta !== 0 ? hashDelta : left.localeCompare(right);
+  });
+  if (learners.length < 2) {
+    throw new Error("Learner-level holdout requires at least two learners");
+  }
+  const testCount = Math.min(learners.length - 1, Math.max(1, Math.round(learners.length * testFraction)));
+  return {
+    testLearners: learners.slice(0, testCount),
+    trainLearners: learners.slice(testCount),
+  };
+}
+
+function emptyHistory(): HistoryState {
+  return {
+    total: 0,
+    successes: 0,
+    independentTotal: 0,
+    independentSuccesses: 0,
+    transferTotal: 0,
+    transferSuccesses: 0,
+    supportFreeTotal: 0,
+    lastSuccess: null,
+    lastOccurredAt: null,
+    emaByEvidenceType: {},
+    trajectoryFeatures: [],
+  };
+}
+
+function betaMean(successes: number, total: number) {
+  return (successes + 1) / (total + 2);
+}
+
+function featureVector(history: HistoryState, at: string) {
+  const daysSinceLast = history.lastOccurredAt
+    ? Math.max(0, (Date.parse(at) - Date.parse(history.lastOccurredAt)) / 86_400_000)
+    : Number.POSITIVE_INFINITY;
+  const recency = Number.isFinite(daysSinceLast) ? Math.exp(-daysSinceLast / 14) : 0;
+  const opportunityScale = Math.min(Math.log1p(history.total) / Math.log(21), 1);
+  return [
+    1,
+    betaMean(history.successes, history.total),
+    opportunityScale,
+    recency,
+    betaMean(history.independentSuccesses, history.independentTotal),
+    betaMean(history.transferSuccesses, history.transferTotal),
+    history.lastSuccess ?? 0.5,
+    history.total === 0 ? 0.5 : history.supportFreeTotal / history.total,
+  ];
+}
+
+function updateEma(history: HistoryState, record: BenchmarkEvidenceRecord) {
+  const supportPenalty = Math.min(Math.max(record.supportLevel * 0.1, 0), 0.5);
+  const observation = record.success ? record.confidence * (1 - supportPenalty) : 0;
+  const alpha = record.success ? 0.35 : 0.5;
+  const previous = history.emaByEvidenceType[record.evidenceType];
+  history.emaByEvidenceType[record.evidenceType] = previous === undefined
+    ? observation * alpha
+    : clampProbability(previous * (1 - alpha) + observation * alpha);
+}
+
+function updateHistory(history: HistoryState, record: BenchmarkEvidenceRecord) {
+  history.total += 1;
+  history.successes += record.success ? 1 : 0;
+  if (record.independent) {
+    history.independentTotal += 1;
+    history.independentSuccesses += record.success ? 1 : 0;
+  }
+  if (record.evidenceType === "transfer") {
+    history.transferTotal += 1;
+    history.transferSuccesses += record.success ? 1 : 0;
+  }
+  if (record.supportLevel === 0) {
+    history.supportFreeTotal += 1;
+  }
+  history.lastSuccess = record.success ? 1 : 0;
+  history.lastOccurredAt = record.occurredAt;
+  updateEma(history, record);
+  history.trajectoryFeatures.push(featureVector(history, record.occurredAt));
+}
+
+function isTargetOutcome(record: BenchmarkEvidenceRecord): record is BenchmarkEvidenceRecord & { evidenceType: "transfer" | "retention" } {
+  if (!record.independent || record.supportLevel !== 0) {
+    return false;
+  }
+  if (record.evidenceType === "transfer") {
+    return record.changedContext;
+  }
+  if (record.evidenceType === "retention") {
+    return record.delayDays !== null && record.delayDays >= 1;
+  }
+  return false;
+}
+
+function chronologicalRecords(records: BenchmarkEvidenceRecord[], learnerSet?: Set<string>) {
+  return records
+    .map((record, index) => ({ record, index }))
+    .filter(({ record }) => !learnerSet || learnerSet.has(record.learnerKey))
+    .sort((left, right) => {
+      const learnerDelta = left.record.learnerKey.localeCompare(right.record.learnerKey);
+      if (learnerDelta !== 0) return learnerDelta;
+      const timeDelta = Date.parse(left.record.occurredAt) - Date.parse(right.record.occurredAt);
+      if (timeDelta !== 0) return timeDelta;
+      return left.index - right.index;
+    })
+    .map(({ record }) => record);
+}
+
+function historyKey(record: BenchmarkEvidenceRecord) {
+  return `${record.learnerKey}\u0000${record.targetId}`;
+}
+
+export function buildEvaluationExamples(records: BenchmarkEvidenceRecord[], learnerSet?: Set<string>): EvaluationExample[] {
+  const histories = new Map<string, HistoryState>();
+  const examples: EvaluationExample[] = [];
+
+  for (const record of chronologicalRecords(records, learnerSet)) {
+    const key = historyKey(record);
+    const history = histories.get(key) ?? emptyHistory();
+    if (isTargetOutcome(record)) {
+      examples.push({
+        record,
+        actual: record.success ? 1 : 0,
+        features: featureVector(history, record.occurredAt),
+        trajectoryFeatures: history.trajectoryFeatures.map((features) => [...features]),
+      });
+    }
+    updateHistory(history, record);
+    histories.set(key, history);
+  }
+  return examples;
+}
+
+function clampProbability(value: number) {
+  return Math.min(1 - 1e-6, Math.max(1e-6, value));
+}
+
+function predictionFromExample(example: EvaluationExample, probability: number): BenchmarkPrediction {
+  return {
+    learnerKey: example.record.learnerKey,
+    targetId: example.record.targetId,
+    evidenceType: example.record.evidenceType as "transfer" | "retention",
+    occurredAt: example.record.occurredAt,
+    actual: example.actual,
+    probability: clampProbability(probability),
+  };
+}
+
+export function predictEmaHistory(records: BenchmarkEvidenceRecord[], learnerSet: Set<string>): BenchmarkPrediction[] {
+  const histories = new Map<string, HistoryState>();
+  const predictions: BenchmarkPrediction[] = [];
+
+  for (const record of chronologicalRecords(records, learnerSet)) {
+    const key = historyKey(record);
+    const history = histories.get(key) ?? emptyHistory();
+    if (isTargetOutcome(record)) {
+      const probability = history.emaByEvidenceType[record.evidenceType] ?? 0.5;
+      predictions.push({
+        learnerKey: record.learnerKey,
+        targetId: record.targetId,
+        evidenceType: record.evidenceType,
+        occurredAt: record.occurredAt,
+        actual: record.success ? 1 : 0,
+        probability: clampProbability(probability),
+      });
+    }
+    updateHistory(history, record);
+    histories.set(key, history);
+  }
+  return predictions;
+}
+
+function bktObservationProbability(known: number, parameters: BktParameters) {
+  return known * (1 - parameters.slip) + (1 - known) * parameters.guess;
+}
+
+function updateBktKnown(known: number, success: boolean, parameters: BktParameters) {
+  const pCorrect = bktObservationProbability(known, parameters);
+  const posterior = success
+    ? (known * (1 - parameters.slip)) / Math.max(pCorrect, 1e-9)
+    : (known * parameters.slip) / Math.max(1 - pCorrect, 1e-9);
+  return clampProbability(posterior + (1 - posterior) * parameters.learn);
+}
+
+function predictBkt(
+  records: BenchmarkEvidenceRecord[],
+  learnerSet: Set<string>,
+  parameters: BktParameters,
+): BenchmarkPrediction[] {
+  const knownByTarget = new Map<string, number>();
+  const predictions: BenchmarkPrediction[] = [];
+
+  for (const record of chronologicalRecords(records, learnerSet)) {
+    const key = historyKey(record);
+    const known = knownByTarget.get(key) ?? parameters.initialKnown;
+    if (isTargetOutcome(record)) {
+      predictions.push({
+        learnerKey: record.learnerKey,
+        targetId: record.targetId,
+        evidenceType: record.evidenceType,
+        occurredAt: record.occurredAt,
+        actual: record.success ? 1 : 0,
+        probability: clampProbability(bktObservationProbability(known, parameters)),
+      });
+    }
+    knownByTarget.set(key, updateBktKnown(known, record.success, parameters));
+  }
+  return predictions;
+}
+
+function fitBktParameters(records: BenchmarkEvidenceRecord[], trainLearners: Set<string>): BktParameters {
+  const initialGrid = [0.1, 0.25, 0.5, 0.75];
+  const learnGrid = [0.05, 0.15, 0.3];
+  const guessGrid = [0.1, 0.2, 0.3];
+  const slipGrid = [0.05, 0.1, 0.2];
+  let best: BktParameters = { initialKnown: 0.25, learn: 0.15, guess: 0.2, slip: 0.1 };
+  let bestLoss = Number.POSITIVE_INFINITY;
+
+  for (const initialKnown of initialGrid) {
+    for (const learn of learnGrid) {
+      for (const guess of guessGrid) {
+        for (const slip of slipGrid) {
+          const candidate = { initialKnown, learn, guess, slip };
+          const predictions = predictBkt(records, trainLearners, candidate);
+          if (predictions.length === 0) continue;
+          const loss = calculateMetrics(predictions).logLoss;
+          if (loss < bestLoss - 1e-12) {
+            bestLoss = loss;
+            best = candidate;
+          }
+        }
+      }
+    }
+  }
+  return best;
+}
+
+function sigmoid(value: number) {
+  const bounded = Math.max(-30, Math.min(30, value));
+  return 1 / (1 + Math.exp(-bounded));
+}
+
+function dot(weights: number[], features: number[]) {
+  let sum = 0;
+  for (let index = 0; index < weights.length; index += 1) {
+    sum += weights[index] * features[index];
+  }
+  return sum;
+}
+
+function fitLogisticRegression(examples: EvaluationExample[]) {
+  const weights = Array.from({ length: FEATURE_COUNT }, () => 0);
+  if (examples.length === 0) return weights;
+  const learningRate = 0.2;
+  const ridge = 0.01;
+
+  for (let step = 0; step < 1200; step += 1) {
+    const gradient = Array.from({ length: FEATURE_COUNT }, () => 0);
+    for (const example of examples) {
+      const error = sigmoid(dot(weights, example.features)) - example.actual;
+      for (let index = 0; index < FEATURE_COUNT; index += 1) {
+        gradient[index] += error * example.features[index];
+      }
+    }
+    for (let index = 0; index < FEATURE_COUNT; index += 1) {
+      const penalty = index === 0 ? 0 : ridge * weights[index];
+      weights[index] -= learningRate * (gradient[index] / examples.length + penalty);
+    }
+  }
+  return weights;
+}
+
+function predictLogistic(examples: EvaluationExample[], weights: number[]) {
+  return examples.map((example) => predictionFromExample(example, sigmoid(dot(weights, example.features))));
+}
+
+function predictLogisticAoa(examples: EvaluationExample[], weights: number[]) {
+  return examples.map((example) => {
+    const trajectory = example.trajectoryFeatures;
+    if (trajectory.length === 0) {
+      return predictionFromExample(example, sigmoid(dot(weights, example.features)));
+    }
+    const average = trajectory.reduce((sum, features) => sum + sigmoid(dot(weights, features)), 0) / trajectory.length;
+    return predictionFromExample(example, average);
+  });
+}
+
+function calculateAuroc(predictions: BenchmarkPrediction[]) {
+  const positives = predictions.filter((prediction) => prediction.actual === 1).length;
+  const negatives = predictions.length - positives;
+  if (positives === 0 || negatives === 0) return null;
+
+  const sorted = [...predictions].sort((left, right) => left.probability - right.probability);
+  let positiveRankSum = 0;
+  let index = 0;
+  while (index < sorted.length) {
+    let end = index + 1;
+    while (end < sorted.length && sorted[end].probability === sorted[index].probability) end += 1;
+    const averageRank = (index + 1 + end) / 2;
+    for (let cursor = index; cursor < end; cursor += 1) {
+      if (sorted[cursor].actual === 1) positiveRankSum += averageRank;
+    }
+    index = end;
+  }
+  return (positiveRankSum - (positives * (positives + 1)) / 2) / (positives * negatives);
+}
+
+export function calculateMetrics(predictions: BenchmarkPrediction[]): BenchmarkMetrics {
+  if (predictions.length === 0) {
+    throw new Error("Cannot calculate metrics without predictions");
+  }
+  let logLoss = 0;
+  let brier = 0;
+  const bins = Array.from({ length: 10 }, () => ({ count: 0, probability: 0, actual: 0 }));
+
+  for (const prediction of predictions) {
+    const probability = clampProbability(prediction.probability);
+    logLoss += -(prediction.actual * Math.log(probability) + (1 - prediction.actual) * Math.log(1 - probability));
+    brier += (probability - prediction.actual) ** 2;
+    const binIndex = Math.min(9, Math.floor(probability * 10));
+    bins[binIndex].count += 1;
+    bins[binIndex].probability += probability;
+    bins[binIndex].actual += prediction.actual;
+  }
+
+  let expectedCalibrationError = 0;
+  for (const bin of bins) {
+    if (bin.count === 0) continue;
+    const meanProbability = bin.probability / bin.count;
+    const meanActual = bin.actual / bin.count;
+    expectedCalibrationError += (bin.count / predictions.length) * Math.abs(meanProbability - meanActual);
+  }
+
+  const positives = predictions.filter((prediction) => prediction.actual === 1).length;
+  return {
+    count: predictions.length,
+    positives,
+    negatives: predictions.length - positives,
+    logLoss: logLoss / predictions.length,
+    brierScore: brier / predictions.length,
+    expectedCalibrationError,
+    auroc: calculateAuroc(predictions),
+  };
+}
+
+function candidateGate(
+  dataset: LearnerModelBenchmarkDataset,
+  baseline: BenchmarkMetrics | null,
+  candidate: BenchmarkMetrics | null,
+) : BenchmarkModelResult["gate"] {
+  if (dataset.synthetic) {
+    return { status: "synthetic-only", reason: "Synthetic data validates benchmark plumbing only and cannot justify model adoption." };
+  }
+  if (!baseline || !candidate) {
+    return { status: "insufficient-data", reason: "Held-out evaluation outcomes are unavailable for a trustworthy comparison." };
+  }
+  if (candidate.count < MIN_REAL_TEST_OUTCOMES || candidate.positives === 0 || candidate.negatives === 0) {
+    return {
+      status: "insufficient-data",
+      reason: `Need at least ${MIN_REAL_TEST_OUTCOMES} held-out outcomes with both success and failure labels.`,
+    };
+  }
+  const improvesLoss = candidate.logLoss <= baseline.logLoss - MIN_LOG_LOSS_IMPROVEMENT;
+  const preservesBrier = candidate.brierScore <= baseline.brierScore;
+  const preservesCalibration = candidate.expectedCalibrationError <= baseline.expectedCalibrationError + MAX_ECE_REGRESSION;
+  if (improvesLoss && preservesBrier && preservesCalibration) {
+    return {
+      status: "eligible-for-shadow-validation",
+      reason: "Candidate beats the held-out EMA baseline without worsening Brier score or materially degrading calibration; this is not a production-adoption decision.",
+    };
+  }
+  return {
+    status: "does-not-beat-baseline",
+    reason: "Candidate did not clear the held-out predictive and calibration gate against EMA history baseline.",
+  };
+}
+
+function metricsOrNull(predictions: BenchmarkPrediction[]) {
+  return predictions.length > 0 ? calculateMetrics(predictions) : null;
+}
+
+export function runLearnerModelBenchmark(
+  input: LearnerModelBenchmarkDataset | unknown,
+  options: { testFraction?: number } = {},
+): LearnerModelBenchmarkReport {
+  const dataset = parseLearnerModelBenchmarkDataset(input);
+  const split = splitBenchmarkLearners(dataset.records, options.testFraction ?? 0.2);
+  const trainSet = new Set(split.trainLearners);
+  const testSet = new Set(split.testLearners);
+  const trainExamples = buildEvaluationExamples(dataset.records, trainSet);
+  const testExamples = buildEvaluationExamples(dataset.records, testSet);
+
+  const emaMetrics = metricsOrNull(predictEmaHistory(dataset.records, testSet));
+  const bktParameters = fitBktParameters(dataset.records, trainSet);
+  const bktMetrics = metricsOrNull(predictBkt(dataset.records, testSet, bktParameters));
+  const logisticWeights = fitLogisticRegression(trainExamples);
+  const lktMetrics = metricsOrNull(predictLogistic(testExamples, logisticWeights));
+  const aoaMetrics = metricsOrNull(predictLogisticAoa(testExamples, logisticWeights));
+
+  return {
+    benchmarkVersion: "learner-model-benchmark-v1",
+    datasetId: dataset.datasetId,
+    synthetic: dataset.synthetic,
+    targetOutcome: "independent-changed-context-transfer-or-delayed-retention",
+    split,
+    trainOutcomeCount: trainExamples.length,
+    testOutcomeCount: testExamples.length,
+    models: [
+      {
+        modelId: "ema-history-v1",
+        metrics: emaMetrics,
+        gate: { status: "baseline", reason: "Reference predictor derived from AtoEnglish's current asymmetric EMA update policy." },
+      },
+      { modelId: "bkt-grid-v1", metrics: bktMetrics, gate: candidateGate(dataset, emaMetrics, bktMetrics) },
+      { modelId: "lkt-logistic-v1", metrics: lktMetrics, gate: candidateGate(dataset, emaMetrics, lktMetrics) },
+      { modelId: "lkt-logistic-aoa-v1", metrics: aoaMetrics, gate: candidateGate(dataset, emaMetrics, aoaMetrics) },
+    ],
+    notes: [
+      "All predictions are generated before the labeled transfer/retention event is applied to learner history.",
+      "Learners are held out as complete identities; train and test learner sets never overlap.",
+      "AOA is an aggregation strategy over LKT-style prediction trajectories, not a standalone learner model.",
+      "Benchmark scores are prediction evidence only; they must not mutate learner proficiency or mastery state.",
+      "Real-data promotion requires a privacy-safe export and a separate shadow-validation decision.",
+    ],
+  };
+}
+
+export function createSyntheticLearnerModelBenchmarkDataset(): LearnerModelBenchmarkDataset {
+  const records: BenchmarkEvidenceRecord[] = [];
+  const base = Date.parse("2026-01-01T00:00:00.000Z");
+  const historyTypes: BenchmarkEvidenceType[] = ["recognition", "retrieval", "production", "retrieval", "production", "repair"];
+
+  for (let learner = 0; learner < 30; learner += 1) {
+    const learnerKey = `synthetic-learner-${String(learner + 1).padStart(2, "0")}`;
+    const abilityBand = learner % 5;
+    for (let target = 0; target < 2; target += 1) {
+      const targetId = `CAP-SYN-${target + 1}`;
+      for (let opportunity = 0; opportunity < historyTypes.length; opportunity += 1) {
+        const threshold = Math.min(4, abilityBand + Math.floor(opportunity / 2));
+        const success = (learner + target + opportunity) % 5 <= threshold;
+        const supportLevel = opportunity < 2 && abilityBand < 2 ? 1 : 0;
+        records.push({
+          learnerKey,
+          targetId,
+          evidenceType: historyTypes[opportunity],
+          success,
+          confidence: 1,
+          supportLevel,
+          independent: supportLevel === 0,
+          changedContext: false,
+          delayDays: null,
+          occurredAt: new Date(base + (learner * 20 + target * 8 + opportunity) * 86_400_000).toISOString(),
+        });
+      }
+      const transferSuccess = abilityBand >= 2 || (learner + target) % 4 === 0;
+      records.push({
+        learnerKey,
+        targetId,
+        evidenceType: "transfer",
+        success: transferSuccess,
+        confidence: 1,
+        supportLevel: 0,
+        independent: true,
+        changedContext: true,
+        delayDays: null,
+        occurredAt: new Date(base + (learner * 20 + target * 8 + 6) * 86_400_000).toISOString(),
+      });
+      records.push({
+        learnerKey,
+        targetId,
+        evidenceType: "retention",
+        success: transferSuccess && (abilityBand >= 3 || learner % 3 !== 0),
+        confidence: 1,
+        supportLevel: 0,
+        independent: true,
+        changedContext: true,
+        delayDays: 7,
+        occurredAt: new Date(base + (learner * 20 + target * 8 + 13) * 86_400_000).toISOString(),
+      });
+    }
+  }
+
+  return {
+    datasetId: "synthetic-pipeline-fixture-v1",
+    synthetic: true,
+    records,
+  };
+}

--- a/src/lib/learning/evidence.ts
+++ b/src/lib/learning/evidence.ts
@@ -9,6 +9,7 @@ export const EVIDENCE_TYPES = [
 ] as const;
 
 export type EvidenceType = (typeof EVIDENCE_TYPES)[number];
+export type EvidenceCoverage = Partial<Record<EvidenceType, number>>;
 export type ResponseModality = "choice" | "text" | "speech" | "gesture" | "none";
 
 export interface LearningAttemptInput {
@@ -124,6 +125,11 @@ export interface LearnerSkillState {
   transfer: number;
   retention: number;
   evidenceCount: number;
+  /**
+   * Coverage is derived from append-only evidence history. Numeric skill values remain a fast
+   * routing snapshot; a zero with no typed evidence is unknown, not observed failure.
+   */
+  evidenceByType?: EvidenceCoverage;
   lastEvidenceAt: string | null;
 }
 
@@ -138,6 +144,15 @@ export function createEmptyLearnerSkillState(targetId: string): LearnerSkillStat
     transfer: 0,
     retention: 0,
     evidenceCount: 0,
+    evidenceByType: {
+      recognition: 0,
+      retrieval: 0,
+      listening: 0,
+      production: 0,
+      repair: 0,
+      transfer: 0,
+      retention: 0,
+    },
     lastEvidenceAt: null,
   };
 }
@@ -157,11 +172,16 @@ export function applyEvidenceToSkillState(
   const observation = evidence.success ? effectiveConfidence : 0;
   const alpha = evidence.success ? 0.35 : 0.5;
   const nextValue = clamp(oldValue * (1 - alpha) + observation * alpha, 0, 1);
+  const typedEvidenceCount = Math.max(0, Math.floor(current.evidenceByType?.[evidence.type] ?? 0));
 
   return {
     ...current,
     [evidence.type]: nextValue,
     evidenceCount: current.evidenceCount + 1,
+    evidenceByType: {
+      ...current.evidenceByType,
+      [evidence.type]: typedEvidenceCount + 1,
+    },
     lastEvidenceAt: occurredAt,
   };
 }

--- a/src/lib/learning/learner-state-read.test.ts
+++ b/src/lib/learning/learner-state-read.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyLearnerSkillState } from "./evidence";
+import { readLearnerDimension } from "./learner-state-read";
+import { planSession, type PlannerCandidate } from "./session-planner";
+
+describe("learner state evidence coverage", () => {
+  it("keeps an unobserved default zero unknown", () => {
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.8,
+      evidenceCount: 1,
+      evidenceByType: { recognition: 1 },
+    };
+
+    expect(readLearnerDimension(state, "production")).toEqual({
+      estimate: null,
+      evidenceCount: 0,
+      status: "unknown",
+      confidence: null,
+      modelVersion: "ema-routing-v1",
+      decisionScope: "routing",
+    });
+  });
+
+  it("keeps an observed zero as real routing evidence", () => {
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    expect(readLearnerDimension(state, "production")).toMatchObject({
+      estimate: 0,
+      evidenceCount: 1,
+      status: "observed",
+      confidence: null,
+    });
+  });
+
+  it("does not turn an unknown dimension into a full skill gap", () => {
+    const candidate: PlannerCandidate = {
+      id: "produce-test",
+      targetId: "CAP-TEST",
+      evidenceType: "production",
+      importance: 0,
+    };
+    const unknownState = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.8,
+      evidenceCount: 1,
+      evidenceByType: { recognition: 1 },
+    };
+    const observedZeroState = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      evidenceCount: 1,
+      evidenceByType: { production: 1 },
+    };
+
+    const unknown = planSession({ candidates: [candidate], states: [unknownState], sessionSize: 1 });
+    const observedZero = planSession({
+      candidates: [candidate],
+      states: [observedZeroState],
+      sessionSize: 1,
+    });
+
+    expect(unknown.opportunities[0]?.breakdown.skillGap).toBe(0);
+    expect(unknown.opportunities[0]?.reasons).toContain("evidence-unknown:production");
+    expect(observedZero.opportunities[0]?.breakdown.skillGap).toBe(1);
+    expect(observedZero.opportunities[0]?.reasons).toContain("skill-gap:1");
+  });
+
+  it("blocks transfer until production has actually been observed", () => {
+    const transfer: PlannerCandidate = {
+      id: "transfer-test",
+      targetId: "CAP-TEST",
+      evidenceType: "transfer",
+    };
+    const state = {
+      ...createEmptyLearnerSkillState("CAP-TEST"),
+      recognition: 0.9,
+      evidenceCount: 2,
+      evidenceByType: { recognition: 2 },
+    };
+
+    const plan = planSession({ candidates: [transfer], states: [state], sessionSize: 1 });
+
+    expect(plan.opportunities).toHaveLength(0);
+    expect(plan.blocked[0]?.reasons).toContain("transfer-needs-observed-production");
+  });
+});

--- a/src/lib/learning/learner-state-read.ts
+++ b/src/lib/learning/learner-state-read.ts
@@ -1,0 +1,67 @@
+import type { EvidenceType, LearnerSkillState } from "./evidence";
+
+export const LEARNER_STATE_MODEL_VERSION = "ema-routing-v1" as const;
+
+export type LearnerDimensionRead = {
+  estimate: number | null;
+  evidenceCount: number;
+  status: "unknown" | "observed";
+  /** Not calibrated yet. Keep null rather than inventing probability-like certainty. */
+  confidence: null;
+  modelVersion: typeof LEARNER_STATE_MODEL_VERSION;
+  decisionScope: "routing";
+};
+
+/**
+ * Read one learner dimension without confusing an unobserved default zero with observed weakness.
+ *
+ * New planner reads attach per-type evidence coverage from append-only evidence history. The
+ * fallback preserves compatibility for older in-memory callers that only know total evidence.
+ */
+export function readLearnerDimension(
+  state: LearnerSkillState,
+  evidenceType: EvidenceType,
+): LearnerDimensionRead {
+  const typedCoverage = state.evidenceByType;
+  const evidenceCount = typedCoverage
+    ? normalizeCount(typedCoverage[evidenceType])
+    : state.evidenceCount > 0
+      ? state.evidenceCount
+      : 0;
+
+  if (evidenceCount === 0) {
+    return {
+      estimate: null,
+      evidenceCount: 0,
+      status: "unknown",
+      confidence: null,
+      modelVersion: LEARNER_STATE_MODEL_VERSION,
+      decisionScope: "routing",
+    };
+  }
+
+  return {
+    estimate: clamp01(state[evidenceType]),
+    evidenceCount,
+    status: "observed",
+    confidence: null,
+    modelVersion: LEARNER_STATE_MODEL_VERSION,
+    decisionScope: "routing",
+  };
+}
+
+export function hasObservedLearnerDimension(
+  state: LearnerSkillState,
+  evidenceType: EvidenceType,
+) {
+  return readLearnerDimension(state, evidenceType).status === "observed";
+}
+
+function normalizeCount(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, Number.isFinite(value) ? value : 0));
+}

--- a/src/lib/learning/session-input.ts
+++ b/src/lib/learning/session-input.ts
@@ -1,4 +1,9 @@
-import type { LearnerSkillState } from "./evidence";
+import {
+  EVIDENCE_TYPES,
+  type EvidenceCoverage,
+  type EvidenceType,
+  type LearnerSkillState,
+} from "./evidence";
 import type { PlannerCandidate } from "./session-planner";
 
 export const PLANNER_SKILL_STATE_SELECT =
@@ -20,6 +25,12 @@ export type LearnerSkillStateRow = {
   last_evidence_at: string | null;
 };
 
+export type LearnerEvidenceCoverageRow = {
+  target_id: string;
+  evidence_type: string;
+  evidence_count: number | string;
+};
+
 export type RecentLearningAttemptRow = {
   capability_id: string | null;
   knowledge_item_id: string | null;
@@ -34,7 +45,10 @@ export type RecentPlannerHistory = {
   recentCandidateIds: string[];
 };
 
-export function mapLearnerSkillStateRow(row: LearnerSkillStateRow): LearnerSkillState {
+export function mapLearnerSkillStateRow(
+  row: LearnerSkillStateRow,
+  evidenceByType?: EvidenceCoverage,
+): LearnerSkillState {
   return {
     targetId: row.target_id,
     recognition: clamp01(row.recognition),
@@ -45,8 +59,25 @@ export function mapLearnerSkillStateRow(row: LearnerSkillStateRow): LearnerSkill
     transfer: clamp01(row.transfer),
     retention: clamp01(row.retention),
     evidenceCount: Math.max(0, Math.floor(row.evidence_count)),
+    evidenceByType,
     lastEvidenceAt: row.last_evidence_at,
   };
+}
+
+export function buildLearnerEvidenceCoverage(rows: LearnerEvidenceCoverageRow[]) {
+  const coverageByTarget = new Map<string, EvidenceCoverage>();
+
+  for (const row of rows) {
+    if (!isEvidenceType(row.evidence_type)) continue;
+    const evidenceCount = normalizeCount(row.evidence_count);
+    if (evidenceCount === 0) continue;
+
+    const coverage = coverageByTarget.get(row.target_id) ?? {};
+    coverage[row.evidence_type] = evidenceCount;
+    coverageByTarget.set(row.target_id, coverage);
+  }
+
+  return coverageByTarget;
 }
 
 export function collectPlannerTargetIds(candidates: PlannerCandidate[]): string[] {
@@ -81,6 +112,16 @@ export function deriveRecentPlannerHistory(rows: RecentLearningAttemptRow[]): Re
 export function normalizeSessionSize(value: number | undefined, fallback = 5) {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.min(12, Math.max(1, Math.floor(value)));
+}
+
+function isEvidenceType(value: string): value is EvidenceType {
+  return (EVIDENCE_TYPES as readonly string[]).includes(value);
+}
+
+function normalizeCount(value: number | string) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.floor(parsed));
 }
 
 function asNonEmptyString(value: unknown) {

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,6 +1,10 @@
 import type { ErrorMemoryEntry } from "./error-memory";
 import type { EvidenceType, LearnerSkillState } from "./evidence";
 import { createEmptyLearnerSkillState } from "./evidence";
+import {
+  hasObservedLearnerDimension,
+  readLearnerDimension,
+} from "./learner-state-read";
 
 export type PlannerCandidate = {
   id: string;
@@ -190,8 +194,13 @@ function checkEligibility(
   ) {
     reasons.push("cold-start-needs-recognition");
   }
-  if (candidate.evidenceType === "transfer" && targetState.production < config.transferProductionFloor) {
-    reasons.push("transfer-needs-prior-production");
+  if (candidate.evidenceType === "transfer") {
+    const production = readLearnerDimension(targetState, "production");
+    if (production.status === "unknown") {
+      reasons.push("transfer-needs-observed-production");
+    } else if ((production.estimate ?? 0) < config.transferProductionFloor) {
+      reasons.push("transfer-needs-prior-production");
+    }
   }
   if (candidate.evidenceType === "retention" && targetState.evidenceCount === 0) {
     reasons.push("retention-needs-prior-evidence");
@@ -220,8 +229,9 @@ function scoreCandidate(input: {
     selectedForTarget,
     config,
   } = input;
-  const skillGap = 1 - clamp01(state[candidate.evidenceType]);
-  const coldStart = state.evidenceCount === 0 ? COLD_START_BONUS[candidate.evidenceType] : 0;
+  const dimension = readLearnerDimension(state, candidate.evidenceType);
+  const skillGap = dimension.estimate === null ? 0 : 1 - clamp01(dimension.estimate);
+  const coldStart = dimension.status === "unknown" ? COLD_START_BONUS[candidate.evidenceType] : 0;
   const staleness = calculateStaleness(state.lastEvidenceAt, now);
   const importance = clamp01(candidate.importance ?? 0.5);
   const transferValue = clamp01(candidate.transferValue ?? 0);
@@ -246,7 +256,9 @@ function scoreCandidate(input: {
     - inSessionRepeatPenalty;
 
   const reasons = [
-    `skill-gap:${round(skillGap)}`,
+    dimension.status === "unknown"
+      ? `evidence-unknown:${candidate.evidenceType}`
+      : `skill-gap:${round(skillGap)}`,
     `importance:${round(importance)}`,
   ];
   if (coldStart > 0) reasons.push(`cold-start:${candidate.evidenceType}`);
@@ -326,14 +338,16 @@ function metadataString(metadata: Record<string, unknown> | undefined, key: stri
 }
 
 function readiness(state: LearnerSkillState) {
-  return Math.max(
-    state.retrieval,
-    state.production,
-    state.transfer,
-    state.retention,
-    state.recognition * 0.5,
-    state.listening * 0.5,
-  );
+  const observed = (["retrieval", "production", "transfer", "retention"] as const)
+    .flatMap((type) => {
+      const dimension = readLearnerDimension(state, type);
+      return dimension.estimate === null ? [] : [dimension.estimate];
+    });
+  const recognition = readLearnerDimension(state, "recognition");
+  const listening = readLearnerDimension(state, "listening");
+  if (recognition.estimate !== null) observed.push(recognition.estimate * 0.5);
+  if (listening.estimate !== null) observed.push(listening.estimate * 0.5);
+  return observed.length > 0 ? Math.max(...observed) : 0;
 }
 
 function calculateStaleness(lastEvidenceAt: string | null, now: number) {

--- a/src/lib/learning/session-planner.ts
+++ b/src/lib/learning/session-planner.ts
@@ -1,10 +1,7 @@
 import type { ErrorMemoryEntry } from "./error-memory";
 import type { EvidenceType, LearnerSkillState } from "./evidence";
 import { createEmptyLearnerSkillState } from "./evidence";
-import {
-  hasObservedLearnerDimension,
-  readLearnerDimension,
-} from "./learner-state-read";
+import { readLearnerDimension } from "./learner-state-read";
 
 export type PlannerCandidate = {
   id: string;

--- a/supabase/migrations/20260903090000_learner_evidence_coverage.sql
+++ b/supabase/migrations/20260903090000_learner_evidence_coverage.sql
@@ -1,0 +1,35 @@
+-- Read-only evidence coverage for learner-state routing.
+--
+-- learner_skill_states is a rebuildable EMA snapshot. Its numeric zero cannot distinguish
+-- "observed at zero" from "not observed" because the snapshot stores only a total evidence_count.
+-- Keep append-only learning_evidence_events as the source of truth and expose only aggregate
+-- target x evidence-type counts to authenticated callers.
+
+CREATE OR REPLACE FUNCTION public.get_learner_evidence_coverage(
+  p_target_ids text[]
+) RETURNS TABLE (
+  target_id text,
+  evidence_type text,
+  evidence_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT
+    e.target_id,
+    e.evidence_type,
+    COUNT(*)::bigint AS evidence_count
+  FROM public.learning_evidence_events AS e
+  WHERE e.user_id = (SELECT auth.uid())
+    AND e.target_id = ANY(COALESCE(p_target_ids, ARRAY[]::text[]))
+  GROUP BY e.target_id, e.evidence_type
+  ORDER BY e.target_id, e.evidence_type;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_learner_evidence_coverage(text[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_learner_evidence_coverage(text[]) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_learner_evidence_coverage(text[]) IS
+  'Returns privacy-safe aggregate evidence counts by target and evidence type for the current authenticated learner. Numeric learner-state snapshots remain routing estimates, not mastery probabilities.';


### PR DESCRIPTION
## Scope

Adds a research-only learner-model benchmark harness on top of the evidence-coverage contract from PR #98.

### Included
- deterministic learner-level held-out split
- future independent transfer / delayed retention as evaluation outcomes
- EMA-history baseline matching the current asymmetric update policy
- small BKT grid-search comparator
- LKT-style logistic comparator
- AOA aggregation over LKT-style prediction trajectories
- log loss, Brier score, ECE, and AUROC metrics
- strict privacy-safe input parser that rejects response/transcript/audio/prompt/metadata payload fields
- synthetic fixture for pipeline tests only; synthetic results can never pass the adoption gate
- CLI and frontier documentation

### Explicitly not included
- no Supabase export/query path
- no production learner-state writes
- no adaptive-routing changes
- no mastery/proficiency mutation
- no Python/R runtime dependency
- no model promotion based on synthetic data

The intended next boundary after this PR is a separately reviewed privacy-safe historical export + real held-out benchmark/shadow validation.

Depends on PR #98 (`frontier/learner-state-evidence-coverage-v1`).