### PR TITLE
Add learner-model real-data readiness boundary

### DIFF
--- a/docs/frontier/LEARNER_MODEL_REAL_DATA_READINESS_V1.md
+++ b/docs/frontier/LEARNER_MODEL_REAL_DATA_READINESS_V1.md
@@ -1,0 +1,94 @@
+# Learner Model Real-Data Readiness V1
+
+## Purpose
+
+This boundary answers one question before any learner model can be compared on real AtoEnglish data:
+
+> Do we have enough privacy-safe, independent transfer / delayed-retention outcomes to run a trustworthy learner-level held-out benchmark?
+
+It does **not** change production learner state, mastery, routing, or evidence generation.
+
+## Operator flow
+
+1. Run `scripts/learner-model-readiness.sql` as a read-only aggregate audit.
+2. Stop unless the result is `exportable-needs-held-out-check`.
+3. Run `scripts/export-learner-model-evidence.sql`.
+4. Save only the returned `benchmark_dataset` JSON. Do not export the underlying tables directly.
+5. Run the existing learner-model benchmark CLI on that JSON.
+6. The TypeScript preflight reuses the benchmark's deterministic learner-level split and requires at least 20 held-out target outcomes with both positive and negative labels.
+7. A candidate that clears the held-out benchmark is only **eligible for shadow validation**. It is not automatically allowed to replace the production learner-state model.
+
+## Privacy boundary
+
+The export intentionally emits only:
+
+- within-export pseudonymous `learnerKey`
+- canonical `targetId`
+- evidence type
+- success
+- confidence
+- support level
+- derived `independent`
+- derived `changedContext`
+- derived retention delay in days
+- evidence timestamp
+
+It never emits:
+
+- raw `user_id`
+- `response_text`
+- transcript or audio
+- prompt text / partner cue
+- raw `context_id`
+- metadata JSON
+- name, email, employer, or other free text
+
+`learnerKey` is a dense within-export pseudonym (`learner-000001`, ...). It is sufficient for learner-level holdout but is not a durable cross-export identity.
+
+## Evidence semantics
+
+### Independent
+
+An event is considered independent only when all of these are true:
+
+- evidence `support_level = 0`
+- attempt `support_level = 0`
+- `hint_count = 0`
+- `reveal_used = false`
+
+### Changed-context transfer
+
+The export compares the transfer event's internal context with the most recent prior successful production / repair / transfer context for the same learner and target. Only the derived boolean is exported. Raw contexts stay inside the database query.
+
+### Delayed retention
+
+For retention evidence, `delayDays` is measured from the most recent prior **successful independent** retrieval / listening / production / repair / transfer / retention evidence for the same learner and target.
+
+A retention outcome enters the benchmark only when `delayDays >= 1`.
+
+## Production audit snapshot — 2026-09-03
+
+Read-only aggregate inspection of project `zpiwddskhduuykpxltun` found:
+
+- canonical `learning_attempts`: 0 rows
+- canonical `learning_evidence_events`: 0 rows
+- `card_review_logs`: 0 rows
+- `pilot_events`: 44 rows from 1 learner
+
+The pilot events are limited to return / landing / start telemetry and contain no scored transfer or delayed-retention outcomes. They must **not** be backfilled or re-labeled as canonical learning evidence.
+
+Therefore the current real-data learner-model benchmark is correctly blocked at:
+
+`no-evidence`
+
+This is a data-collection limitation, not evidence that any candidate learner model is better or worse.
+
+## Exit condition
+
+This boundary becomes actionable when canonical evidence has enough real learner-level target outcomes for the deterministic held-out split to contain:
+
+- at least 20 target outcomes,
+- at least one success,
+- at least one failure.
+
+Only then should the model-comparison report be used to decide whether a candidate is eligible for shadow validation.

--- a/scripts/export-learner-model-evidence.sql
+++ b/scripts/export-learner-model-evidence.sql
@@ -1,0 +1,103 @@
+-- Read-only privacy-safe export for the learner-model benchmark.
+--
+-- Output contract matches LearnerModelBenchmarkDataset.
+-- Raw user ids are used only inside this query to derive stable within-export pseudonyms.
+-- The result never includes response_text, transcript/audio payloads, prompts, context ids,
+-- metadata, email, name, or any other free text beyond canonical target ids.
+--
+-- Run scripts/learner-model-readiness.sql first. An empty export is expected while production
+-- has no canonical evidence and must not be treated as a benchmark dataset.
+
+WITH ranked_learners AS (
+  SELECT
+    user_id,
+    DENSE_RANK() OVER (ORDER BY user_id) AS learner_rank
+  FROM (
+    SELECT DISTINCT user_id
+    FROM public.learning_evidence_events
+  ) AS learners
+), classified AS (
+  SELECT
+    e.id AS evidence_id,
+    'learner-' || LPAD(r.learner_rank::text, 6, '0') AS learner_key,
+    e.target_id,
+    e.evidence_type,
+    e.success,
+    e.confidence,
+    e.support_level,
+    e.created_at,
+    (
+      e.support_level = 0
+      AND a.support_level = 0
+      AND a.hint_count = 0
+      AND a.reveal_used = false
+    ) AS independent,
+    (
+      e.evidence_type = 'transfer'
+      AND e.context_id IS NOT NULL
+      AND prior_context.context_id IS NOT NULL
+      AND e.context_id IS DISTINCT FROM prior_context.context_id
+    ) AS changed_context,
+    CASE
+      WHEN e.evidence_type = 'retention' AND prior_independent_success.created_at IS NOT NULL
+        THEN EXTRACT(EPOCH FROM (e.created_at - prior_independent_success.created_at)) / 86400.0
+      ELSE NULL
+    END AS delay_days
+  FROM public.learning_evidence_events AS e
+  JOIN public.learning_attempts AS a
+    ON a.id = e.attempt_id
+  JOIN ranked_learners AS r
+    ON r.user_id = e.user_id
+  LEFT JOIN LATERAL (
+    SELECT prior.context_id
+    FROM public.learning_evidence_events AS prior
+    WHERE prior.user_id = e.user_id
+      AND prior.target_id = e.target_id
+      AND prior.success = true
+      AND prior.evidence_type IN ('production', 'repair', 'transfer')
+      AND prior.context_id IS NOT NULL
+      AND (prior.created_at, prior.id) < (e.created_at, e.id)
+    ORDER BY prior.created_at DESC, prior.id DESC
+    LIMIT 1
+  ) AS prior_context ON true
+  LEFT JOIN LATERAL (
+    SELECT prior.created_at
+    FROM public.learning_evidence_events AS prior
+    JOIN public.learning_attempts AS prior_attempt
+      ON prior_attempt.id = prior.attempt_id
+    WHERE prior.user_id = e.user_id
+      AND prior.target_id = e.target_id
+      AND prior.success = true
+      AND prior.support_level = 0
+      AND prior_attempt.support_level = 0
+      AND prior_attempt.hint_count = 0
+      AND prior_attempt.reveal_used = false
+      AND prior.evidence_type IN ('retrieval', 'listening', 'production', 'repair', 'transfer', 'retention')
+      AND (prior.created_at, prior.id) < (e.created_at, e.id)
+    ORDER BY prior.created_at DESC, prior.id DESC
+    LIMIT 1
+  ) AS prior_independent_success ON true
+)
+SELECT jsonb_build_object(
+  'datasetId', 'atoenglish-canonical-evidence-' || TO_CHAR(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYYMMDD"T"HH24MISS"Z"'),
+  'synthetic', false,
+  'records', COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'learnerKey', learner_key,
+        'targetId', target_id,
+        'evidenceType', evidence_type,
+        'success', success,
+        'confidence', confidence,
+        'supportLevel', support_level,
+        'independent', independent,
+        'changedContext', changed_context,
+        'delayDays', delay_days,
+        'occurredAt', created_at
+      )
+      ORDER BY learner_key, created_at, evidence_id
+    ),
+    '[]'::jsonb
+  )
+) AS benchmark_dataset
+FROM classified;

--- a/scripts/learner-model-readiness.sql
+++ b/scripts/learner-model-readiness.sql
@@ -1,0 +1,131 @@
+-- Read-only aggregate preflight for the learner-model benchmark.
+--
+-- Privacy boundary:
+-- - emits counts/timestamps only
+-- - never emits user ids, response_text, transcripts, prompts, context ids, or metadata
+-- - does not mutate production data
+--
+-- Exact learner-level held-out sufficiency is checked again in TypeScript after a privacy-safe export.
+
+WITH classified AS (
+  SELECT
+    e.user_id,
+    e.evidence_type,
+    e.success,
+    e.created_at,
+    (
+      e.support_level = 0
+      AND a.support_level = 0
+      AND a.hint_count = 0
+      AND a.reveal_used = false
+    ) AS independent,
+    (
+      e.evidence_type = 'transfer'
+      AND e.context_id IS NOT NULL
+      AND prior_context.context_id IS NOT NULL
+      AND e.context_id IS DISTINCT FROM prior_context.context_id
+    ) AS changed_context,
+    CASE
+      WHEN e.evidence_type = 'retention' AND prior_independent_success.created_at IS NOT NULL
+        THEN EXTRACT(EPOCH FROM (e.created_at - prior_independent_success.created_at)) / 86400.0
+      ELSE NULL
+    END AS delay_days
+  FROM public.learning_evidence_events AS e
+  JOIN public.learning_attempts AS a
+    ON a.id = e.attempt_id
+  LEFT JOIN LATERAL (
+    SELECT prior.context_id
+    FROM public.learning_evidence_events AS prior
+    WHERE prior.user_id = e.user_id
+      AND prior.target_id = e.target_id
+      AND prior.success = true
+      AND prior.evidence_type IN ('production', 'repair', 'transfer')
+      AND prior.context_id IS NOT NULL
+      AND (prior.created_at, prior.id) < (e.created_at, e.id)
+    ORDER BY prior.created_at DESC, prior.id DESC
+    LIMIT 1
+  ) AS prior_context ON true
+  LEFT JOIN LATERAL (
+    SELECT prior.created_at
+    FROM public.learning_evidence_events AS prior
+    JOIN public.learning_attempts AS prior_attempt
+      ON prior_attempt.id = prior.attempt_id
+    WHERE prior.user_id = e.user_id
+      AND prior.target_id = e.target_id
+      AND prior.success = true
+      AND prior.support_level = 0
+      AND prior_attempt.support_level = 0
+      AND prior_attempt.hint_count = 0
+      AND prior_attempt.reveal_used = false
+      AND prior.evidence_type IN ('retrieval', 'listening', 'production', 'repair', 'transfer', 'retention')
+      AND (prior.created_at, prior.id) < (e.created_at, e.id)
+    ORDER BY prior.created_at DESC, prior.id DESC
+    LIMIT 1
+  ) AS prior_independent_success ON true
+), summarized AS (
+  SELECT
+    COUNT(*)::bigint AS evidence_events,
+    COUNT(DISTINCT user_id)::bigint AS learners,
+    COUNT(*) FILTER (
+      WHERE independent
+        AND (
+          (evidence_type = 'transfer' AND changed_context)
+          OR (evidence_type = 'retention' AND delay_days >= 1)
+        )
+    )::bigint AS target_outcomes,
+    COUNT(DISTINCT user_id) FILTER (
+      WHERE independent
+        AND (
+          (evidence_type = 'transfer' AND changed_context)
+          OR (evidence_type = 'retention' AND delay_days >= 1)
+        )
+    )::bigint AS outcome_learners,
+    COUNT(*) FILTER (
+      WHERE independent
+        AND success
+        AND (
+          (evidence_type = 'transfer' AND changed_context)
+          OR (evidence_type = 'retention' AND delay_days >= 1)
+        )
+    )::bigint AS positive_outcomes,
+    COUNT(*) FILTER (
+      WHERE independent
+        AND NOT success
+        AND (
+          (evidence_type = 'transfer' AND changed_context)
+          OR (evidence_type = 'retention' AND delay_days >= 1)
+        )
+    )::bigint AS negative_outcomes,
+    COUNT(*) FILTER (
+      WHERE independent
+        AND evidence_type = 'transfer'
+        AND changed_context
+    )::bigint AS transfer_outcomes,
+    COUNT(*) FILTER (
+      WHERE independent
+        AND evidence_type = 'retention'
+        AND delay_days >= 1
+    )::bigint AS retention_outcomes,
+    MIN(created_at) AS first_evidence_at,
+    MAX(created_at) AS latest_evidence_at
+  FROM classified
+)
+SELECT
+  evidence_events,
+  learners,
+  target_outcomes,
+  outcome_learners,
+  positive_outcomes,
+  negative_outcomes,
+  transfer_outcomes,
+  retention_outcomes,
+  first_evidence_at,
+  latest_evidence_at,
+  CASE
+    WHEN evidence_events = 0 THEN 'no-evidence'
+    WHEN learners < 2 THEN 'insufficient-learners'
+    WHEN target_outcomes = 0 THEN 'no-target-outcomes'
+    WHEN positive_outcomes = 0 OR negative_outcomes = 0 THEN 'target-label-collapse'
+    ELSE 'exportable-needs-held-out-check'
+  END AS readiness_status
+FROM summarized;

--- a/src/lib/learning/benchmark/real-data-readiness.test.ts
+++ b/src/lib/learning/benchmark/real-data-readiness.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createSyntheticLearnerModelBenchmarkDataset,
+  type BenchmarkEvidenceRecord,
+} from "./learner-model-benchmark";
+import { assessLearnerModelRealDataReadiness } from "./real-data-readiness";
+
+function singleLearnerRecords(): BenchmarkEvidenceRecord[] {
+  return [
+    {
+      learnerKey: "learner-a",
+      targetId: "CAP-001",
+      evidenceType: "production",
+      success: true,
+      confidence: 1,
+      supportLevel: 0,
+      independent: true,
+      changedContext: false,
+      delayDays: null,
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      learnerKey: "learner-a",
+      targetId: "CAP-001",
+      evidenceType: "transfer",
+      success: true,
+      confidence: 1,
+      supportLevel: 0,
+      independent: true,
+      changedContext: true,
+      delayDays: null,
+      occurredAt: "2026-01-02T00:00:00.000Z",
+    },
+  ];
+}
+
+describe("learner-model real-data readiness", () => {
+  it("fails closed when canonical evidence is empty", () => {
+    const readiness = assessLearnerModelRealDataReadiness([]);
+
+    expect(readiness.status).toBe("no-evidence");
+    expect(readiness.evidenceEventCount).toBe(0);
+  });
+
+  it("requires learner-level holdout rather than treating one learner as a benchmark", () => {
+    const readiness = assessLearnerModelRealDataReadiness(singleLearnerRecords());
+
+    expect(readiness.status).toBe("insufficient-learners");
+    expect(readiness.learnerCount).toBe(1);
+    expect(readiness.targetOutcomeCount).toBe(1);
+  });
+
+  it("uses the benchmark's deterministic split and clears preflight on a structurally sufficient dataset", () => {
+    const dataset = createSyntheticLearnerModelBenchmarkDataset();
+    const readiness = assessLearnerModelRealDataReadiness(dataset.records);
+
+    expect(readiness.status).toBe("ready-for-held-out-benchmark");
+    expect(readiness.testOutcomeCount).toBeGreaterThanOrEqual(20);
+    expect(readiness.testPositiveCount).toBeGreaterThan(0);
+    expect(readiness.testNegativeCount).toBeGreaterThan(0);
+  });
+
+  it("does not call a tiny two-learner dataset benchmark-ready", () => {
+    const first = singleLearnerRecords();
+    const second = first.map((record) => ({
+      ...record,
+      learnerKey: "learner-b",
+      success: !record.success,
+    }));
+    const readiness = assessLearnerModelRealDataReadiness([...first, ...second]);
+
+    expect(readiness.status).toBe("insufficient-held-out-outcomes");
+    expect(readiness.testOutcomeCount).toBeLessThan(20);
+  });
+});

--- a/src/lib/learning/benchmark/real-data-readiness.ts
+++ b/src/lib/learning/benchmark/real-data-readiness.ts
@@ -1,0 +1,130 @@
+import {
+  buildEvaluationExamples,
+  runLearnerModelBenchmark,
+  type BenchmarkEvidenceRecord,
+} from "./learner-model-benchmark";
+
+export type LearnerModelRealDataReadinessStatus =
+  | "no-evidence"
+  | "insufficient-learners"
+  | "no-target-outcomes"
+  | "insufficient-held-out-outcomes"
+  | "held-out-label-collapse"
+  | "ready-for-held-out-benchmark";
+
+export type LearnerModelRealDataReadiness = {
+  status: LearnerModelRealDataReadinessStatus;
+  reason: string;
+  evidenceEventCount: number;
+  learnerCount: number;
+  targetOutcomeCount: number;
+  trainOutcomeCount: number;
+  testOutcomeCount: number;
+  testPositiveCount: number;
+  testNegativeCount: number;
+};
+
+const MIN_HELD_OUT_OUTCOMES = 20;
+
+export function assessLearnerModelRealDataReadiness(
+  records: BenchmarkEvidenceRecord[],
+  options: { testFraction?: number } = {},
+): LearnerModelRealDataReadiness {
+  const evidenceEventCount = records.length;
+  const learnerCount = new Set(records.map((record) => record.learnerKey)).size;
+  const targetOutcomeCount = buildEvaluationExamples(records).length;
+
+  if (evidenceEventCount === 0) {
+    return {
+      status: "no-evidence",
+      reason: "No canonical learning evidence is available for a real-data benchmark.",
+      evidenceEventCount,
+      learnerCount,
+      targetOutcomeCount,
+      trainOutcomeCount: 0,
+      testOutcomeCount: 0,
+      testPositiveCount: 0,
+      testNegativeCount: 0,
+    };
+  }
+
+  if (learnerCount < 2) {
+    return {
+      status: "insufficient-learners",
+      reason: "Learner-level holdout requires evidence from at least two distinct learners.",
+      evidenceEventCount,
+      learnerCount,
+      targetOutcomeCount,
+      trainOutcomeCount: 0,
+      testOutcomeCount: 0,
+      testPositiveCount: 0,
+      testNegativeCount: 0,
+    };
+  }
+
+  if (targetOutcomeCount === 0) {
+    return {
+      status: "no-target-outcomes",
+      reason: "No independent changed-context transfer or delayed retention outcomes are available.",
+      evidenceEventCount,
+      learnerCount,
+      targetOutcomeCount,
+      trainOutcomeCount: 0,
+      testOutcomeCount: 0,
+      testPositiveCount: 0,
+      testNegativeCount: 0,
+    };
+  }
+
+  const report = runLearnerModelBenchmark(
+    {
+      datasetId: "real-data-readiness-preflight",
+      synthetic: false,
+      records,
+    },
+    options,
+  );
+  const baselineMetrics = report.models.find((model) => model.modelId === "ema-history-v1")?.metrics ?? null;
+  const testPositiveCount = baselineMetrics?.positives ?? 0;
+  const testNegativeCount = baselineMetrics?.negatives ?? 0;
+
+  if (report.testOutcomeCount < MIN_HELD_OUT_OUTCOMES) {
+    return {
+      status: "insufficient-held-out-outcomes",
+      reason: `The deterministic held-out split has ${report.testOutcomeCount} target outcomes; at least ${MIN_HELD_OUT_OUTCOMES} are required by the benchmark adoption gate.`,
+      evidenceEventCount,
+      learnerCount,
+      targetOutcomeCount,
+      trainOutcomeCount: report.trainOutcomeCount,
+      testOutcomeCount: report.testOutcomeCount,
+      testPositiveCount,
+      testNegativeCount,
+    };
+  }
+
+  if (testPositiveCount === 0 || testNegativeCount === 0) {
+    return {
+      status: "held-out-label-collapse",
+      reason: "The held-out target outcomes contain only one label, so predictive discrimination cannot be evaluated.",
+      evidenceEventCount,
+      learnerCount,
+      targetOutcomeCount,
+      trainOutcomeCount: report.trainOutcomeCount,
+      testOutcomeCount: report.testOutcomeCount,
+      testPositiveCount,
+      testNegativeCount,
+    };
+  }
+
+  return {
+    status: "ready-for-held-out-benchmark",
+    reason: "The real dataset clears the structural preflight for the existing learner-model benchmark. Candidate models still need to beat the held-out EMA baseline and then pass separate shadow validation.",
+    evidenceEventCount,
+    learnerCount,
+    targetOutcomeCount,
+    trainOutcomeCount: report.trainOutcomeCount,
+    testOutcomeCount: report.testOutcomeCount,
+    testPositiveCount,
+    testNegativeCount,
+  };
+}


### PR DESCRIPTION
## Scope

Adds the privacy-safe bridge between canonical AtoEnglish evidence and the offline learner-model benchmark from PR #99.

### Included
- real-data preflight using the benchmark's deterministic learner-level split
- fail-closed states for empty evidence, insufficient learners/outcomes, and held-out label collapse
- read-only aggregate Supabase readiness SQL
- read-only privacy-safe benchmark export SQL
- within-export learner pseudonyms; raw user ids never leave the query
- stricter independent evidence definition: support=0, hint=0, reveal=false
- changed-context derived inside SQL without exporting context ids
- delayed-retention interval derived from prior successful independent evidence
- documentation of the production readiness snapshot

### Production verification on 2026-09-03
- canonical learning_attempts: 0 rows
- canonical learning_evidence_events: 0 rows
- card_review_logs: 0 rows
- pilot_events: 44 rows from 1 learner, with no scored transfer/retention outcomes
- readiness SQL returns `no-evidence`
- export SQL returns a non-synthetic dataset with `records: []`

### Explicitly not included
- no backfill from pilot telemetry
- no raw transcript/response/prompt/context/metadata export
- no schema or RLS changes
- no production learner-state writes
- no model promotion

Depends on PR #99 (`frontier/learner-model-benchmark-v1`).