### PR TITLE
Experiment: free local pronunciation sensor V1

### DIFF
--- a/docs/experiments/pronunciation-free-sensor-v1.md
+++ b/docs/experiments/pronunciation-free-sensor-v1.md
@@ -1,0 +1,118 @@
+# Free pronunciation sensor V1 — bounded experiment
+
+**Status:** owner-authorized technical experiment  
+**Branch:** `frontier/pronunciation-free-sensor-v1`  
+**Date:** 2026-09-03
+
+## Why this exception exists
+
+`docs/product/DO_NOT_BUILD.md` normally defers phoneme-level pronunciation scoring infrastructure. This experiment is intentionally narrower than a scoring system and exists because the current pronunciation-provider path hit a real blocker: the attempted hosted provider integration was not usable for the owner, while the owner requires a zero-API-cost path.
+
+The repository rule allows a deferred item to be reconsidered when the blocker, evidence, smaller alternatives, reversible scope, acceptance criteria, and rollback are explicit. This document is that exception record.
+
+## Problem
+
+AtoEnglish needs evidence about whether a learner produced a target English phone, but a paid or account-dependent pronunciation API is not acceptable for the current experiment.
+
+Browser speech recognition is insufficient for this question because word recognition confidence is not phoneme-level pronunciation evidence.
+
+## Intended outcome
+
+Prove or falsify one narrow technical hypothesis:
+
+> A free, local browser phoneme recognizer can produce a useful candidate phone sequence for a short prompted word, starting with `think /θɪŋk/`, without uploading learner audio.
+
+This experiment does **not** claim pronunciation accuracy, mastery, CEFR ability, or learning improvement.
+
+## Current evidence
+
+- The product requires bounded speaking output and concise feedback, but repository policy explicitly avoids premature proprietary speech infrastructure.
+- The owner reports that the browser recording → 16 kHz audio path has already worked in the preceding local experiment.
+- The hosted-provider route became a blocker, so a local-only sensor is the smallest free alternative worth testing.
+- `onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX` is an Apache-2.0 ONNX phoneme-recognition model intended for Transformers.js and 16 kHz audio. It is used here only as an unvalidated sensor.
+
+## Allowed scope
+
+- `src/features/pronunciation-free/**`
+- `src/app/pronunciation-free-preview/**`
+- `public/workers/pronunciation-phoneme-worker.mjs`
+- the minimum CSP change in `next.config.mjs` needed for a pinned browser ML runtime and Hugging Face model downloads
+- this experiment document
+
+## Explicitly forbidden scope
+
+- no lesson/curriculum changes
+- no authentication changes
+- no database, migration, RLS, analytics, XP, FSRS, or mastery changes
+- no raw-audio upload or persistence
+- no transcript persistence
+- no learner-facing 0–100 pronunciation score
+- no automatic pass/fail or learning-engine decision
+- no model training or fine-tuning
+- no paid API
+- no new npm dependency in V1
+- no merge or production deployment by an agent
+
+## Implementation boundary
+
+The experiment is local-first:
+
+```text
+microphone
+→ MediaRecorder
+→ browser decode/downmix/resample to mono Float32 16 kHz
+→ dedicated Web Worker
+→ pinned Transformers.js browser runtime
+→ Wav2Vec2 phoneme recognizer
+→ observed phone sequence
+→ deterministic expected/observed alignment
+→ candidate error evidence
+```
+
+The raw recording remains in the browser. The worker downloads model/runtime assets, but learner audio is not sent to AtoEnglish or to the model host.
+
+## Acceptance criteria
+
+1. `/pronunciation-free-preview` loads without requiring an API key or backend pronunciation service.
+2. A learner can record one short prompted word and hear the local recording back.
+3. Audio is converted to mono 16 kHz floating-point samples before inference.
+4. Inference runs in a dedicated browser worker so model work does not intentionally run on the React main thread.
+5. The first model load reports visible progress and later loads can use browser caching provided by the runtime.
+6. The result exposes the raw observed phone sequence and a deterministic alignment against the canonical target IPA.
+7. The UI labels all output as `unvalidated` candidate evidence and never converts edit distance into a pronunciation score.
+8. No application request uploads the recording or derived transcript/evidence during the experiment.
+9. The model path attempts WebGPU first and falls back to WASM when necessary.
+10. The experiment can be removed by deleting this branch/files without a data migration or production-state rollback.
+
+## Required technical checks
+
+```bash
+npx vitest run src/features/pronunciation-free/ipa.test.ts
+npx tsc --noEmit
+npm run lint
+npm run build
+```
+
+Do not claim these checks passed unless they ran against the final branch state.
+
+## Manual product/technical review
+
+Test at least these prompted productions for `think`:
+
+- normal attempt: `think`
+- deliberate `/θ/ → /s/` attempt: approximately `sink`
+- deliberate `/θ/ → /t/` attempt: approximately `tink`
+
+Review questions:
+
+- Does the observed sequence actually change in the expected direction?
+- Does the sensor invent errors on a normal attempt?
+- How long is the first model download and inference on a normal laptop and phone?
+- Does WebGPU work, and does WASM fallback work when WebGPU is unavailable?
+- Does the browser Network panel show model/runtime downloads but no audio upload?
+
+If the sensor cannot reliably separate these gross contrasts, stop this path instead of building scoring, prosody, calibration, or learner feedback around it.
+
+## Rollback
+
+Delete `frontier/pronunciation-free-sensor-v1` or close its pull request. No database or production data rollback is required.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,10 +36,11 @@ const nextConfig = {
   async headers() {
     const isDev = process.env.NODE_ENV === "development";
 
-    // In production: no unsafe-eval. In dev: Next.js HMR needs it.
+    // Dev keeps unsafe-eval for Next.js HMR. Production only permits the
+    // narrower wasm-unsafe-eval needed by the local pronunciation WASM fallback.
     const scriptSrc = isDev
-      ? "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com; "
-      : "script-src 'self' 'unsafe-inline' https://browser.sentry-cdn.com https://va.vercel-scripts.com; ";
+      ? "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com https://cdn.jsdelivr.net; "
+      : "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com https://va.vercel-scripts.com https://cdn.jsdelivr.net; ";
 
     const csp = [
       "default-src 'self'; ",
@@ -48,7 +49,7 @@ const nextConfig = {
       "img-src 'self' blob: data: https://lh3.googleusercontent.com https://*.supabase.co https://i.ytimg.com; ",
       "frame-src https://www.youtube-nocookie.com; ",
       "font-src 'self' data: https://fonts.gstatic.com; ",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.upstash.io https://vitals.vercel-insights.com; ",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.upstash.io https://vitals.vercel-insights.com https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co https://*.hf.co https://*.xethub.hf.co; ",
       "media-src 'self' blob: data:; ",
       "object-src 'none'; ",
       "worker-src 'self' blob:; ",

--- a/public/workers/pronunciation-phoneme-worker.mjs
+++ b/public/workers/pronunciation-phoneme-worker.mjs
@@ -14,20 +14,11 @@ function errorMessage(error) {
 }
 
 function sanitizeProgress(progress) {
-  const value =
-    progress && typeof progress === "object"
-      ? progress
-      : {};
+  const value = progress && typeof progress === "object" ? progress : {};
 
   return {
-    status:
-      typeof value.status === "string"
-        ? value.status
-        : "loading",
-    file:
-      typeof value.file === "string"
-        ? value.file
-        : null,
+    status: typeof value.status === "string" ? value.status : "loading",
+    file: typeof value.file === "string" ? value.file : null,
     progress:
       typeof value.progress === "number" && Number.isFinite(value.progress)
         ? value.progress
@@ -79,9 +70,12 @@ async function createRecognizer() {
     });
   }
 
+  // q8 is the safer/default quantized path for WASM in Transformers.js.
+  // The previous q4 fallback was smaller, but more aggressive quantization is
+  // not worth sacrificing browser compatibility for this falsification test.
   attempts.push({
     device: "wasm",
-    dtype: "q4",
+    dtype: "q8",
   });
 
   let lastError = null;
@@ -106,16 +100,19 @@ async function createRecognizer() {
 
 function getRecognizer() {
   if (!recognizerPromise) {
-    recognizerPromise = createRecognizer();
+    recognizerPromise = createRecognizer().catch((error) => {
+      // A failed first load must not permanently poison the worker. This lets a
+      // later retry succeed after a transient network/cache/runtime failure.
+      recognizerPromise = null;
+      throw error;
+    });
   }
 
   return recognizerPromise;
 }
 
 function extractText(output) {
-  const candidate = Array.isArray(output)
-    ? output[0]
-    : output;
+  const candidate = Array.isArray(output) ? output[0] : output;
 
   if (
     !candidate ||

--- a/public/workers/pronunciation-phoneme-worker.mjs
+++ b/public/workers/pronunciation-phoneme-worker.mjs
@@ -1,0 +1,177 @@
+import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+
+const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
+const MODEL_REVISION = "c69750f";
+
+let recognizerPromise = null;
+
+function errorMessage(error) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "phoneme_model_error";
+}
+
+function sanitizeProgress(progress) {
+  const value =
+    progress && typeof progress === "object"
+      ? progress
+      : {};
+
+  return {
+    status:
+      typeof value.status === "string"
+        ? value.status
+        : "loading",
+    file:
+      typeof value.file === "string"
+        ? value.file
+        : null,
+    progress:
+      typeof value.progress === "number" && Number.isFinite(value.progress)
+        ? value.progress
+        : null,
+  };
+}
+
+async function loadWithRuntime(runtime) {
+  self.postMessage({
+    type: "runtime",
+    state: "loading",
+    runtime,
+    message: null,
+  });
+
+  const recognizer = await pipeline(
+    "automatic-speech-recognition",
+    MODEL_ID,
+    {
+      revision: MODEL_REVISION,
+      device: runtime.device,
+      dtype: runtime.dtype,
+      progress_callback: (progress) => {
+        self.postMessage({
+          type: "progress",
+          progress: sanitizeProgress(progress),
+        });
+      },
+    },
+  );
+
+  self.postMessage({
+    type: "runtime",
+    state: "ready",
+    runtime,
+    message: null,
+  });
+
+  return { recognizer, runtime };
+}
+
+async function createRecognizer() {
+  const attempts = [];
+
+  if ("gpu" in navigator) {
+    attempts.push({
+      device: "webgpu",
+      dtype: "q4f16",
+    });
+  }
+
+  attempts.push({
+    device: "wasm",
+    dtype: "q4",
+  });
+
+  let lastError = null;
+
+  for (const runtime of attempts) {
+    try {
+      return await loadWithRuntime(runtime);
+    } catch (error) {
+      lastError = error;
+
+      self.postMessage({
+        type: "runtime",
+        state: "fallback",
+        runtime,
+        message: errorMessage(error),
+      });
+    }
+  }
+
+  throw lastError ?? new Error("phoneme_model_unavailable");
+}
+
+function getRecognizer() {
+  if (!recognizerPromise) {
+    recognizerPromise = createRecognizer();
+  }
+
+  return recognizerPromise;
+}
+
+function extractText(output) {
+  const candidate = Array.isArray(output)
+    ? output[0]
+    : output;
+
+  if (
+    !candidate ||
+    typeof candidate !== "object" ||
+    typeof candidate.text !== "string"
+  ) {
+    throw new Error("invalid_phoneme_model_output");
+  }
+
+  return candidate.text.trim();
+}
+
+self.addEventListener("message", async (event) => {
+  const message = event.data;
+
+  if (
+    !message ||
+    typeof message !== "object" ||
+    message.type !== "recognize"
+  ) {
+    return;
+  }
+
+  const { id, sampleRate, samples } = message;
+
+  if (
+    typeof id !== "number" ||
+    sampleRate !== 16_000 ||
+    !(samples instanceof Float32Array) ||
+    samples.length === 0
+  ) {
+    if (typeof id === "number") {
+      self.postMessage({
+        type: "error",
+        id,
+        message: "invalid_phoneme_audio",
+      });
+    }
+    return;
+  }
+
+  try {
+    const { recognizer, runtime } = await getRecognizer();
+    const output = await recognizer(samples);
+
+    self.postMessage({
+      type: "result",
+      id,
+      text: extractText(output),
+      runtime,
+    });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      id,
+      message: errorMessage(error),
+    });
+  }
+});

--- a/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
+++ b/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
@@ -28,13 +28,7 @@ import type {
 const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
 const MODEL_REVISION = "c69750f";
 
-type Phase =
-  | "idle"
-  | "recording"
-  | "ready"
-  | "analyzing"
-  | "result"
-  | "error";
+type Phase = "idle" | "recording" | "ready" | "analyzing" | "result" | "error";
 
 type PreviewTarget = {
   word: string;
@@ -89,11 +83,8 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   const [message, setMessage] = useState<string | null>(null);
   const [recording, setRecording] = useState<LocalRecordingResult | null>(null);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
-  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(
-    null,
-  );
-  const [workerProgress, setWorkerProgress] =
-    useState<PhonemeWorkerProgress | null>(null);
+  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(null);
+  const [workerProgress, setWorkerProgress] = useState<PhonemeWorkerProgress | null>(null);
   const [runtime, setRuntime] = useState<LocalPhonemeRuntime | null>(null);
   const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
 
@@ -103,55 +94,11 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   const audioUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
-      if (event.type === "progress") {
-        setWorkerProgress(event.progress);
-        return;
-      }
-
-      setRuntime(event.runtime);
-
-      if (event.state === "fallback") {
-        setRuntimeMessage(
-          event.runtime.device === "webgpu"
-            ? "WebGPU không dùng được; đang thử WASM trên CPU."
-            : "WASM cũng không khởi tạo được.",
-        );
-        return;
-      }
-
-      if (event.state === "ready") {
-        setRuntimeMessage(
-          event.runtime.device === "webgpu"
-            ? "Model đang chạy cục bộ bằng WebGPU."
-            : "Model đang chạy cục bộ bằng WASM trên CPU.",
-        );
-      }
-    };
-
-    try {
-      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
-    } catch {
-      setPhase("error");
-      setMessage("Không khởi tạo được Web Worker cho pronunciation sensor.");
-    }
-
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-
+      if (timerRef.current) clearTimeout(timerRef.current);
       sessionRef.current?.cancel();
-      sessionRef.current = null;
-
       recognizerRef.current?.terminate();
-      recognizerRef.current = null;
-
-      if (audioUrlRef.current) {
-        URL.revokeObjectURL(audioUrlRef.current);
-        audioUrlRef.current = null;
-      }
+      if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
     };
   }, []);
 
@@ -167,6 +114,40 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
       URL.revokeObjectURL(audioUrlRef.current);
       audioUrlRef.current = null;
     }
+  };
+
+  const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
+    if (event.type === "progress") {
+      setWorkerProgress(event.progress);
+      return;
+    }
+
+    setRuntime(event.runtime);
+
+    if (event.state === "fallback") {
+      setRuntimeMessage(
+        event.runtime.device === "webgpu"
+          ? "WebGPU không dùng được; đang thử WASM trên CPU."
+          : "WASM cũng không khởi tạo được.",
+      );
+      return;
+    }
+
+    if (event.state === "ready") {
+      setRuntimeMessage(
+        event.runtime.device === "webgpu"
+          ? "Model đang chạy cục bộ bằng WebGPU."
+          : "Model đang chạy cục bộ bằng WASM trên CPU.",
+      );
+    }
+  };
+
+  const getRecognizer = () => {
+    if (!recognizerRef.current) {
+      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
+    }
+
+    return recognizerRef.current;
   };
 
   const stopRecording = async () => {
@@ -227,12 +208,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   };
 
   const analyze = async () => {
-    const currentRecording = recording;
-    const recognizer = recognizerRef.current;
-
-    if (!currentRecording || !recognizer || phase === "analyzing") {
-      return;
-    }
+    if (!recording || phase === "analyzing") return;
 
     setPhase("analyzing");
     setMessage(
@@ -242,7 +218,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
     setWorkerProgress(null);
 
     try {
-      const result = await recognizer.recognize(currentRecording.samples);
+      const result = await getRecognizer().recognize(recording.samples);
       const expectedPhones = tokenizeExpectedIpa(target.ipa);
       const observedPhones = parseObservedPhonemes(result.text);
 
@@ -297,7 +273,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
         <header className="flex items-start justify-between gap-5">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -317,13 +293,9 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
             </p>
             <div className="mt-3 flex flex-wrap items-end gap-x-4 gap-y-2">
               <p className="text-5xl font-semibold tracking-tight">{target.word}</p>
-              <p className="pb-1 font-mono text-xl text-muted-foreground">
-                {target.ipa}
-              </p>
+              <p className="pb-1 font-mono text-xl text-muted-foreground">{target.ipa}</p>
             </div>
-            <p className="mt-4 text-sm leading-6 text-muted-foreground">
-              {target.howTo}
-            </p>
+            <p className="mt-4 text-sm leading-6 text-muted-foreground">{target.howTo}</p>
             {target.vietnameseTip ? (
               <p className="mt-2 text-sm leading-6">{target.vietnameseTip}</p>
             ) : null}
@@ -336,8 +308,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase === "recording" || phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <Mic className="size-4" />
-              Ghi một lượt
+              <Mic className="size-4" /> Ghi một lượt
             </button>
 
             <button
@@ -346,16 +317,13 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase !== "recording"}
               className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <Square className="size-4" />
-              Dừng
+              <Square className="size-4" /> Dừng
             </button>
 
             <button
               type="button"
               onClick={() => void analyze()}
-              disabled={
-                !recording || phase === "recording" || phase === "analyzing"
-              }
+              disabled={!recording || phase === "recording" || phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
               <Cpu className="size-4" />
@@ -368,19 +336,11 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <RotateCcw className="size-4" />
-              Reset
+              <RotateCcw className="size-4" /> Reset
             </button>
           </div>
 
-          {audioUrl ? (
-            <audio
-              className="mt-6 w-full"
-              controls
-              preload="metadata"
-              src={audioUrl}
-            />
-          ) : null}
+          {audioUrl ? <audio className="mt-6 w-full" controls preload="metadata" src={audioUrl} /> : null}
 
           {message ? (
             <div className="mt-5 rounded-2xl border bg-muted/40 p-4 text-sm leading-6">
@@ -392,9 +352,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
             <div className="mt-5 rounded-2xl border p-4">
               <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
                 <span>{workerProgress.status}</span>
-                {progressPercent !== null ? (
-                  <span>{progressPercent.toFixed(0)}%</span>
-                ) : null}
+                {progressPercent !== null ? <span>{progressPercent.toFixed(0)}%</span> : null}
               </div>
               {progressPercent !== null ? (
                 <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
@@ -405,25 +363,19 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                 </div>
               ) : null}
               {workerProgress.file ? (
-                <p className="mt-2 break-all text-xs text-muted-foreground">
-                  {workerProgress.file}
-                </p>
+                <p className="mt-2 break-all text-xs text-muted-foreground">{workerProgress.file}</p>
               ) : null}
             </div>
           ) : null}
 
           {runtimeMessage ? (
-            <p className="mt-4 text-xs leading-5 text-muted-foreground">
-              {runtimeMessage}
-            </p>
+            <p className="mt-4 text-xs leading-5 text-muted-foreground">{runtimeMessage}</p>
           ) : null}
 
           {observation ? (
             <div className="mt-7 space-y-5 rounded-2xl border p-5">
               <div>
-                <p className="text-sm font-semibold">
-                  Candidate phoneme evidence · chưa hiệu chuẩn
-                </p>
+                <p className="text-sm font-semibold">Candidate phoneme evidence · chưa hiệu chuẩn</p>
                 <p className="mt-1 text-sm leading-6 text-muted-foreground">
                   Đây là điều model nghe được, không phải kết luận bạn phát âm đúng hay sai.
                 </p>
@@ -434,17 +386,13 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                     Expected
                   </p>
-                  <p className="mt-2 font-mono text-xl">
-                    {observation.expectedPhones.join(" ")}
-                  </p>
+                  <p className="mt-2 font-mono text-xl">{observation.expectedPhones.join(" ")}</p>
                 </div>
                 <div className="rounded-xl bg-muted/40 p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                     Model observed
                   </p>
-                  <p className="mt-2 font-mono text-xl">
-                    {observation.observedPhones.join(" ")}
-                  </p>
+                  <p className="mt-2 font-mono text-xl">{observation.observedPhones.join(" ")}</p>
                 </div>
               </div>
 
@@ -456,26 +404,18 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                   >
                     <span className="font-mono">{item.expected ?? "—"}</span>
                     <span className="font-mono">{item.observed ?? "—"}</span>
-                    <span
-                      className={
-                        item.kind === "match"
-                          ? "text-muted-foreground"
-                          : "font-medium"
-                      }
-                    >
+                    <span className={item.kind === "match" ? "text-muted-foreground" : "font-medium"}>
                       {alignmentLabel(item)}
                     </span>
                   </div>
                 ))}
               </div>
 
-              <div className="text-xs leading-5 text-muted-foreground">
+              <p className="text-xs leading-5 text-muted-foreground">
                 Model: {observation.model.id} · revision {observation.model.revision}
-                {runtime
-                  ? ` · ${runtime.device}/${runtime.dtype}`
-                  : ""}
+                {runtime ? ` · ${runtime.device}/${runtime.dtype}` : ""}
                 {` · calibration: ${observation.calibration}`}
-              </div>
+              </p>
             </div>
           ) : null}
         </section>

--- a/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
+++ b/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { Cpu, Mic, RotateCcw, ShieldCheck, Square } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  LOCAL_PRONUNCIATION_MAX_SECONDS,
+  startLocalPronunciationRecording,
+  type LocalRecordingResult,
+  type LocalRecordingSession,
+} from "@/features/pronunciation-free/audio";
+import {
+  alignPhoneSequences,
+  parseObservedPhonemes,
+  tokenizeExpectedIpa,
+} from "@/features/pronunciation-free/ipa";
+import {
+  BrowserPhonemeRecognizer,
+  type PhonemeWorkerEvent,
+} from "@/features/pronunciation-free/phoneme-worker-client";
+import type {
+  LocalPhonemeObservation,
+  LocalPhonemeRuntime,
+  PhonemeWorkerProgress,
+  PhoneAlignment,
+} from "@/features/pronunciation-free/types";
+
+const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
+const MODEL_REVISION = "c69750f";
+
+type Phase =
+  | "idle"
+  | "recording"
+  | "ready"
+  | "analyzing"
+  | "result"
+  | "error";
+
+type PreviewTarget = {
+  word: string;
+  ipa: string;
+  howTo: string;
+  vietnameseTip: string | null;
+};
+
+function alignmentLabel(alignment: PhoneAlignment) {
+  switch (alignment.kind) {
+    case "match":
+      return "khớp";
+    case "substitution":
+      return "model nghi thay âm";
+    case "deletion":
+      return "model nghi thiếu âm";
+    case "insertion":
+      return "model nghi thêm âm";
+  }
+}
+
+function recordingErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+
+  if (message === "microphone_recording_unavailable") {
+    return "Trình duyệt này chưa hỗ trợ cách ghi âm cần cho thử nghiệm.";
+  }
+
+  if (message === "recording_too_short") {
+    return "Đoạn ghi âm quá ngắn. Nói từ mục tiêu rõ một lần rồi dừng.";
+  }
+
+  if (message === "recording_too_long") {
+    return "Đoạn ghi âm dài hơn giới hạn của thử nghiệm.";
+  }
+
+  return "Không hoàn tất được đoạn ghi âm. Kiểm tra quyền microphone rồi thử lại.";
+}
+
+function inferenceErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+
+  if (message.includes("Failed to fetch") || message.includes("fetch")) {
+    return "Không tải được model cục bộ. Kiểm tra mạng hoặc Content Security Policy rồi thử lại.";
+  }
+
+  return "Model phoneme chưa chạy được trên trình duyệt này. Không có điểm phát âm nào được tạo.";
+}
+
+export function PronunciationFreePreview({ target }: { target: PreviewTarget }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [recording, setRecording] = useState<LocalRecordingResult | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(
+    null,
+  );
+  const [workerProgress, setWorkerProgress] =
+    useState<PhonemeWorkerProgress | null>(null);
+  const [runtime, setRuntime] = useState<LocalPhonemeRuntime | null>(null);
+  const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
+
+  const sessionRef = useRef<LocalRecordingSession | null>(null);
+  const recognizerRef = useRef<BrowserPhonemeRecognizer | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
+      if (event.type === "progress") {
+        setWorkerProgress(event.progress);
+        return;
+      }
+
+      setRuntime(event.runtime);
+
+      if (event.state === "fallback") {
+        setRuntimeMessage(
+          event.runtime.device === "webgpu"
+            ? "WebGPU không dùng được; đang thử WASM trên CPU."
+            : "WASM cũng không khởi tạo được.",
+        );
+        return;
+      }
+
+      if (event.state === "ready") {
+        setRuntimeMessage(
+          event.runtime.device === "webgpu"
+            ? "Model đang chạy cục bộ bằng WebGPU."
+            : "Model đang chạy cục bộ bằng WASM trên CPU.",
+        );
+      }
+    };
+
+    try {
+      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
+    } catch {
+      setPhase("error");
+      setMessage("Không khởi tạo được Web Worker cho pronunciation sensor.");
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+
+      sessionRef.current?.cancel();
+      sessionRef.current = null;
+
+      recognizerRef.current?.terminate();
+      recognizerRef.current = null;
+
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+        audioUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const revokeAudioUrl = () => {
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+  };
+
+  const stopRecording = async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+
+    clearTimer();
+
+    try {
+      const result = await session.stop();
+      sessionRef.current = null;
+
+      revokeAudioUrl();
+      const nextAudioUrl = URL.createObjectURL(result.recording);
+      audioUrlRef.current = nextAudioUrl;
+
+      setRecording(result);
+      setAudioUrl(nextAudioUrl);
+      setObservation(null);
+      setPhase("ready");
+      setMessage(
+        `Đã chuẩn hóa ${result.durationSeconds.toFixed(2)} giây audio thành mono 16 kHz ngay trong trình duyệt.`,
+      );
+    } catch (error) {
+      sessionRef.current = null;
+      setRecording(null);
+      setObservation(null);
+      setPhase("error");
+      setMessage(recordingErrorMessage(error));
+    }
+  };
+
+  const startRecording = async () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+
+    revokeAudioUrl();
+    setAudioUrl(null);
+    setRecording(null);
+    setObservation(null);
+    setWorkerProgress(null);
+    setMessage(null);
+
+    try {
+      const session = await startLocalPronunciationRecording();
+      sessionRef.current = session;
+      setPhase("recording");
+      setMessage(`Nói “${target.word}” một lần tự nhiên, rồi bấm Dừng.`);
+
+      timerRef.current = setTimeout(() => {
+        void stopRecording();
+      }, LOCAL_PRONUNCIATION_MAX_SECONDS * 1_000);
+    } catch (error) {
+      setPhase("error");
+      setMessage(recordingErrorMessage(error));
+    }
+  };
+
+  const analyze = async () => {
+    const currentRecording = recording;
+    const recognizer = recognizerRef.current;
+
+    if (!currentRecording || !recognizer || phase === "analyzing") {
+      return;
+    }
+
+    setPhase("analyzing");
+    setMessage(
+      "Đang chạy phoneme model trên thiết bị. Lần đầu cần tải model lớn nên có thể chờ khá lâu.",
+    );
+    setObservation(null);
+    setWorkerProgress(null);
+
+    try {
+      const result = await recognizer.recognize(currentRecording.samples);
+      const expectedPhones = tokenizeExpectedIpa(target.ipa);
+      const observedPhones = parseObservedPhonemes(result.text);
+
+      if (observedPhones.length === 0) {
+        throw new Error("empty_phoneme_observation");
+      }
+
+      const nextObservation: LocalPhonemeObservation = {
+        calibration: "unvalidated",
+        model: {
+          id: MODEL_ID,
+          revision: MODEL_REVISION,
+          runtime: result.runtime,
+        },
+        target: {
+          word: target.word,
+          ipa: target.ipa,
+        },
+        expectedPhones,
+        observedPhones,
+        alignment: alignPhoneSequences(expectedPhones, observedPhones),
+      };
+
+      setRuntime(result.runtime);
+      setObservation(nextObservation);
+      setPhase("result");
+      setMessage(null);
+    } catch (error) {
+      setPhase("error");
+      setMessage(inferenceErrorMessage(error));
+    }
+  };
+
+  const reset = () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+
+    revokeAudioUrl();
+    setAudioUrl(null);
+    setRecording(null);
+    setObservation(null);
+    setWorkerProgress(null);
+    setMessage(null);
+    setPhase("idle");
+  };
+
+  const progressPercent =
+    workerProgress?.progress === null || workerProgress?.progress === undefined
+      ? null
+      : Math.min(100, Math.max(0, workerProgress.progress));
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-8 sm:px-6 sm:py-12">
+        <header className="flex items-start justify-between gap-5">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Pronunciation · free sensor V1
+            </p>
+            <h1 className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight sm:text-5xl">
+              Nghe phoneme cục bộ trước, chưa chấm điểm phát âm.
+            </h1>
+          </div>
+          <ShieldCheck className="mt-1 hidden size-8 shrink-0 text-muted-foreground sm:block" />
+        </header>
+
+        <section className="mt-10 rounded-3xl border bg-card p-5 shadow-sm sm:p-8">
+          <div className="rounded-2xl border bg-muted/40 p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Từ thử nghiệm
+            </p>
+            <div className="mt-3 flex flex-wrap items-end gap-x-4 gap-y-2">
+              <p className="text-5xl font-semibold tracking-tight">{target.word}</p>
+              <p className="pb-1 font-mono text-xl text-muted-foreground">
+                {target.ipa}
+              </p>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-muted-foreground">
+              {target.howTo}
+            </p>
+            {target.vietnameseTip ? (
+              <p className="mt-2 text-sm leading-6">{target.vietnameseTip}</p>
+            ) : null}
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={startRecording}
+              disabled={phase === "recording" || phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Mic className="size-4" />
+              Ghi một lượt
+            </button>
+
+            <button
+              type="button"
+              onClick={() => void stopRecording()}
+              disabled={phase !== "recording"}
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Square className="size-4" />
+              Dừng
+            </button>
+
+            <button
+              type="button"
+              onClick={() => void analyze()}
+              disabled={
+                !recording || phase === "recording" || phase === "analyzing"
+              }
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Cpu className="size-4" />
+              {phase === "analyzing" ? "Đang phân tích…" : "Phân tích cục bộ"}
+            </button>
+
+            <button
+              type="button"
+              onClick={reset}
+              disabled={phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCcw className="size-4" />
+              Reset
+            </button>
+          </div>
+
+          {audioUrl ? (
+            <audio
+              className="mt-6 w-full"
+              controls
+              preload="metadata"
+              src={audioUrl}
+            />
+          ) : null}
+
+          {message ? (
+            <div className="mt-5 rounded-2xl border bg-muted/40 p-4 text-sm leading-6">
+              {message}
+            </div>
+          ) : null}
+
+          {phase === "analyzing" && workerProgress ? (
+            <div className="mt-5 rounded-2xl border p-4">
+              <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+                <span>{workerProgress.status}</span>
+                {progressPercent !== null ? (
+                  <span>{progressPercent.toFixed(0)}%</span>
+                ) : null}
+              </div>
+              {progressPercent !== null ? (
+                <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-foreground transition-[width]"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+              ) : null}
+              {workerProgress.file ? (
+                <p className="mt-2 break-all text-xs text-muted-foreground">
+                  {workerProgress.file}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {runtimeMessage ? (
+            <p className="mt-4 text-xs leading-5 text-muted-foreground">
+              {runtimeMessage}
+            </p>
+          ) : null}
+
+          {observation ? (
+            <div className="mt-7 space-y-5 rounded-2xl border p-5">
+              <div>
+                <p className="text-sm font-semibold">
+                  Candidate phoneme evidence · chưa hiệu chuẩn
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  Đây là điều model nghe được, không phải kết luận bạn phát âm đúng hay sai.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl bg-muted/40 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Expected
+                  </p>
+                  <p className="mt-2 font-mono text-xl">
+                    {observation.expectedPhones.join(" ")}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-muted/40 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Model observed
+                  </p>
+                  <p className="mt-2 font-mono text-xl">
+                    {observation.observedPhones.join(" ")}
+                  </p>
+                </div>
+              </div>
+
+              <div className="overflow-hidden rounded-xl border">
+                {observation.alignment.map((item, index) => (
+                  <div
+                    key={`${item.kind}-${index}-${item.expected ?? "none"}-${item.observed ?? "none"}`}
+                    className="grid grid-cols-[1fr_1fr_2fr] gap-3 border-b px-4 py-3 text-sm last:border-b-0"
+                  >
+                    <span className="font-mono">{item.expected ?? "—"}</span>
+                    <span className="font-mono">{item.observed ?? "—"}</span>
+                    <span
+                      className={
+                        item.kind === "match"
+                          ? "text-muted-foreground"
+                          : "font-medium"
+                      }
+                    >
+                      {alignmentLabel(item)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="text-xs leading-5 text-muted-foreground">
+                Model: {observation.model.id} · revision {observation.model.revision}
+                {runtime
+                  ? ` · ${runtime.device}/${runtime.dtype}`
+                  : ""}
+                {` · calibration: ${observation.calibration}`}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm font-semibold">Bài test cố ý</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Ghi một lượt “think”, rồi thử cố ý nói gần “sink” và “tink”. Sensor chỉ đáng đi tiếp nếu chuỗi phoneme thay đổi theo hướng hợp lý.
+            </p>
+          </div>
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm font-semibold">Privacy / chi phí</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Audio được xử lý trên thiết bị và không upload qua API AtoEnglish. Lần đầu trình duyệt vẫn phải tải runtime và model miễn phí, khoảng vài trăm MB.
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/pronunciation-free-preview/page.tsx
+++ b/src/app/pronunciation-free-preview/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+
+import { ALL_SOUNDS } from "@/lib/data/ipa-sounds";
+
+import { PronunciationFreePreview } from "./PronunciationFreePreview";
+
+export default function PronunciationFreePreviewPage() {
+  const sound = ALL_SOUNDS.find(
+    (candidate) => candidate.id === "th-voiceless",
+  );
+
+  if (!sound) {
+    notFound();
+  }
+
+  return (
+    <PronunciationFreePreview
+      target={{
+        word: sound.exampleWord,
+        ipa: sound.exampleIpa,
+        howTo: sound.howTo,
+        vietnameseTip: sound.vietnameseTip ?? null,
+      }}
+    />
+  );
+}

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -177,6 +177,29 @@ async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
   }
 }
 
+async function openMicrophoneStream() {
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+      video: false,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "OverconstrainedError") {
+      return navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+    }
+
+    throw error;
+  }
+}
+
 export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
   if (
     typeof navigator === "undefined" ||
@@ -186,14 +209,13 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     throw new Error("microphone_recording_unavailable");
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-    },
-    video: false,
-  });
+  const stream = await openMicrophoneStream();
+  const audioTrack = stream.getAudioTracks()[0];
+
+  if (!audioTrack || audioTrack.readyState !== "live") {
+    for (const track of stream.getTracks()) track.stop();
+    throw new Error("microphone_track_unavailable");
+  }
 
   const mimeType = preferredRecorderMimeType();
   const recorder = mimeType
@@ -276,7 +298,7 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     stopTracks();
   };
 
-  recorder.start();
+  recorder.start(250);
 
   return { stop, cancel };
 }

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -3,6 +3,7 @@ const MIN_RECORDING_SECONDS = 0.15;
 const MAX_RECORDING_SECONDS = 8;
 const SILENCE_PEAK_THRESHOLD = 0.001;
 const SILENCE_RMS_THRESHOLD = 0.0001;
+const PROCESSOR_BUFFER_SIZE = 4096;
 
 export type LocalRecordingResult = {
   recording: Blob;
@@ -17,21 +18,6 @@ export type LocalRecordingSession = {
   cancel(): void;
 };
 
-function preferredRecorderMimeType() {
-  if (typeof MediaRecorder === "undefined") return "";
-
-  const candidates = [
-    "audio/webm;codecs=opus",
-    "audio/webm",
-    "audio/ogg;codecs=opus",
-    "audio/mp4",
-  ];
-
-  return (
-    candidates.find((candidate) => MediaRecorder.isTypeSupported(candidate)) ?? ""
-  );
-}
-
 function downmixToMono(audioBuffer: AudioBuffer) {
   const mono = new Float32Array(audioBuffer.length);
 
@@ -44,6 +30,18 @@ function downmixToMono(audioBuffer: AudioBuffer) {
   }
 
   return mono;
+}
+
+function concatenateChunks(chunks: Float32Array[], totalLength: number) {
+  const samples = new Float32Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    samples.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return samples;
 }
 
 async function resampleMono(
@@ -129,62 +127,14 @@ function encodePcm16Wav(samples: Float32Array, sampleRate: number) {
   return new Blob([new Uint8Array(buffer)], { type: "audio/wav" });
 }
 
-async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
-  const AudioContextClass = globalThis.AudioContext;
-
-  if (!AudioContextClass) {
-    throw new Error("audio_context_unavailable");
-  }
-
-  const context = new AudioContextClass();
-
-  try {
-    const encoded = await recording.arrayBuffer();
-    const decoded = await context.decodeAudioData(encoded.slice(0));
-
-    if (!Number.isFinite(decoded.duration) || decoded.duration < MIN_RECORDING_SECONDS) {
-      throw new Error("recording_too_short");
-    }
-
-    if (decoded.duration > MAX_RECORDING_SECONDS + 0.5) {
-      throw new Error("recording_too_long");
-    }
-
-    const mono = downmixToMono(decoded);
-    const samples = await resampleMono(
-      mono,
-      decoded.sampleRate,
-      TARGET_SAMPLE_RATE,
-    );
-    const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
-
-    if (
-      peakAmplitude < SILENCE_PEAK_THRESHOLD &&
-      rmsAmplitude < SILENCE_RMS_THRESHOLD
-    ) {
-      throw new Error("recording_signal_missing");
-    }
-
-    return {
-      recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
-      samples,
-      durationSeconds: samples.length / TARGET_SAMPLE_RATE,
-      peakAmplitude,
-      rmsAmplitude,
-    };
-  } finally {
-    await context.close();
-  }
-}
-
 async function openMicrophoneStream() {
   try {
     return await navigator.mediaDevices.getUserMedia({
       audio: {
-        channelCount: 1,
-        echoCancellation: false,
-        noiseSuppression: false,
-        autoGainControl: false,
+        channelCount: { ideal: 1 },
+        echoCancellation: { ideal: false },
+        noiseSuppression: { ideal: false },
+        autoGainControl: { ideal: false },
       },
       video: false,
     });
@@ -201,10 +151,12 @@ async function openMicrophoneStream() {
 }
 
 export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
+  const AudioContextClass = globalThis.AudioContext;
+
   if (
     typeof navigator === "undefined" ||
     !navigator.mediaDevices?.getUserMedia ||
-    typeof MediaRecorder === "undefined"
+    !AudioContextClass
   ) {
     throw new Error("microphone_recording_unavailable");
   }
@@ -217,71 +169,102 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     throw new Error("microphone_track_unavailable");
   }
 
-  const mimeType = preferredRecorderMimeType();
-  const recorder = mimeType
-    ? new MediaRecorder(stream, { mimeType })
-    : new MediaRecorder(stream);
+  const context = new AudioContextClass();
+  const source = context.createMediaStreamSource(stream);
+  const processor = context.createScriptProcessor(PROCESSOR_BUFFER_SIZE, 1, 1);
+  const mute = context.createGain();
+  mute.gain.value = 0;
 
-  const chunks: Blob[] = [];
+  const chunks: Float32Array[] = [];
+  let totalSamples = 0;
   let finalized = false;
   let stopPromise: Promise<LocalRecordingResult> | null = null;
 
-  const stopTracks = () => {
+  processor.onaudioprocess = (event) => {
+    if (finalized) return;
+
+    const chunk = downmixToMono(event.inputBuffer);
+    chunks.push(chunk);
+    totalSamples += chunk.length;
+  };
+
+  source.connect(processor);
+  processor.connect(mute);
+  mute.connect(context.destination);
+
+  if (context.state === "suspended") {
+    await context.resume();
+  }
+
+  const cleanup = () => {
+    processor.onaudioprocess = null;
+
+    try {
+      source.disconnect();
+      processor.disconnect();
+      mute.disconnect();
+    } catch {
+      // Nodes may already be disconnected during browser teardown.
+    }
+
     for (const track of stream.getTracks()) {
       track.stop();
     }
   };
 
-  recorder.addEventListener("dataavailable", (event) => {
-    if (event.data.size > 0) {
-      chunks.push(event.data);
-    }
-  });
-
   const stop = () => {
     if (stopPromise) return stopPromise;
 
-    if (finalized || recorder.state !== "recording") {
+    if (finalized) {
       return Promise.reject(new Error("recorder_not_recording"));
     }
 
     finalized = true;
 
-    stopPromise = new Promise<LocalRecordingResult>((resolve, reject) => {
-      recorder.addEventListener(
-        "stop",
-        async () => {
-          stopTracks();
+    stopPromise = (async () => {
+      cleanup();
 
-          const recording = new Blob(chunks, {
-            type: recorder.mimeType || chunks[0]?.type || "audio/webm",
-          });
+      try {
+        if (totalSamples === 0) {
+          throw new Error("empty_audio_recording");
+        }
 
-          if (recording.size === 0) {
-            reject(new Error("empty_audio_recording"));
-            return;
-          }
+        const sourceSamples = concatenateChunks(chunks, totalSamples);
+        const sourceDuration = sourceSamples.length / context.sampleRate;
 
-          try {
-            resolve(await decodeRecording(recording));
-          } catch (error) {
-            reject(error);
-          }
-        },
-        { once: true },
-      );
+        if (sourceDuration < MIN_RECORDING_SECONDS) {
+          throw new Error("recording_too_short");
+        }
 
-      recorder.addEventListener(
-        "error",
-        () => {
-          stopTracks();
-          reject(new Error("media_recorder_error"));
-        },
-        { once: true },
-      );
+        if (sourceDuration > MAX_RECORDING_SECONDS + 0.75) {
+          throw new Error("recording_too_long");
+        }
 
-      recorder.stop();
-    });
+        const samples = await resampleMono(
+          sourceSamples,
+          context.sampleRate,
+          TARGET_SAMPLE_RATE,
+        );
+        const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
+
+        if (
+          peakAmplitude < SILENCE_PEAK_THRESHOLD &&
+          rmsAmplitude < SILENCE_RMS_THRESHOLD
+        ) {
+          throw new Error("recording_signal_missing");
+        }
+
+        return {
+          recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
+          samples,
+          durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+          peakAmplitude,
+          rmsAmplitude,
+        };
+      } finally {
+        await context.close();
+      }
+    })();
 
     return stopPromise;
   };
@@ -290,15 +273,9 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     if (finalized) return;
 
     finalized = true;
-
-    if (recorder.state === "recording") {
-      recorder.stop();
-    }
-
-    stopTracks();
+    cleanup();
+    void context.close();
   };
-
-  recorder.start(250);
 
   return { stop, cancel };
 }

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -1,11 +1,15 @@
 const TARGET_SAMPLE_RATE = 16_000;
 const MIN_RECORDING_SECONDS = 0.15;
 const MAX_RECORDING_SECONDS = 8;
+const SILENCE_PEAK_THRESHOLD = 0.001;
+const SILENCE_RMS_THRESHOLD = 0.0001;
 
 export type LocalRecordingResult = {
   recording: Blob;
   samples: Float32Array;
   durationSeconds: number;
+  peakAmplitude: number;
+  rmsAmplitude: number;
 };
 
 export type LocalRecordingSession = {
@@ -72,6 +76,59 @@ async function resampleMono(
   return Float32Array.from(rendered.getChannelData(0));
 }
 
+function measureSignal(samples: Float32Array) {
+  let peakAmplitude = 0;
+  let squareSum = 0;
+
+  for (const sample of samples) {
+    const absolute = Math.abs(sample);
+    if (absolute > peakAmplitude) peakAmplitude = absolute;
+    squareSum += sample * sample;
+  }
+
+  return {
+    peakAmplitude,
+    rmsAmplitude: samples.length > 0 ? Math.sqrt(squareSum / samples.length) : 0,
+  };
+}
+
+function writeAscii(view: DataView, offset: number, value: string) {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+function encodePcm16Wav(samples: Float32Array, sampleRate: number) {
+  const bytesPerSample = 2;
+  const dataSize = samples.length * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (const value of samples) {
+    const sample = Math.max(-1, Math.min(1, value));
+    const pcm = sample < 0 ? Math.round(sample * 0x8000) : Math.round(sample * 0x7fff);
+    view.setInt16(offset, pcm, true);
+    offset += bytesPerSample;
+  }
+
+  return new Blob([new Uint8Array(buffer)], { type: "audio/wav" });
+}
+
 async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
   const AudioContextClass = globalThis.AudioContext;
 
@@ -99,11 +156,21 @@ async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
       decoded.sampleRate,
       TARGET_SAMPLE_RATE,
     );
+    const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
+
+    if (
+      peakAmplitude < SILENCE_PEAK_THRESHOLD &&
+      rmsAmplitude < SILENCE_RMS_THRESHOLD
+    ) {
+      throw new Error("recording_signal_missing");
+    }
 
     return {
-      recording,
+      recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
       samples,
       durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+      peakAmplitude,
+      rmsAmplitude,
     };
   } finally {
     await context.close();

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -1,0 +1,217 @@
+const TARGET_SAMPLE_RATE = 16_000;
+const MIN_RECORDING_SECONDS = 0.15;
+const MAX_RECORDING_SECONDS = 8;
+
+export type LocalRecordingResult = {
+  recording: Blob;
+  samples: Float32Array;
+  durationSeconds: number;
+};
+
+export type LocalRecordingSession = {
+  stop(): Promise<LocalRecordingResult>;
+  cancel(): void;
+};
+
+function preferredRecorderMimeType() {
+  if (typeof MediaRecorder === "undefined") return "";
+
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/ogg;codecs=opus",
+    "audio/mp4",
+  ];
+
+  return (
+    candidates.find((candidate) => MediaRecorder.isTypeSupported(candidate)) ?? ""
+  );
+}
+
+function downmixToMono(audioBuffer: AudioBuffer) {
+  const mono = new Float32Array(audioBuffer.length);
+
+  for (let channel = 0; channel < audioBuffer.numberOfChannels; channel += 1) {
+    const channelSamples = audioBuffer.getChannelData(channel);
+
+    for (let index = 0; index < channelSamples.length; index += 1) {
+      mono[index] += channelSamples[index] / audioBuffer.numberOfChannels;
+    }
+  }
+
+  return mono;
+}
+
+async function resampleMono(
+  samples: Float32Array,
+  sourceSampleRate: number,
+  targetSampleRate: number,
+) {
+  if (sourceSampleRate === targetSampleRate) {
+    return Float32Array.from(samples);
+  }
+
+  if (typeof OfflineAudioContext === "undefined") {
+    throw new Error("offline_audio_context_unavailable");
+  }
+
+  const targetLength = Math.ceil(
+    samples.length * (targetSampleRate / sourceSampleRate),
+  );
+
+  const context = new OfflineAudioContext(1, targetLength, targetSampleRate);
+  const sourceBuffer = context.createBuffer(1, samples.length, sourceSampleRate);
+  sourceBuffer.getChannelData(0).set(samples);
+
+  const source = context.createBufferSource();
+  source.buffer = sourceBuffer;
+  source.connect(context.destination);
+  source.start(0);
+
+  const rendered = await context.startRendering();
+  return Float32Array.from(rendered.getChannelData(0));
+}
+
+async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
+  const AudioContextClass = globalThis.AudioContext;
+
+  if (!AudioContextClass) {
+    throw new Error("audio_context_unavailable");
+  }
+
+  const context = new AudioContextClass();
+
+  try {
+    const encoded = await recording.arrayBuffer();
+    const decoded = await context.decodeAudioData(encoded.slice(0));
+
+    if (!Number.isFinite(decoded.duration) || decoded.duration < MIN_RECORDING_SECONDS) {
+      throw new Error("recording_too_short");
+    }
+
+    if (decoded.duration > MAX_RECORDING_SECONDS + 0.5) {
+      throw new Error("recording_too_long");
+    }
+
+    const mono = downmixToMono(decoded);
+    const samples = await resampleMono(
+      mono,
+      decoded.sampleRate,
+      TARGET_SAMPLE_RATE,
+    );
+
+    return {
+      recording,
+      samples,
+      durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+    };
+  } finally {
+    await context.close();
+  }
+}
+
+export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.mediaDevices?.getUserMedia ||
+    typeof MediaRecorder === "undefined"
+  ) {
+    throw new Error("microphone_recording_unavailable");
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+    video: false,
+  });
+
+  const mimeType = preferredRecorderMimeType();
+  const recorder = mimeType
+    ? new MediaRecorder(stream, { mimeType })
+    : new MediaRecorder(stream);
+
+  const chunks: Blob[] = [];
+  let finalized = false;
+  let stopPromise: Promise<LocalRecordingResult> | null = null;
+
+  const stopTracks = () => {
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+  };
+
+  recorder.addEventListener("dataavailable", (event) => {
+    if (event.data.size > 0) {
+      chunks.push(event.data);
+    }
+  });
+
+  const stop = () => {
+    if (stopPromise) return stopPromise;
+
+    if (finalized || recorder.state !== "recording") {
+      return Promise.reject(new Error("recorder_not_recording"));
+    }
+
+    finalized = true;
+
+    stopPromise = new Promise<LocalRecordingResult>((resolve, reject) => {
+      recorder.addEventListener(
+        "stop",
+        async () => {
+          stopTracks();
+
+          const recording = new Blob(chunks, {
+            type: recorder.mimeType || chunks[0]?.type || "audio/webm",
+          });
+
+          if (recording.size === 0) {
+            reject(new Error("empty_audio_recording"));
+            return;
+          }
+
+          try {
+            resolve(await decodeRecording(recording));
+          } catch (error) {
+            reject(error);
+          }
+        },
+        { once: true },
+      );
+
+      recorder.addEventListener(
+        "error",
+        () => {
+          stopTracks();
+          reject(new Error("media_recorder_error"));
+        },
+        { once: true },
+      );
+
+      recorder.stop();
+    });
+
+    return stopPromise;
+  };
+
+  const cancel = () => {
+    if (finalized) return;
+
+    finalized = true;
+
+    if (recorder.state === "recording") {
+      recorder.stop();
+    }
+
+    stopTracks();
+  };
+
+  recorder.start();
+
+  return { stop, cancel };
+}
+
+export const LOCAL_PRONUNCIATION_MAX_SECONDS = MAX_RECORDING_SECONDS;

--- a/src/features/pronunciation-free/ipa.test.ts
+++ b/src/features/pronunciation-free/ipa.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  alignPhoneSequences,
+  parseObservedPhonemes,
+  tokenizeExpectedIpa,
+} from "./ipa";
+
+describe("pronunciation-free IPA utilities", () => {
+  it("tokenizes the canonical think IPA", () => {
+    expect(tokenizeExpectedIpa("/θɪŋk/")).toEqual(["θ", "ɪ", "ŋ", "k"]);
+  });
+
+  it("keeps long vowels and affricates as one phone", () => {
+    expect(tokenizeExpectedIpa("/tʃiːp/")).toEqual(["tʃ", "iː", "p"]);
+  });
+
+  it("parses the model's whitespace-separated phonetic labels", () => {
+    expect(parseObservedPhonemes("s ɪ ŋ k")).toEqual(["s", "ɪ", "ŋ", "k"]);
+  });
+
+  it("normalizes common tie-bar and glyph variants", () => {
+    expect(parseObservedPhonemes("t͡ʃ ɪ ɡ")).toEqual(["tʃ", "ɪ", "g"]);
+  });
+
+  it("diagnoses a theta-to-s substitution without inventing other errors", () => {
+    expect(
+      alignPhoneSequences(["θ", "ɪ", "ŋ", "k"], ["s", "ɪ", "ŋ", "k"]),
+    ).toEqual([
+      { kind: "substitution", expected: "θ", observed: "s" },
+      { kind: "match", expected: "ɪ", observed: "ɪ" },
+      { kind: "match", expected: "ŋ", observed: "ŋ" },
+      { kind: "match", expected: "k", observed: "k" },
+    ]);
+  });
+
+  it("represents a missing final consonant as a deletion", () => {
+    expect(alignPhoneSequences(["s", "t", "ɒ", "p"], ["s", "t", "ɒ"])).toEqual([
+      { kind: "match", expected: "s", observed: "s" },
+      { kind: "match", expected: "t", observed: "t" },
+      { kind: "match", expected: "ɒ", observed: "ɒ" },
+      { kind: "deletion", expected: "p", observed: null },
+    ]);
+  });
+
+  it("represents an added phone as an insertion", () => {
+    expect(alignPhoneSequences(["s", "t", "ɒ", "p"], ["s", "t", "ɒ", "p", "ə"])).toEqual([
+      { kind: "match", expected: "s", observed: "s" },
+      { kind: "match", expected: "t", observed: "t" },
+      { kind: "match", expected: "ɒ", observed: "ɒ" },
+      { kind: "match", expected: "p", observed: "p" },
+      { kind: "insertion", expected: null, observed: "ə" },
+    ]);
+  });
+});

--- a/src/features/pronunciation-free/ipa.ts
+++ b/src/features/pronunciation-free/ipa.ts
@@ -1,0 +1,172 @@
+import type { PhoneAlignment } from "./types";
+
+const MULTI_CHARACTER_PHONES = [
+  "tʃ",
+  "dʒ",
+  "iː",
+  "ɑː",
+  "ɔː",
+  "uː",
+  "ɜː",
+  "eɪ",
+  "aɪ",
+  "ɔɪ",
+  "aʊ",
+  "əʊ",
+  "oʊ",
+  "ɪə",
+  "eə",
+  "ʊə",
+].sort((left, right) => right.length - left.length);
+
+const IPA_MARKS = new Set(["/", "[", "]", "ˈ", "ˌ", ".", " ", "\t", "\n"]);
+
+function normalizePhoneToken(value: string) {
+  return value
+    .normalize("NFC")
+    .replaceAll("t͡ʃ", "tʃ")
+    .replaceAll("d͡ʒ", "dʒ")
+    .replaceAll("ɡ", "g")
+    .trim();
+}
+
+function comparisonPhone(value: string | null) {
+  if (value === null) return null;
+  return normalizePhoneToken(value);
+}
+
+export function tokenizeExpectedIpa(ipa: string) {
+  const normalized = normalizePhoneToken(ipa);
+  const phones: string[] = [];
+
+  let index = 0;
+
+  while (index < normalized.length) {
+    const current = normalized[index];
+
+    if (IPA_MARKS.has(current)) {
+      index += 1;
+      continue;
+    }
+
+    const multiPhone = MULTI_CHARACTER_PHONES.find((candidate) =>
+      normalized.startsWith(candidate, index),
+    );
+
+    if (multiPhone) {
+      phones.push(multiPhone);
+      index += multiPhone.length;
+      continue;
+    }
+
+    const codePoint = normalized.codePointAt(index);
+    if (codePoint === undefined) break;
+
+    const phone = String.fromCodePoint(codePoint);
+    phones.push(phone);
+    index += phone.length;
+  }
+
+  return phones.filter(Boolean);
+}
+
+export function parseObservedPhonemes(value: string) {
+  const normalized = normalizePhoneToken(value);
+
+  if (!normalized) return [];
+
+  const whitespaceTokens = normalized
+    .split(/\s+/u)
+    .map(normalizePhoneToken)
+    .filter(Boolean);
+
+  if (whitespaceTokens.length > 1) {
+    return whitespaceTokens;
+  }
+
+  return tokenizeExpectedIpa(normalized);
+}
+
+function substitutionCost(expected: string, observed: string) {
+  return comparisonPhone(expected) === comparisonPhone(observed) ? 0 : 1;
+}
+
+export function alignPhoneSequences(
+  expectedPhones: readonly string[],
+  observedPhones: readonly string[],
+): PhoneAlignment[] {
+  const rows = expectedPhones.length + 1;
+  const columns = observedPhones.length + 1;
+  const matrix = Array.from({ length: rows }, () =>
+    Array<number>(columns).fill(0),
+  );
+
+  for (let row = 1; row < rows; row += 1) {
+    matrix[row][0] = row;
+  }
+
+  for (let column = 1; column < columns; column += 1) {
+    matrix[0][column] = column;
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let column = 1; column < columns; column += 1) {
+      const substitution =
+        matrix[row - 1][column - 1] +
+        substitutionCost(expectedPhones[row - 1], observedPhones[column - 1]);
+      const deletion = matrix[row - 1][column] + 1;
+      const insertion = matrix[row][column - 1] + 1;
+
+      matrix[row][column] = Math.min(substitution, deletion, insertion);
+    }
+  }
+
+  const alignment: PhoneAlignment[] = [];
+  let row = expectedPhones.length;
+  let column = observedPhones.length;
+
+  while (row > 0 || column > 0) {
+    if (row > 0 && column > 0) {
+      const expected = expectedPhones[row - 1];
+      const observed = observedPhones[column - 1];
+      const diagonalCost =
+        matrix[row - 1][column - 1] + substitutionCost(expected, observed);
+
+      if (matrix[row][column] === diagonalCost) {
+        alignment.push({
+          kind:
+            comparisonPhone(expected) === comparisonPhone(observed)
+              ? "match"
+              : "substitution",
+          expected,
+          observed,
+        });
+        row -= 1;
+        column -= 1;
+        continue;
+      }
+    }
+
+    if (row > 0 && matrix[row][column] === matrix[row - 1][column] + 1) {
+      alignment.push({
+        kind: "deletion",
+        expected: expectedPhones[row - 1],
+        observed: null,
+      });
+      row -= 1;
+      continue;
+    }
+
+    if (column > 0) {
+      alignment.push({
+        kind: "insertion",
+        expected: null,
+        observed: observedPhones[column - 1],
+      });
+      column -= 1;
+      continue;
+    }
+  }
+
+  return alignment.reverse();
+}

--- a/src/features/pronunciation-free/phoneme-worker-client.ts
+++ b/src/features/pronunciation-free/phoneme-worker-client.ts
@@ -40,7 +40,7 @@ function parseRuntime(value: unknown): LocalPhonemeRuntime | null {
     return { device, dtype };
   }
 
-  if (device === "wasm" && dtype === "q4") {
+  if (device === "wasm" && dtype === "q8") {
     return { device, dtype };
   }
 

--- a/src/features/pronunciation-free/phoneme-worker-client.ts
+++ b/src/features/pronunciation-free/phoneme-worker-client.ts
@@ -1,0 +1,175 @@
+import type {
+  LocalPhonemeRuntime,
+  PhonemeWorkerProgress,
+} from "./types";
+
+export type PhonemeWorkerEvent =
+  | {
+      type: "progress";
+      progress: PhonemeWorkerProgress;
+    }
+  | {
+      type: "runtime";
+      state: "loading" | "ready" | "fallback";
+      runtime: LocalPhonemeRuntime;
+      message: string | null;
+    };
+
+export type PhonemeRecognitionResult = {
+  text: string;
+  runtime: LocalPhonemeRuntime;
+};
+
+type PendingRequest = {
+  resolve(value: PhonemeRecognitionResult): void;
+  reject(error: Error): void;
+};
+
+type WorkerMessage = Record<string, unknown>;
+
+function isWorkerMessage(value: unknown): value is WorkerMessage {
+  return typeof value === "object" && value !== null;
+}
+
+function parseRuntime(value: unknown): LocalPhonemeRuntime | null {
+  if (!isWorkerMessage(value)) return null;
+
+  const { device, dtype } = value;
+
+  if (device === "webgpu" && dtype === "q4f16") {
+    return { device, dtype };
+  }
+
+  if (device === "wasm" && dtype === "q4") {
+    return { device, dtype };
+  }
+
+  return null;
+}
+
+function parseProgress(value: unknown): PhonemeWorkerProgress | null {
+  if (!isWorkerMessage(value) || typeof value.status !== "string") {
+    return null;
+  }
+
+  return {
+    status: value.status,
+    file: typeof value.file === "string" ? value.file : null,
+    progress:
+      typeof value.progress === "number" && Number.isFinite(value.progress)
+        ? value.progress
+        : null,
+  };
+}
+
+export class BrowserPhonemeRecognizer {
+  private readonly worker: Worker;
+  private readonly pending = new Map<number, PendingRequest>();
+  private requestId = 0;
+
+  constructor(onEvent?: (event: PhonemeWorkerEvent) => void) {
+    this.worker = new Worker("/workers/pronunciation-phoneme-worker.mjs", {
+      type: "module",
+      name: "atoenglish-pronunciation-phoneme",
+    });
+
+    this.worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+      const message = event.data;
+      if (!isWorkerMessage(message) || typeof message.type !== "string") return;
+
+      if (message.type === "progress") {
+        const progress = parseProgress(message.progress);
+        if (progress) onEvent?.({ type: "progress", progress });
+        return;
+      }
+
+      if (message.type === "runtime") {
+        const runtime = parseRuntime(message.runtime);
+        const state = message.state;
+
+        if (
+          runtime &&
+          (state === "loading" || state === "ready" || state === "fallback")
+        ) {
+          onEvent?.({
+            type: "runtime",
+            state,
+            runtime,
+            message: typeof message.message === "string" ? message.message : null,
+          });
+        }
+        return;
+      }
+
+      const id = message.id;
+      if (typeof id !== "number") return;
+
+      const request = this.pending.get(id);
+      if (!request) return;
+
+      if (message.type === "result") {
+        const runtime = parseRuntime(message.runtime);
+        const text = message.text;
+
+        if (!runtime || typeof text !== "string") {
+          this.pending.delete(id);
+          request.reject(new Error("invalid_phoneme_worker_result"));
+          return;
+        }
+
+        this.pending.delete(id);
+        request.resolve({ text, runtime });
+        return;
+      }
+
+      if (message.type === "error") {
+        this.pending.delete(id);
+        request.reject(
+          new Error(
+            typeof message.message === "string"
+              ? message.message
+              : "phoneme_worker_error",
+          ),
+        );
+      }
+    });
+
+    this.worker.addEventListener("error", () => {
+      const error = new Error("phoneme_worker_crashed");
+
+      for (const request of this.pending.values()) {
+        request.reject(error);
+      }
+
+      this.pending.clear();
+    });
+  }
+
+  recognize(samples: Float32Array) {
+    if (samples.length === 0) {
+      return Promise.reject(new Error("empty_phoneme_audio"));
+    }
+
+    const id = ++this.requestId;
+
+    return new Promise<PhonemeRecognitionResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage({
+        type: "recognize",
+        id,
+        sampleRate: 16_000,
+        samples,
+      });
+    });
+  }
+
+  terminate() {
+    this.worker.terminate();
+
+    const error = new Error("phoneme_worker_terminated");
+    for (const request of this.pending.values()) {
+      request.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -14,7 +14,7 @@ export type PhoneAlignment = {
 
 export type LocalPhonemeRuntime = {
   device: "webgpu" | "wasm";
-  dtype: "q4f16" | "q4";
+  dtype: "q4f16" | "q8";
 };
 
 export type LocalPhonemeObservation = {

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -1,0 +1,40 @@
+export type PronunciationSensorCalibration = "unvalidated";
+
+export type PhoneAlignmentKind =
+  | "match"
+  | "substitution"
+  | "deletion"
+  | "insertion";
+
+export type PhoneAlignment = {
+  kind: PhoneAlignmentKind;
+  expected: string | null;
+  observed: string | null;
+};
+
+export type LocalPhonemeRuntime = {
+  device: "webgpu" | "wasm";
+  dtype: "q4f16" | "q4";
+};
+
+export type LocalPhonemeObservation = {
+  calibration: PronunciationSensorCalibration;
+  model: {
+    id: string;
+    revision: string;
+    runtime: LocalPhonemeRuntime;
+  };
+  target: {
+    word: string;
+    ipa: string;
+  };
+  expectedPhones: string[];
+  observedPhones: string[];
+  alignment: PhoneAlignment[];
+};
+
+export type PhonemeWorkerProgress = {
+  status: string;
+  file: string | null;
+  progress: number | null;
+};


### PR DESCRIPTION
## Problem
The hosted pronunciation-provider path became unusable for the owner, while this experiment must have zero API cost and no model hosting.

## Outcome
Prove or falsify one narrow hypothesis: a browser-local phoneme recognizer can produce useful candidate phone evidence for a short prompted word (`think /θɪŋk/`) without uploading learner audio.

## What changed
- added a bounded exception/task contract in `docs/experiments/pronunciation-free-sensor-v1.md`
- added local microphone capture, downmixing, and resampling to mono Float32 16 kHz
- added a dedicated module Web Worker
- pinned Transformers.js browser runtime to 4.2.0 and the ONNX phoneme model revision to `c69750f`
- attempts WebGPU `q4f16`, then falls back to WASM `q4`
- added deterministic expected/observed IPA tokenization + Levenshtein alignment
- added a technical preview at `/pronunciation-free-preview`
- minimally extended CSP for jsDelivr/Hugging Face model assets and WASM fallback

## Scientific boundary
This PR does **not** implement pronunciation scoring. It exposes model-observed phones as `calibration: "unvalidated"` candidate evidence only. There is no 0–100 score, pass/fail, mastery update, raw-audio upload, transcript persistence, database change, or analytics change.

## Verification on current head
GitHub Verify run #429 passed:
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test` ✅ — 50 test files / 408 tests, including `src/features/pronunciation-free/ipa.test.ts` (7/7)
- `npm run test:content-standard` ✅ — 50 tests
- fresh Supabase migrations ✅
- database lint ✅
- pgTAP database/RLS tests ✅

`npm run build` is still pending because the repository PR Verify workflow does not run the production build.

## Manual falsification test still required
Record three deliberate productions for the target `think`:
1. normal `think`
2. approximately `sink` (`θ → s`)
3. approximately `tink` (`θ → t`)

Continue this path only if observed phones change in the expected direction without frequent false alarms on normal attempts.

Manual browser checks are also required for first model download, WebGPU/WASM runtime behavior, microphone capture, and Network-panel confirmation that audio is not uploaded.

## Rollback
Close this PR/delete the branch. No database or production-state rollback is required.

## Explicitly out of scope
Curriculum, auth, database/RLS, analytics, XP/FSRS/mastery, model training, prosody/scoring, paid APIs, deployment, and merge.