### PR TITLE
Research: pronunciation evidence engine R&D V1

### DIFF
--- a/docs/experiments/pronunciation-free-sensor-v1.md
+++ b/docs/experiments/pronunciation-free-sensor-v1.md
@@ -1,0 +1,118 @@
+# Free pronunciation sensor V1 — bounded experiment
+
+**Status:** owner-authorized technical experiment  
+**Branch:** `frontier/pronunciation-free-sensor-v1`  
+**Date:** 2026-09-03
+
+## Why this exception exists
+
+`docs/product/DO_NOT_BUILD.md` normally defers phoneme-level pronunciation scoring infrastructure. This experiment is intentionally narrower than a scoring system and exists because the current pronunciation-provider path hit a real blocker: the attempted hosted provider integration was not usable for the owner, while the owner requires a zero-API-cost path.
+
+The repository rule allows a deferred item to be reconsidered when the blocker, evidence, smaller alternatives, reversible scope, acceptance criteria, and rollback are explicit. This document is that exception record.
+
+## Problem
+
+AtoEnglish needs evidence about whether a learner produced a target English phone, but a paid or account-dependent pronunciation API is not acceptable for the current experiment.
+
+Browser speech recognition is insufficient for this question because word recognition confidence is not phoneme-level pronunciation evidence.
+
+## Intended outcome
+
+Prove or falsify one narrow technical hypothesis:
+
+> A free, local browser phoneme recognizer can produce a useful candidate phone sequence for a short prompted word, starting with `think /θɪŋk/`, without uploading learner audio.
+
+This experiment does **not** claim pronunciation accuracy, mastery, CEFR ability, or learning improvement.
+
+## Current evidence
+
+- The product requires bounded speaking output and concise feedback, but repository policy explicitly avoids premature proprietary speech infrastructure.
+- The owner reports that the browser recording → 16 kHz audio path has already worked in the preceding local experiment.
+- The hosted-provider route became a blocker, so a local-only sensor is the smallest free alternative worth testing.
+- `onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX` is an Apache-2.0 ONNX phoneme-recognition model intended for Transformers.js and 16 kHz audio. It is used here only as an unvalidated sensor.
+
+## Allowed scope
+
+- `src/features/pronunciation-free/**`
+- `src/app/pronunciation-free-preview/**`
+- `public/workers/pronunciation-phoneme-worker.mjs`
+- the minimum CSP change in `next.config.mjs` needed for a pinned browser ML runtime and Hugging Face model downloads
+- this experiment document
+
+## Explicitly forbidden scope
+
+- no lesson/curriculum changes
+- no authentication changes
+- no database, migration, RLS, analytics, XP, FSRS, or mastery changes
+- no raw-audio upload or persistence
+- no transcript persistence
+- no learner-facing 0–100 pronunciation score
+- no automatic pass/fail or learning-engine decision
+- no model training or fine-tuning
+- no paid API
+- no new npm dependency in V1
+- no merge or production deployment by an agent
+
+## Implementation boundary
+
+The experiment is local-first:
+
+```text
+microphone
+→ MediaRecorder
+→ browser decode/downmix/resample to mono Float32 16 kHz
+→ dedicated Web Worker
+→ pinned Transformers.js browser runtime
+→ Wav2Vec2 phoneme recognizer
+→ observed phone sequence
+→ deterministic expected/observed alignment
+→ candidate error evidence
+```
+
+The raw recording remains in the browser. The worker downloads model/runtime assets, but learner audio is not sent to AtoEnglish or to the model host.
+
+## Acceptance criteria
+
+1. `/pronunciation-free-preview` loads without requiring an API key or backend pronunciation service.
+2. A learner can record one short prompted word and hear the local recording back.
+3. Audio is converted to mono 16 kHz floating-point samples before inference.
+4. Inference runs in a dedicated browser worker so model work does not intentionally run on the React main thread.
+5. The first model load reports visible progress and later loads can use browser caching provided by the runtime.
+6. The result exposes the raw observed phone sequence and a deterministic alignment against the canonical target IPA.
+7. The UI labels all output as `unvalidated` candidate evidence and never converts edit distance into a pronunciation score.
+8. No application request uploads the recording or derived transcript/evidence during the experiment.
+9. The model path attempts WebGPU first and falls back to WASM when necessary.
+10. The experiment can be removed by deleting this branch/files without a data migration or production-state rollback.
+
+## Required technical checks
+
+```bash
+npx vitest run src/features/pronunciation-free/ipa.test.ts
+npx tsc --noEmit
+npm run lint
+npm run build
+```
+
+Do not claim these checks passed unless they ran against the final branch state.
+
+## Manual product/technical review
+
+Test at least these prompted productions for `think`:
+
+- normal attempt: `think`
+- deliberate `/θ/ → /s/` attempt: approximately `sink`
+- deliberate `/θ/ → /t/` attempt: approximately `tink`
+
+Review questions:
+
+- Does the observed sequence actually change in the expected direction?
+- Does the sensor invent errors on a normal attempt?
+- How long is the first model download and inference on a normal laptop and phone?
+- Does WebGPU work, and does WASM fallback work when WebGPU is unavailable?
+- Does the browser Network panel show model/runtime downloads but no audio upload?
+
+If the sensor cannot reliably separate these gross contrasts, stop this path instead of building scoring, prosody, calibration, or learner feedback around it.
+
+## Rollback
+
+Delete `frontier/pronunciation-free-sensor-v1` or close its pull request. No database or production data rollback is required.

--- a/docs/research/pronunciation-engine-frontier-2026.md
+++ b/docs/research/pronunciation-engine-frontier-2026.md
@@ -1,0 +1,385 @@
+# AtoEnglish Pronunciation Engine — frontier research program (2026)
+
+**Branch:** `frontier/pronunciation-engine-rd-v1`  
+**Status:** research + reversible implementation only  
+**Goal:** build and validate an original, free/open pronunciation-assessment stack that can eventually outperform existing learner-facing systems on the metrics that matter to AtoEnglish.
+
+## 1. What “best” means
+
+AtoEnglish must not claim to be the best because it has more outputs or a prettier score. It earns that claim only if it wins on held-out human-rated learner speech.
+
+The target system must optimize all of these, not one scalar:
+
+1. **Phone-level assessment:** correlation with human phone scores and strong correct-vs-mispronounced separation.
+2. **Mispronunciation detection:** low false acceptance and low false rejection, reported together with F1/MCC/AUC.
+3. **Diagnosis:** identify substitution/deletion/insertion and the most plausible produced sound.
+4. **Articulatory diagnosis:** explain *how* a production differs (place, manner, voicing, vowel height/backness/rounding), not just “wrong phone”.
+5. **Word/utterance assessment:** accuracy, completeness, stress, fluency, prosody, and total quality at the appropriate granularity.
+6. **Uncertainty:** abstain when evidence is weak instead of inventing a precise score.
+7. **Multiple valid pronunciations:** never penalize a legitimate target variant simply because one reference string was chosen.
+8. **Speaker robustness:** speaker-disjoint evaluation; inspect age, gender, L1/accent, microphone and noise slices instead of fitting speakers seen in training.
+9. **Learning value:** feedback must improve the next production and delayed production, not merely correlate with a rater.
+10. **Privacy/cost:** prefer local inference and free/open components; raw learner audio is not persisted by default.
+
+A native-accent imitation score is explicitly **not** the objective. Intelligibility and target contrast control matter more than sounding like one prestige accent.
+
+## 2. Frontier findings that change the design
+
+### 2.1 GOP is still useful, but plain softmax GOP is not enough
+
+Kaldi’s SpeechOcean762 recipe formalizes neural GOP from phone posteriors and phone posterior ratios. It remains an important baseline, but modern work shows two weaknesses:
+
+- forced alignment can be wrong on non-native speech;
+- softmax posteriors can be overconfident and poorly separated.
+
+Interspeech 2025 reported that **logit-based GOP** can outperform probability-based GOP for mispronunciation classification, with hybrid probability/logit evidence useful across datasets.
+
+**Design consequence:** preserve raw logits/top-k evidence where a sensor exposes them. Do not reduce a model to top-1 text before scoring.
+
+### 2.2 Context-aware CTC is a stronger direction than ordinary CTC-GOP
+
+BEA 2026 showed that standard CTC is too peaky and context-independent for stable GOP. Context-aware CTC with output-context dependency plus label-prior and entropy regularization improved SpeechOcean762 phone PCC from the classic GOPT baseline region to **0.641** and improved word total PCC as well.
+
+**Design consequence:** our long-term trainable acoustic scorer should be frame/context aware. Browser top-1 phoneme recognition is only one sensor, never the scoring architecture.
+
+### 2.3 MDD should be jointly modeled with assessment
+
+Interspeech 2023 showed joint pronunciation assessment + MDD multi-task learning improves assessment correlation and MDD relative to isolated tasks.
+
+**Design consequence:** score prediction and error diagnosis must share evidence. Do not build an independent “score service” and “mistake service” with incompatible representations.
+
+### 2.4 Prompt-free / acoustically faithful MDD is now a serious frontier
+
+CROTTC-IF (2026) explicitly attacks CTC acoustic sparsity and canonical-prompt bias. The reported L2-ARCTIC F1 is **71.77%**. The core idea is important even when we do not copy the implementation: preserve acoustic deviations first, then inject canonical knowledge after acoustic evidence has been formed.
+
+**Design consequence:** target text must not force the acoustic sensor to “hear what it expects”. Canonical pronunciation belongs in alignment/fusion, not in a way that overwrites acoustic evidence.
+
+### 2.5 Articulatory features improve diagnosis
+
+2024–2026 work on phonological/articulatory-level MDD reports lower false acceptance/rejection/diagnosis error than phone-only approaches in multiple settings. SLaTE 2025 specifically found articulatory-feature integration improves diagnostic quality.
+
+**Design consequence:** every English phone gets an articulatory feature representation. Alignment cost and learner feedback can then express `θ → s` as a structured place/manner contrast rather than an arbitrary character edit.
+
+### 2.6 Prosody needs dedicated evidence
+
+Speech Prosody 2024 and SLaTE 2025 show that F0, loudness/energy and duration/rhythm features add information beyond GOP for prosody and fluency.
+
+**Design consequence:** never derive prosody/fluency from segmental GOP alone. Build a separate suprasegmental evidence stream.
+
+### 2.7 Hierarchical scoring is better aligned with human rubrics
+
+GOPT established multi-aspect, multi-granularity scoring. HierTFR (ACL 2024) and HiPPO (2025) go further by modeling linguistic hierarchy and ordinal/correlation structure rather than predicting every score in parallel.
+
+**Design consequence:** the eventual learned scorer should follow the hierarchy:
+
+```text
+frames -> phones -> syllables/words -> utterance
+```
+
+and preserve relations among accuracy, stress, fluency, prosody, completeness and total score.
+
+### 2.8 Uncertainty and alternate valid pronunciations are mandatory
+
+Prior MDD work shows that treating one recognized phone string and one canonical pronunciation as certain creates false alarms. Uncertainty-aware approaches improve precision.
+
+**Design consequence:** use candidate distributions/N-best evidence where available; support multiple target variants; expose `abstain` when confidence is inadequate.
+
+## 3. Free/open research stack and license boundary
+
+### Commercially usable foundations
+
+| Component | Use | License/status |
+|---|---|---|
+| SpeechOcean762 | human-rated non-native English training/evaluation | CC BY 4.0; commercial use allowed |
+| LibriSpeech | native English acoustic/pretraining/reference speech | CC BY 4.0 |
+| GOPT code | multi-aspect/multi-granularity baseline and evaluation ideas | BSD-3-Clause |
+| Kaldi GOP recipe | GOP definitions/baseline | Kaldi Apache-2.0 project |
+| PanPhon concepts/data | IPA articulatory feature representation and feature edit distance | MIT family license |
+| Apache-licensed Wav2Vec2/XLS-R/ONNX checkpoints | acoustic/phone sensors where model card and training-data terms are compatible | verify each checkpoint individually |
+
+### Research-only / do not copy into production without explicit rights review
+
+| Resource | Why restricted |
+|---|---|
+| L2-ARCTIC | CC BY-NC 4.0; useful for Vietnamese/L1 research and benchmarking, not assumed production-training safe |
+| IF-MDD repository | public research source currently has no repository license file; learn from papers/results, do not copy source into AtoEnglish |
+| HierTFR repository | public code repository currently reports no license; learn from paper architecture, do not copy source |
+
+A model’s own license label does not automatically erase restrictions inherited from its training data. Every production checkpoint needs a model-and-data license review.
+
+## 4. Architecture
+
+```text
+Microphone / WAV
+      |
+      v
+[Signal quality gate]
+ clipping · RMS · silence · duration · SNR proxy
+      |
+      +------------------------------+
+      |                              |
+      v                              v
+[Acoustic phone sensors]       [Prosody DSP]
+ logits/top-k/timestamps        F0 · energy · duration
+ multiple independent views    pauses · rhythm · stress
+      |                              |
+      v                              |
+[Acoustic evidence]                  |
+      |                              |
+      +-------------+----------------+
+                    |
+                    v
+       [Canonical pronunciation lattice]
+       multiple valid pronunciations/stress
+                    |
+                    v
+       [Phonological weighted alignment]
+       posterior-aware dynamic programming
+       match/substitution/deletion/insertion
+                    |
+                    v
+       [Articulatory diagnosis layer]
+       place/manner/voice/vowel geometry
+                    |
+                    v
+             [Evidence fusion]
+       segmental + completeness + prosody
+       uncertainty + sensor agreement
+                    |
+                    v
+        [Human-score calibration layer]
+       monotonic/ordinal; speaker-disjoint
+                    |
+                    v
+          PronunciationAssessment
+                    |
+       +------------+-------------+
+       |                          |
+       v                          v
+ learner feedback            research metrics
+ corrective retry            PCC/F1/MCC/ECE/FAR/FRR
+```
+
+## 5. Core representation
+
+The engine should distinguish these concepts:
+
+```text
+sensor observation != diagnosis != calibrated score != learning decision
+```
+
+A sensor may say:
+
+```json
+{
+  "expected": "θ",
+  "candidates": [
+    { "phone": "s", "probability": 0.62 },
+    { "phone": "θ", "probability": 0.24 },
+    { "phone": "t", "probability": 0.14 }
+  ]
+}
+```
+
+The alignment layer may infer a likely substitution. The articulatory layer describes the contrast. Only a human-calibrated model is allowed to turn this into a learner-facing score.
+
+## 6. Algorithms to implement in AtoEnglish first
+
+### Kernel A — phonological feature distance
+
+Replace binary Levenshtein substitution cost (`same=0`, `different=1`) with a weighted articulatory distance.
+
+For consonants compare at least:
+
+- manner;
+- place;
+- voicing;
+- sonorancy/laterality/nasality where relevant.
+
+For vowels compare at least:
+
+- height;
+- backness;
+- rounding;
+- length/tenseness proxy;
+- diphthong trajectory.
+
+The weights are a **prior**, not truth. They must later be fitted/validated against human labels.
+
+### Kernel B — posterior-aware alignment
+
+Dynamic programming should align a canonical sequence to observed phone candidates. Substitution cost is the expected articulatory/acoustic cost under the candidate distribution, not merely the top-1 phone.
+
+Insertion/deletion stay explicit because final consonant deletion and cluster reduction are important learner errors.
+
+### Kernel C — alternate-reference lattice
+
+Score all legitimate canonical variants and keep the best-supported variant. Never punish a learner for a dictionary-supported variant.
+
+### Kernel D — uncertainty/abstention
+
+Inputs that fail signal quality, have weak posterior margin, severe sensor disagreement, or fall outside calibrated support should return `abstain`/`needs_retry`, not a fake exact score.
+
+### Kernel E — monotonic human calibration
+
+Use a monotonic calibrator (initially isotonic regression/PAVA) to map a raw model signal to human-score scale without assuming a linear relationship. Fit calibration only on speaker-disjoint calibration data.
+
+### Kernel F — rigorous metrics
+
+Implement and track:
+
+- phone/word/utterance Pearson and Spearman correlations;
+- MAE/RMSE;
+- precision/recall/F1;
+- Matthews correlation coefficient;
+- FAR/FRR;
+- diagnosis accuracy/error rate;
+- ROC AUC where probability/ranking evidence exists;
+- Brier score and Expected Calibration Error for confidence quality.
+
+## 7. Model roadmap
+
+### V0 — deterministic evidence kernel (now)
+
+No training. Build the original AtoEnglish representation, phonological distance, posterior-aware alignment, calibration and evaluation utilities. Existing browser phoneme output can feed this kernel if it works, but the kernel must not depend on that one model.
+
+### V1 — multi-sensor browser benchmark
+
+Benchmark at least two independently trained commercial-safe phone recognizers on identical audio. Record model identity, quantization/runtime, latency, candidate sequence, and agreement. Do not fuse models until each is evaluated separately.
+
+### V2 — SpeechOcean762 scoring baseline
+
+Reproduce GOPT/Kaldi or a modern equivalent as a **benchmark**, then train an original small hierarchical scorer on SpeechOcean762 with speaker-disjoint splits. Preserve the official human labels and avoid test-speaker leakage.
+
+### V3 — modern acoustic scorer
+
+Train an original CTC/logit model with ideas validated by 2025–2026 work:
+
+- logit-GOP evidence;
+- context-aware/non-peaky frame representation;
+- joint APA + MDD objectives;
+- articulatory auxiliary target;
+- canonical information injected after acoustically faithful representation.
+
+### V4 — suprasegmental model
+
+Fuse phone evidence with F0/energy/duration/pause/rhythm/stress features. Validate prosody and fluency separately from segmental accuracy.
+
+### V5 — Vietnamese calibration dataset
+
+L2-ARCTIC can be used as non-commercial research reference, especially because it includes Vietnamese speakers, but the production system needs AtoEnglish-owned consented Vietnamese learner data or another commercially compatible corpus.
+
+Start with high-value contrasts and positions:
+
+- `/θ/`, `/ð/` substitutions;
+- final consonant deletion/weakening;
+- consonant-cluster reduction/epenthesis;
+- `/ɪ/` vs `/iː/` and other vowel contrasts;
+- stress placement;
+- later rhythm/intonation.
+
+Do not hard-code these as automatic errors merely because they are common in literature. They are priors for targeted data collection and testing.
+
+## 8. Evaluation protocol
+
+### Split rule
+
+**All primary results are speaker-disjoint.** No utterances from a speaker in training may appear in validation/test.
+
+### Required test slices
+
+- adult vs child where data allows;
+- male/female/other metadata where available and appropriate;
+- L1/accent groups when available;
+- quiet vs noisy/device conditions;
+- phone identity and word position;
+- correct vs mispronounced prevalence;
+- short word vs sentence;
+- seen vs unseen lexical items where possible.
+
+### Threshold rule
+
+Do not choose a global `0.5` threshold by habit. Optimize/report thresholds on validation data (e.g. MCC or cost-weighted FAR/FRR), then freeze them before test evaluation. Consider phone-specific thresholds only when sample sizes support them.
+
+### Calibration rule
+
+A system is not “confident” because a neural network emitted `0.93`. Report calibration error and reliability. Confidence is allowed to control learner-facing feedback only after calibration.
+
+### Human ceiling
+
+Where multiple human ratings exist, report inter-rater agreement/reliability. The model must be compared against the variability of the human target, not an imaginary perfectly deterministic label.
+
+## 9. Product output contract
+
+The eventual production object should look conceptually like this:
+
+```ts
+{
+  calibration: "unvalidated" | "calibrating" | "validated",
+  decision: "evidence" | "feedback" | "abstain",
+  target: {
+    word: "think",
+    selectedPronunciation: ["θ", "ɪ", "ŋ", "k"]
+  },
+  signalQuality: { ... },
+  phones: [
+    {
+      expected: "θ",
+      observedCandidates: [
+        { phone: "s", probability: 0.62 },
+        { phone: "θ", probability: 0.24 }
+      ],
+      diagnosis: "substitution",
+      articulatoryDelta: {
+        place: "dental -> alveolar",
+        manner: "fricative -> fricative",
+        voicing: "unchanged"
+      },
+      confidence: 0.0 // only after calibration
+    }
+  ],
+  aspects: {
+    segmentalAccuracy: null,
+    completeness: null,
+    stress: null,
+    fluency: null,
+    prosody: null,
+    total: null
+  },
+  uncertainty: { ... }
+}
+```
+
+Until calibrated, learner-facing numeric scores remain `null` even if research-only raw signals exist internally.
+
+## 10. Stop conditions
+
+Stop or replace a component when any of the following occurs:
+
+- a phoneme sensor cannot separate deliberately large contrasts such as `θ/s/t` better than chance/reliable baselines;
+- a new model improves aggregate PCC while materially worsening FAR on common learner errors;
+- a model only works because target text leaks into acoustic recognition;
+- a component has incompatible or ambiguous production licensing;
+- a system cannot reproduce its result on a speaker-disjoint split;
+- confidence is badly miscalibrated and no abstention path exists;
+- learner feedback does not improve subsequent productions.
+
+## 11. Primary references
+
+- Zhang et al. 2021, SpeechOcean762: https://www.openslr.org/101/ and DOI `10.21437/Interspeech.2021-1259`
+- Kaldi GOP SpeechOcean762 recipe: https://github.com/kaldi-asr/kaldi/tree/master/egs/gop_speechocean762
+- Gong et al. 2022, GOPT: https://arxiv.org/abs/2205.03432 and https://github.com/YuanGongND/gopt
+- Ryu et al. 2023, joint APA + MDD: DOI `10.21437/Interspeech.2023-337`
+- Yan et al. 2024, HierTFR: https://aclanthology.org/2024.acl-long.95/
+- Shahin & Ahmed 2024, phonological-level MDD: DOI `10.21437/Interspeech.2024-1874`
+- Dong et al. 2024, L2 prosody acoustic + neural features: DOI `10.21437/SpeechProsody.2024-34`
+- Parikh et al. 2025, logit GOP: DOI `10.21437/Interspeech.2025-1012`
+- Parikh et al. 2025, phonological knowledge / restricted substitutions: DOI `10.21437/Interspeech.2025-829`
+- Wei et al. 2025, articulatory-enhanced MDD: DOI `10.21437/SLaTE.2025-7` and `10.21437/SLaTE.2025-16`
+- Dong et al. 2025, suprasegmental features for APA: DOI `10.21437/SLaTE.2025-5`
+- Yan et al. 2025, HiPPO: https://aclanthology.org/2025.ijcnlp-long.45/
+- Tu et al. 2025, training-free retrieval MDD: https://arxiv.org/abs/2511.20107
+- Geng et al. 2026, CROTTC / prompt-free MDD: https://arxiv.org/abs/2604.22133
+- Li et al. 2026, context-aware CTC APA: https://aclanthology.org/2026.bea-1.3/
+- PanPhon articulatory features: https://aclanthology.org/C16-1328/
+- L2-ARCTIC (research-only licensing for our purposes): https://psi.engr.tamu.edu/l2-arctic-corpus/

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,10 +36,11 @@ const nextConfig = {
   async headers() {
     const isDev = process.env.NODE_ENV === "development";
 
-    // In production: no unsafe-eval. In dev: Next.js HMR needs it.
+    // Dev keeps unsafe-eval for Next.js HMR. Production only permits the
+    // narrower wasm-unsafe-eval needed by the local pronunciation WASM fallback.
     const scriptSrc = isDev
-      ? "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com; "
-      : "script-src 'self' 'unsafe-inline' https://browser.sentry-cdn.com https://va.vercel-scripts.com; ";
+      ? "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com https://cdn.jsdelivr.net; "
+      : "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://browser.sentry-cdn.com https://va.vercel-scripts.com https://cdn.jsdelivr.net; ";
 
     const csp = [
       "default-src 'self'; ",
@@ -48,7 +49,7 @@ const nextConfig = {
       "img-src 'self' blob: data: https://lh3.googleusercontent.com https://*.supabase.co https://i.ytimg.com; ",
       "frame-src https://www.youtube-nocookie.com; ",
       "font-src 'self' data: https://fonts.gstatic.com; ",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.upstash.io https://vitals.vercel-insights.com; ",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.upstash.io https://vitals.vercel-insights.com https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co https://*.hf.co https://*.xethub.hf.co; ",
       "media-src 'self' blob: data:; ",
       "object-src 'none'; ",
       "worker-src 'self' blob:; ",

--- a/public/workers/pronunciation-phoneme-worker.mjs
+++ b/public/workers/pronunciation-phoneme-worker.mjs
@@ -1,15 +1,18 @@
-import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+import {
+  AutoModelForCTC,
+  AutoProcessor,
+  AutoTokenizer,
+} from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
 
 const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
 const MODEL_REVISION = "c69750f";
+const TOP_K = 5;
 
 let recognizerPromise = null;
+let assetsPromise = null;
 
 function errorMessage(error) {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
+  if (error instanceof Error && error.message) return error.message;
   return "phoneme_model_error";
 }
 
@@ -26,6 +29,33 @@ function sanitizeProgress(progress) {
   };
 }
 
+function progressCallback(progress) {
+  self.postMessage({
+    type: "progress",
+    progress: sanitizeProgress(progress),
+  });
+}
+
+async function getStaticAssets() {
+  if (!assetsPromise) {
+    assetsPromise = Promise.all([
+      AutoProcessor.from_pretrained(MODEL_ID, {
+        revision: MODEL_REVISION,
+        progress_callback: progressCallback,
+      }),
+      AutoTokenizer.from_pretrained(MODEL_ID, {
+        revision: MODEL_REVISION,
+        progress_callback: progressCallback,
+      }),
+    ]).catch((error) => {
+      assetsPromise = null;
+      throw error;
+    });
+  }
+
+  return assetsPromise;
+}
+
 async function loadWithRuntime(runtime) {
   self.postMessage({
     type: "runtime",
@@ -34,21 +64,13 @@ async function loadWithRuntime(runtime) {
     message: null,
   });
 
-  const recognizer = await pipeline(
-    "automatic-speech-recognition",
-    MODEL_ID,
-    {
-      revision: MODEL_REVISION,
-      device: runtime.device,
-      dtype: runtime.dtype,
-      progress_callback: (progress) => {
-        self.postMessage({
-          type: "progress",
-          progress: sanitizeProgress(progress),
-        });
-      },
-    },
-  );
+  const [processor, tokenizer] = await getStaticAssets();
+  const model = await AutoModelForCTC.from_pretrained(MODEL_ID, {
+    revision: MODEL_REVISION,
+    device: runtime.device,
+    dtype: runtime.dtype,
+    progress_callback: progressCallback,
+  });
 
   self.postMessage({
     type: "runtime",
@@ -57,26 +79,17 @@ async function loadWithRuntime(runtime) {
     message: null,
   });
 
-  return { recognizer, runtime };
+  return { model, processor, tokenizer, runtime };
 }
 
 async function createRecognizer() {
   const attempts = [];
 
   if ("gpu" in navigator) {
-    attempts.push({
-      device: "webgpu",
-      dtype: "q4f16",
-    });
+    attempts.push({ device: "webgpu", dtype: "q4f16" });
   }
 
-  // q8 is the safer/default quantized path for WASM in Transformers.js.
-  // The previous q4 fallback was smaller, but more aggressive quantization is
-  // not worth sacrificing browser compatibility for this falsification test.
-  attempts.push({
-    device: "wasm",
-    dtype: "q8",
-  });
+  attempts.push({ device: "wasm", dtype: "q8" });
 
   let lastError = null;
 
@@ -85,7 +98,6 @@ async function createRecognizer() {
       return await loadWithRuntime(runtime);
     } catch (error) {
       lastError = error;
-
       self.postMessage({
         type: "runtime",
         state: "fallback",
@@ -101,28 +113,255 @@ async function createRecognizer() {
 function getRecognizer() {
   if (!recognizerPromise) {
     recognizerPromise = createRecognizer().catch((error) => {
-      // A failed first load must not permanently poison the worker. This lets a
-      // later retry succeed after a transient network/cache/runtime failure.
       recognizerPromise = null;
       throw error;
     });
   }
-
   return recognizerPromise;
 }
 
-function extractText(output) {
-  const candidate = Array.isArray(output) ? output[0] : output;
+function finiteDimension(value, label) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`invalid_phoneme_logits_${label}`);
+  }
+  return number;
+}
 
-  if (
-    !candidate ||
-    typeof candidate !== "object" ||
-    typeof candidate.text !== "string"
-  ) {
-    throw new Error("invalid_phoneme_model_output");
+function logitsShape(logits) {
+  if (!logits || typeof logits !== "object" || !Array.isArray(logits.dims)) {
+    throw new Error("invalid_phoneme_logits");
   }
 
-  return candidate.text.trim();
+  if (logits.dims.length !== 3) {
+    throw new Error("invalid_phoneme_logits_rank");
+  }
+
+  const batch = finiteDimension(logits.dims[0], "batch");
+  const frames = finiteDimension(logits.dims[1], "frames");
+  const vocabulary = finiteDimension(logits.dims[2], "vocabulary");
+
+  if (batch !== 1) throw new Error("invalid_phoneme_logits_batch");
+
+  const data = logits.data;
+  if (!data || typeof data.length !== "number") {
+    throw new Error("invalid_phoneme_logits_data");
+  }
+  if (data.length !== frames * vocabulary) {
+    throw new Error("invalid_phoneme_logits_size");
+  }
+
+  return { data, frames, vocabulary };
+}
+
+function softmaxPosteriorMatrix(logits) {
+  const { data, frames, vocabulary } = logitsShape(logits);
+  const probabilities = new Float32Array(frames * vocabulary);
+  const topIds = new Int32Array(frames);
+  let entropySum = 0;
+  let peakSum = 0;
+  let top2MarginSum = 0;
+
+  for (let frame = 0; frame < frames; frame += 1) {
+    const offset = frame * vocabulary;
+    let maximum = -Infinity;
+
+    for (let token = 0; token < vocabulary; token += 1) {
+      const value = Number(data[offset + token]);
+      if (!Number.isFinite(value)) throw new Error("phoneme_logits_not_finite");
+      maximum = Math.max(maximum, value);
+    }
+
+    let denominator = 0;
+    for (let token = 0; token < vocabulary; token += 1) {
+      denominator += Math.exp(Number(data[offset + token]) - maximum);
+    }
+    if (!Number.isFinite(denominator) || denominator <= 0) {
+      throw new Error("invalid_phoneme_softmax_denominator");
+    }
+
+    let first = -Infinity;
+    let second = -Infinity;
+    let firstId = 0;
+    let entropy = 0;
+
+    for (let token = 0; token < vocabulary; token += 1) {
+      const probability =
+        Math.exp(Number(data[offset + token]) - maximum) / denominator;
+      probabilities[offset + token] = probability;
+      if (probability > 0) entropy -= probability * Math.log(probability);
+
+      if (probability > first) {
+        second = first;
+        first = probability;
+        firstId = token;
+      } else if (probability > second) {
+        second = probability;
+      }
+    }
+
+    topIds[frame] = firstId;
+    entropySum += entropy;
+    peakSum += first;
+    top2MarginSum += first - (Number.isFinite(second) ? second : 0);
+  }
+
+  return {
+    probabilities,
+    topIds,
+    frames,
+    vocabulary,
+    meanEntropy: entropySum / frames,
+    meanPeakPosterior: peakSum / frames,
+    meanTop2Margin: top2MarginSum / frames,
+  };
+}
+
+function numericTokenId(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number >= 0 ? number : null;
+}
+
+function specialTokenIds(model, tokenizer, blankTokenId) {
+  const ids = new Set([blankTokenId]);
+  const sources = [model?.config, tokenizer];
+  const names = [
+    "pad_token_id",
+    "bos_token_id",
+    "eos_token_id",
+    "unk_token_id",
+    "sep_token_id",
+    "cls_token_id",
+  ];
+
+  for (const source of sources) {
+    if (!source || typeof source !== "object") continue;
+    for (const name of names) {
+      const id = numericTokenId(source[name]);
+      if (id !== null) ids.add(id);
+    }
+  }
+
+  return ids;
+}
+
+function tokenDecoder(tokenizer) {
+  const cache = new Map();
+
+  return (tokenId) => {
+    if (cache.has(tokenId)) return cache.get(tokenId);
+
+    let decoded = "";
+    try {
+      decoded = tokenizer.decode([tokenId], {
+        skip_special_tokens: true,
+        clean_up_tokenization_spaces: false,
+      });
+    } catch {
+      decoded = "";
+    }
+
+    const label = typeof decoded === "string" ? decoded.normalize("NFC").trim() : "";
+    cache.set(tokenId, label);
+    return label;
+  };
+}
+
+function aggregateSegmentCandidates(
+  posterior,
+  startFrame,
+  endFrameExclusive,
+  ignoredTokenIds,
+  decodeToken,
+) {
+  const frameCount = endFrameExclusive - startFrame;
+  const averages = new Float64Array(posterior.vocabulary);
+
+  for (let frame = startFrame; frame < endFrameExclusive; frame += 1) {
+    const offset = frame * posterior.vocabulary;
+    for (let token = 0; token < posterior.vocabulary; token += 1) {
+      averages[token] += posterior.probabilities[offset + token] / frameCount;
+    }
+  }
+
+  const ranked = Array.from({ length: posterior.vocabulary }, (_, tokenId) => ({
+    tokenId,
+    probability: averages[tokenId],
+  })).sort((left, right) => right.probability - left.probability);
+
+  const candidates = [];
+  for (const candidate of ranked) {
+    if (candidates.length >= TOP_K) break;
+    if (ignoredTokenIds.has(candidate.tokenId) || candidate.probability <= 0) continue;
+
+    const phone = decodeToken(candidate.tokenId);
+    if (!phone) continue;
+
+    candidates.push({
+      phone,
+      probability: candidate.probability,
+    });
+  }
+
+  return candidates;
+}
+
+function collapseCtcSegments(
+  posterior,
+  tokenizer,
+  model,
+  audioDurationMs,
+  blankTokenId,
+) {
+  const ignoredTokenIds = specialTokenIds(model, tokenizer, blankTokenId);
+  const decodeToken = tokenDecoder(tokenizer);
+  const frameDurationMs = audioDurationMs / posterior.frames;
+  const observations = [];
+  const emittedPhones = [];
+
+  let cursor = 0;
+  while (cursor < posterior.frames) {
+    const tokenId = posterior.topIds[cursor];
+    let end = cursor + 1;
+    while (end < posterior.frames && posterior.topIds[end] === tokenId) end += 1;
+
+    if (!ignoredTokenIds.has(tokenId)) {
+      const phone = decodeToken(tokenId);
+      if (phone) {
+        const candidates = aggregateSegmentCandidates(
+          posterior,
+          cursor,
+          end,
+          ignoredTokenIds,
+          decodeToken,
+        );
+
+        if (candidates.length > 0) {
+          observations.push({
+            candidates,
+            startMs: cursor * frameDurationMs,
+            endMs: end * frameDurationMs,
+            source: `${MODEL_ID}@${MODEL_REVISION}:ctc-posterior-top${TOP_K}`,
+          });
+          emittedPhones.push(phone);
+        }
+      }
+    }
+
+    cursor = end;
+  }
+
+  return { observations, emittedPhones };
+}
+
+function meanBlankPosterior(posterior, blankTokenId) {
+  if (blankTokenId < 0 || blankTokenId >= posterior.vocabulary) return null;
+
+  let sum = 0;
+  for (let frame = 0; frame < posterior.frames; frame += 1) {
+    sum += posterior.probabilities[frame * posterior.vocabulary + blankTokenId];
+  }
+  return sum / posterior.frames;
 }
 
 self.addEventListener("message", async (event) => {
@@ -145,23 +384,58 @@ self.addEventListener("message", async (event) => {
     samples.length === 0
   ) {
     if (typeof id === "number") {
-      self.postMessage({
-        type: "error",
-        id,
-        message: "invalid_phoneme_audio",
-      });
+      self.postMessage({ type: "error", id, message: "invalid_phoneme_audio" });
     }
     return;
   }
 
   try {
-    const { recognizer, runtime } = await getRecognizer();
-    const output = await recognizer(samples);
+    const { model, processor, tokenizer, runtime } = await getRecognizer();
+    const inputs = await processor(samples);
+    const output = await model(inputs);
+    const logits = output?.logits;
+    const posterior = softmaxPosteriorMatrix(logits);
+
+    const blankTokenId =
+      numericTokenId(model?.config?.pad_token_id) ??
+      numericTokenId(tokenizer?.pad_token_id) ??
+      0;
+
+    if (blankTokenId >= posterior.vocabulary) {
+      throw new Error("phoneme_blank_token_out_of_range");
+    }
+
+    const audioDurationMs = (samples.length / sampleRate) * 1_000;
+    const { observations, emittedPhones } = collapseCtcSegments(
+      posterior,
+      tokenizer,
+      model,
+      audioDurationMs,
+      blankTokenId,
+    );
+
+    if (observations.length === 0) {
+      throw new Error("empty_phoneme_observation");
+    }
 
     self.postMessage({
       type: "result",
       id,
-      text: extractText(output),
+      text: emittedPhones.join(" "),
+      observations,
+      posterior: {
+        frameCount: posterior.frames,
+        vocabularySize: posterior.vocabulary,
+        blankTokenId,
+        meanEntropy: posterior.meanEntropy,
+        normalizedMeanEntropy:
+          posterior.vocabulary > 1
+            ? posterior.meanEntropy / Math.log(posterior.vocabulary)
+            : 0,
+        meanPeakPosterior: posterior.meanPeakPosterior,
+        meanTop2Margin: posterior.meanTop2Margin,
+        meanBlankPosterior: meanBlankPosterior(posterior, blankTokenId),
+      },
       runtime,
     });
   } catch (error) {

--- a/public/workers/pronunciation-phoneme-worker.mjs
+++ b/public/workers/pronunciation-phoneme-worker.mjs
@@ -14,20 +14,11 @@ function errorMessage(error) {
 }
 
 function sanitizeProgress(progress) {
-  const value =
-    progress && typeof progress === "object"
-      ? progress
-      : {};
+  const value = progress && typeof progress === "object" ? progress : {};
 
   return {
-    status:
-      typeof value.status === "string"
-        ? value.status
-        : "loading",
-    file:
-      typeof value.file === "string"
-        ? value.file
-        : null,
+    status: typeof value.status === "string" ? value.status : "loading",
+    file: typeof value.file === "string" ? value.file : null,
     progress:
       typeof value.progress === "number" && Number.isFinite(value.progress)
         ? value.progress
@@ -79,9 +70,12 @@ async function createRecognizer() {
     });
   }
 
+  // q8 is the safer/default quantized path for WASM in Transformers.js.
+  // The previous q4 fallback was smaller, but more aggressive quantization is
+  // not worth sacrificing browser compatibility for this falsification test.
   attempts.push({
     device: "wasm",
-    dtype: "q4",
+    dtype: "q8",
   });
 
   let lastError = null;
@@ -106,16 +100,19 @@ async function createRecognizer() {
 
 function getRecognizer() {
   if (!recognizerPromise) {
-    recognizerPromise = createRecognizer();
+    recognizerPromise = createRecognizer().catch((error) => {
+      // A failed first load must not permanently poison the worker. This lets a
+      // later retry succeed after a transient network/cache/runtime failure.
+      recognizerPromise = null;
+      throw error;
+    });
   }
 
   return recognizerPromise;
 }
 
 function extractText(output) {
-  const candidate = Array.isArray(output)
-    ? output[0]
-    : output;
+  const candidate = Array.isArray(output) ? output[0] : output;
 
   if (
     !candidate ||

--- a/public/workers/pronunciation-phoneme-worker.mjs
+++ b/public/workers/pronunciation-phoneme-worker.mjs
@@ -1,0 +1,177 @@
+import { pipeline } from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0";
+
+const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
+const MODEL_REVISION = "c69750f";
+
+let recognizerPromise = null;
+
+function errorMessage(error) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "phoneme_model_error";
+}
+
+function sanitizeProgress(progress) {
+  const value =
+    progress && typeof progress === "object"
+      ? progress
+      : {};
+
+  return {
+    status:
+      typeof value.status === "string"
+        ? value.status
+        : "loading",
+    file:
+      typeof value.file === "string"
+        ? value.file
+        : null,
+    progress:
+      typeof value.progress === "number" && Number.isFinite(value.progress)
+        ? value.progress
+        : null,
+  };
+}
+
+async function loadWithRuntime(runtime) {
+  self.postMessage({
+    type: "runtime",
+    state: "loading",
+    runtime,
+    message: null,
+  });
+
+  const recognizer = await pipeline(
+    "automatic-speech-recognition",
+    MODEL_ID,
+    {
+      revision: MODEL_REVISION,
+      device: runtime.device,
+      dtype: runtime.dtype,
+      progress_callback: (progress) => {
+        self.postMessage({
+          type: "progress",
+          progress: sanitizeProgress(progress),
+        });
+      },
+    },
+  );
+
+  self.postMessage({
+    type: "runtime",
+    state: "ready",
+    runtime,
+    message: null,
+  });
+
+  return { recognizer, runtime };
+}
+
+async function createRecognizer() {
+  const attempts = [];
+
+  if ("gpu" in navigator) {
+    attempts.push({
+      device: "webgpu",
+      dtype: "q4f16",
+    });
+  }
+
+  attempts.push({
+    device: "wasm",
+    dtype: "q4",
+  });
+
+  let lastError = null;
+
+  for (const runtime of attempts) {
+    try {
+      return await loadWithRuntime(runtime);
+    } catch (error) {
+      lastError = error;
+
+      self.postMessage({
+        type: "runtime",
+        state: "fallback",
+        runtime,
+        message: errorMessage(error),
+      });
+    }
+  }
+
+  throw lastError ?? new Error("phoneme_model_unavailable");
+}
+
+function getRecognizer() {
+  if (!recognizerPromise) {
+    recognizerPromise = createRecognizer();
+  }
+
+  return recognizerPromise;
+}
+
+function extractText(output) {
+  const candidate = Array.isArray(output)
+    ? output[0]
+    : output;
+
+  if (
+    !candidate ||
+    typeof candidate !== "object" ||
+    typeof candidate.text !== "string"
+  ) {
+    throw new Error("invalid_phoneme_model_output");
+  }
+
+  return candidate.text.trim();
+}
+
+self.addEventListener("message", async (event) => {
+  const message = event.data;
+
+  if (
+    !message ||
+    typeof message !== "object" ||
+    message.type !== "recognize"
+  ) {
+    return;
+  }
+
+  const { id, sampleRate, samples } = message;
+
+  if (
+    typeof id !== "number" ||
+    sampleRate !== 16_000 ||
+    !(samples instanceof Float32Array) ||
+    samples.length === 0
+  ) {
+    if (typeof id === "number") {
+      self.postMessage({
+        type: "error",
+        id,
+        message: "invalid_phoneme_audio",
+      });
+    }
+    return;
+  }
+
+  try {
+    const { recognizer, runtime } = await getRecognizer();
+    const output = await recognizer(samples);
+
+    self.postMessage({
+      type: "result",
+      id,
+      text: extractText(output),
+      runtime,
+    });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      id,
+      message: errorMessage(error),
+    });
+  }
+});

--- a/src/app/pronunciation-free-preview/PronunciationEvidencePreview.tsx
+++ b/src/app/pronunciation-free-preview/PronunciationEvidencePreview.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { Cpu, Mic, RotateCcw, Square } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  LOCAL_PRONUNCIATION_MAX_SECONDS,
+  startLocalPronunciationRecording,
+  type LocalRecordingResult,
+  type LocalRecordingSession,
+} from "@/features/pronunciation-free/audio";
+import {
+  BrowserPhonemeRecognizer,
+  type PhonemeWorkerEvent,
+} from "@/features/pronunciation-free/phoneme-worker-client";
+import type {
+  LocalCtcPosteriorSummary,
+  LocalObservedPhone,
+  LocalPhonemeRuntime,
+  PhonemeWorkerProgress,
+} from "@/features/pronunciation-free/types";
+import { tokenizeExpectedIpa } from "@/features/pronunciation-free/ipa";
+import {
+  alignCanonicalPronunciation,
+  analyzeProsody,
+  analyzeSignalQuality,
+  composeUnvalidatedPronunciationAssessment,
+  deriveUncalibratedSegmentalEvidence,
+  type PhoneAlignmentEvidence,
+  type ProsodySummary,
+  type SignalQualityEvidence,
+  type UnvalidatedPronunciationAssessment,
+} from "@/lib/pronunciation-engine";
+
+const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
+const MODEL_REVISION = "c69750f";
+const SAMPLE_RATE = 16_000;
+
+type Phase = "idle" | "recording" | "ready" | "analyzing" | "result" | "error";
+
+type PreviewTarget = {
+  word: string;
+  ipa: string;
+  howTo: string;
+  vietnameseTip: string | null;
+};
+
+type EvidenceResult = {
+  runtime: LocalPhonemeRuntime;
+  observations: LocalObservedPhone[];
+  posterior: LocalCtcPosteriorSummary;
+  alignment: PhoneAlignmentEvidence[];
+  signal: SignalQualityEvidence;
+  prosody: ProsodySummary;
+  assessment: UnvalidatedPronunciationAssessment;
+};
+
+function percent(value: number | null, digits = 1) {
+  return value === null ? "—" : `${(value * 100).toFixed(digits)}%`;
+}
+
+function safeErrorCode(error: unknown) {
+  const value = error instanceof Error ? error.message : String(error ?? "unknown_error");
+  return value.replace(/[\r\n\t]+/gu, " ").slice(0, 220);
+}
+
+function recordingError(error: unknown) {
+  const code = safeErrorCode(error);
+  if (code === "recording_too_short") return "Đoạn ghi âm quá ngắn.";
+  if (code === "recording_too_long") return "Đoạn ghi âm quá dài.";
+  if (code === "recording_signal_missing") return "Microphone không thu được tín hiệu giọng nói đủ rõ.";
+  return `Không ghi âm được · ${code}`;
+}
+
+function alignmentLabel(item: PhoneAlignmentEvidence) {
+  if (item.kind === "match") return "khớp top-1";
+  if (item.kind === "substitution") return "candidate substitution";
+  if (item.kind === "deletion") return "candidate deletion";
+  return "candidate insertion";
+}
+
+export function PronunciationEvidencePreview({ target }: { target: PreviewTarget }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [recording, setRecording] = useState<LocalRecordingResult | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [progress, setProgress] = useState<PhonemeWorkerProgress | null>(null);
+  const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
+  const [result, setResult] = useState<EvidenceResult | null>(null);
+
+  const sessionRef = useRef<LocalRecordingSession | null>(null);
+  const recognizerRef = useRef<BrowserPhonemeRecognizer | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      sessionRef.current?.cancel();
+      recognizerRef.current?.terminate();
+      if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
+    };
+  }, []);
+
+  const clearTimer = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  };
+
+  const clearAudioUrl = () => {
+    if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
+    audioUrlRef.current = null;
+    setAudioUrl(null);
+  };
+
+  const onWorkerEvent = (event: PhonemeWorkerEvent) => {
+    if (event.type === "progress") {
+      setProgress(event.progress);
+      return;
+    }
+
+    if (event.state === "fallback") {
+      setRuntimeMessage(
+        `${event.runtime.device}/${event.runtime.dtype} thất bại${event.message ? ` · ${event.message.slice(0, 140)}` : ""}`,
+      );
+      return;
+    }
+
+    if (event.state === "ready") {
+      setRuntimeMessage(`CTC model sẵn sàng · ${event.runtime.device}/${event.runtime.dtype}`);
+    }
+  };
+
+  const recognizer = () => {
+    if (!recognizerRef.current) {
+      recognizerRef.current = new BrowserPhonemeRecognizer(onWorkerEvent);
+    }
+    return recognizerRef.current;
+  };
+
+  const stopRecording = async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+    clearTimer();
+
+    try {
+      const nextRecording = await session.stop();
+      sessionRef.current = null;
+      clearAudioUrl();
+      const nextUrl = URL.createObjectURL(nextRecording.recording);
+      audioUrlRef.current = nextUrl;
+      setAudioUrl(nextUrl);
+      setRecording(nextRecording);
+      setResult(null);
+      setPhase("ready");
+      setMessage(
+        `Audio local: ${nextRecording.durationSeconds.toFixed(2)}s · 16 kHz mono · RMS ${nextRecording.rmsAmplitude.toFixed(4)}`,
+      );
+    } catch (error) {
+      sessionRef.current = null;
+      setRecording(null);
+      setResult(null);
+      setPhase("error");
+      setMessage(recordingError(error));
+    }
+  };
+
+  const startRecording = async () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+    clearAudioUrl();
+    setRecording(null);
+    setResult(null);
+    setProgress(null);
+    setMessage(null);
+
+    try {
+      const session = await startLocalPronunciationRecording();
+      sessionRef.current = session;
+      setPhase("recording");
+      setMessage(`Nói “${target.word}” một lần tự nhiên.`);
+      timerRef.current = setTimeout(() => void stopRecording(), LOCAL_PRONUNCIATION_MAX_SECONDS * 1_000);
+    } catch (error) {
+      setPhase("error");
+      setMessage(recordingError(error));
+    }
+  };
+
+  const analyze = async () => {
+    if (!recording || phase === "analyzing") return;
+
+    setPhase("analyzing");
+    setResult(null);
+    setProgress(null);
+    setMessage(
+      "Đang chạy CTC trực tiếp và giữ posterior top-k thật. Lần đầu có thể phải tải model lớn.",
+    );
+
+    try {
+      const signal = analyzeSignalQuality(recording.samples, SAMPLE_RATE);
+      const prosody = analyzeProsody(recording.samples, SAMPLE_RATE);
+      const recognition = await recognizer().recognize(recording.samples);
+      const expectedPhones = tokenizeExpectedIpa(target.ipa);
+
+      const alignmentResult = alignCanonicalPronunciation(
+        { id: `${target.word}-preview`, phones: expectedPhones },
+        recognition.observations,
+      );
+      const segmental = deriveUncalibratedSegmentalEvidence(alignmentResult);
+      const assessment = composeUnvalidatedPronunciationAssessment({
+        signalQuality: signal,
+        segmental,
+        prosody,
+      });
+
+      setResult({
+        runtime: recognition.runtime,
+        observations: recognition.observations,
+        posterior: recognition.posterior,
+        alignment: alignmentResult.alignment,
+        signal,
+        prosody,
+        assessment,
+      });
+      setPhase("result");
+      setMessage(null);
+    } catch (error) {
+      setPhase("error");
+      setMessage(`Phân tích thất bại · ${safeErrorCode(error)}`);
+    }
+  };
+
+  const reset = () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+    clearAudioUrl();
+    setRecording(null);
+    setProgress(null);
+    setRuntimeMessage(null);
+    setResult(null);
+    setMessage(null);
+    setPhase("idle");
+  };
+
+  const progressPercent =
+    progress?.progress === null || progress?.progress === undefined
+      ? null
+      : Math.min(100, Math.max(0, progress.progress));
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-6 sm:py-12">
+        <header>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            AtoEnglish pronunciation evidence R&D
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-5xl">
+            {target.word} <span className="font-mono text-muted-foreground">{target.ipa}</span>
+          </h1>
+          <p className="mt-4 max-w-3xl text-sm leading-6 text-muted-foreground">
+            Đây là màn hình đo evidence, không phải máy cho điểm. CTC posterior, chất lượng tín hiệu,
+            alignment và prosody được giữ riêng; điểm người học vẫn bị khóa cho tới khi hiệu chuẩn với human raters.
+          </p>
+        </header>
+
+        <section className="mt-8 rounded-3xl border bg-card p-5 sm:p-7">
+          <p className="text-sm leading-6">{target.howTo}</p>
+          {target.vietnameseTip ? (
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">{target.vietnameseTip}</p>
+          ) : null}
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={startRecording}
+              disabled={phase === "recording" || phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-semibold text-background disabled:opacity-40"
+            >
+              <Mic className="size-4" /> Ghi
+            </button>
+            <button
+              type="button"
+              onClick={() => void stopRecording()}
+              disabled={phase !== "recording"}
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:opacity-40"
+            >
+              <Square className="size-4" /> Dừng
+            </button>
+            <button
+              type="button"
+              onClick={() => void analyze()}
+              disabled={!recording || phase === "recording" || phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:opacity-40"
+            >
+              <Cpu className="size-4" /> {phase === "analyzing" ? "Đang chạy…" : "Phân tích evidence"}
+            </button>
+            <button
+              type="button"
+              onClick={reset}
+              disabled={phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:opacity-40"
+            >
+              <RotateCcw className="size-4" /> Reset
+            </button>
+          </div>
+
+          {audioUrl ? <audio className="mt-5 w-full" controls src={audioUrl} /> : null}
+          {message ? <p className="mt-5 rounded-2xl border bg-muted/40 p-4 text-sm">{message}</p> : null}
+          {runtimeMessage ? <p className="mt-3 break-words text-xs text-muted-foreground">{runtimeMessage}</p> : null}
+
+          {phase === "analyzing" && progress ? (
+            <div className="mt-5 rounded-2xl border p-4 text-xs text-muted-foreground">
+              <div className="flex justify-between gap-4">
+                <span>{progress.status}</span>
+                <span>{progressPercent === null ? "…" : `${progressPercent.toFixed(0)}%`}</span>
+              </div>
+              {progress.file ? <p className="mt-2 break-all">{progress.file}</p> : null}
+            </div>
+          ) : null}
+        </section>
+
+        {result ? (
+          <div className="mt-6 space-y-6">
+            <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-2xl border p-4">
+                <p className="text-xs text-muted-foreground">Signal decision</p>
+                <p className="mt-2 font-semibold">{result.assessment.decision}</p>
+              </div>
+              <div className="rounded-2xl border p-4">
+                <p className="text-xs text-muted-foreground">CTC entropy</p>
+                <p className="mt-2 font-semibold">{percent(result.posterior.normalizedMeanEntropy)}</p>
+              </div>
+              <div className="rounded-2xl border p-4">
+                <p className="text-xs text-muted-foreground">Top-2 margin</p>
+                <p className="mt-2 font-semibold">{percent(result.posterior.meanTop2Margin)}</p>
+              </div>
+              <div className="rounded-2xl border p-4">
+                <p className="text-xs text-muted-foreground">Blank posterior</p>
+                <p className="mt-2 font-semibold">{percent(result.posterior.meanBlankPosterior)}</p>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border p-5 sm:p-7">
+              <h2 className="text-lg font-semibold">CTC phone segments · posterior thật</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Top-k không được renormalize thành 100%; phần xác suất bị bỏ vẫn được coi là uncertainty.
+              </p>
+              <div className="mt-4 space-y-3">
+                {result.observations.map((observation, index) => (
+                  <div key={`${index}-${observation.startMs}`} className="rounded-2xl bg-muted/40 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span className="font-mono text-xl">{observation.candidates[0]?.phone ?? "—"}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {observation.startMs.toFixed(0)}–{observation.endMs.toFixed(0)} ms
+                      </span>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {observation.candidates.map((candidate) => (
+                        <span key={`${candidate.phone}-${candidate.probability}`} className="rounded-full border px-3 py-1 font-mono text-xs">
+                          {candidate.phone} {percent(candidate.probability)}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-3xl border p-5 sm:p-7">
+              <h2 className="text-lg font-semibold">Posterior-aware alignment</h2>
+              <div className="mt-4 overflow-hidden rounded-2xl border">
+                {result.alignment.map((item, index) => (
+                  <div
+                    key={`${index}-${item.kind}-${item.expected ?? "none"}-${item.observed ?? "none"}`}
+                    className="grid grid-cols-[0.8fr_0.8fr_1.7fr] gap-3 border-b px-4 py-3 text-sm last:border-b-0"
+                  >
+                    <span className="font-mono">{item.expected ?? "—"}</span>
+                    <span className="font-mono">{item.observed ?? "—"}</span>
+                    <span>
+                      {alignmentLabel(item)} · cost {item.cost.toFixed(3)} · p {item.observedProbability?.toFixed(3) ?? "—"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-3xl border p-5">
+                <h2 className="font-semibold">Signal quality</h2>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  RMS {result.signal.rmsAmplitude.toFixed(4)} · active {percent(result.signal.activeSpeechFraction)} · SNR proxy {result.signal.snrProxyDb?.toFixed(1) ?? "—"} dB
+                </p>
+                <p className="mt-2 text-sm">Warnings: {result.signal.warnings.join(", ") || "none"}</p>
+              </div>
+              <div className="rounded-3xl border p-5">
+                <h2 className="font-semibold">Prosody evidence</h2>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  voiced {percent(result.prosody.voicedFraction)} · pause {percent(result.prosody.pauseFraction)} · median F0 {result.prosody.pitch.medianHz?.toFixed(1) ?? "—"} Hz
+                </p>
+                <p className="mt-2 text-sm">Pitch range {result.prosody.pitch.rangeSemitones?.toFixed(1) ?? "—"} st · dynamic range {result.prosody.energy.dynamicRangeDb.toFixed(1)} dB</p>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-dashed p-5 text-sm leading-6 text-muted-foreground">
+              Learner scores: pronunciation=null · completeness=null · stress=null · fluency=null · prosody=null · total=null.
+              Calibration vẫn là <span className="font-mono">{result.assessment.calibration}</span>. Runtime: {result.runtime.device}/{result.runtime.dtype}. Model: {MODEL_ID}@{MODEL_REVISION}.
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
+++ b/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
@@ -28,13 +28,7 @@ import type {
 const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
 const MODEL_REVISION = "c69750f";
 
-type Phase =
-  | "idle"
-  | "recording"
-  | "ready"
-  | "analyzing"
-  | "result"
-  | "error";
+type Phase = "idle" | "recording" | "ready" | "analyzing" | "result" | "error";
 
 type PreviewTarget = {
   word: string;
@@ -89,11 +83,8 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   const [message, setMessage] = useState<string | null>(null);
   const [recording, setRecording] = useState<LocalRecordingResult | null>(null);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
-  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(
-    null,
-  );
-  const [workerProgress, setWorkerProgress] =
-    useState<PhonemeWorkerProgress | null>(null);
+  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(null);
+  const [workerProgress, setWorkerProgress] = useState<PhonemeWorkerProgress | null>(null);
   const [runtime, setRuntime] = useState<LocalPhonemeRuntime | null>(null);
   const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
 
@@ -103,55 +94,11 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   const audioUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
-      if (event.type === "progress") {
-        setWorkerProgress(event.progress);
-        return;
-      }
-
-      setRuntime(event.runtime);
-
-      if (event.state === "fallback") {
-        setRuntimeMessage(
-          event.runtime.device === "webgpu"
-            ? "WebGPU không dùng được; đang thử WASM trên CPU."
-            : "WASM cũng không khởi tạo được.",
-        );
-        return;
-      }
-
-      if (event.state === "ready") {
-        setRuntimeMessage(
-          event.runtime.device === "webgpu"
-            ? "Model đang chạy cục bộ bằng WebGPU."
-            : "Model đang chạy cục bộ bằng WASM trên CPU.",
-        );
-      }
-    };
-
-    try {
-      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
-    } catch {
-      setPhase("error");
-      setMessage("Không khởi tạo được Web Worker cho pronunciation sensor.");
-    }
-
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-
+      if (timerRef.current) clearTimeout(timerRef.current);
       sessionRef.current?.cancel();
-      sessionRef.current = null;
-
       recognizerRef.current?.terminate();
-      recognizerRef.current = null;
-
-      if (audioUrlRef.current) {
-        URL.revokeObjectURL(audioUrlRef.current);
-        audioUrlRef.current = null;
-      }
+      if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
     };
   }, []);
 
@@ -167,6 +114,40 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
       URL.revokeObjectURL(audioUrlRef.current);
       audioUrlRef.current = null;
     }
+  };
+
+  const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
+    if (event.type === "progress") {
+      setWorkerProgress(event.progress);
+      return;
+    }
+
+    setRuntime(event.runtime);
+
+    if (event.state === "fallback") {
+      setRuntimeMessage(
+        event.runtime.device === "webgpu"
+          ? "WebGPU không dùng được; đang thử WASM trên CPU."
+          : "WASM cũng không khởi tạo được.",
+      );
+      return;
+    }
+
+    if (event.state === "ready") {
+      setRuntimeMessage(
+        event.runtime.device === "webgpu"
+          ? "Model đang chạy cục bộ bằng WebGPU."
+          : "Model đang chạy cục bộ bằng WASM trên CPU.",
+      );
+    }
+  };
+
+  const getRecognizer = () => {
+    if (!recognizerRef.current) {
+      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
+    }
+
+    return recognizerRef.current;
   };
 
   const stopRecording = async () => {
@@ -227,12 +208,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
   };
 
   const analyze = async () => {
-    const currentRecording = recording;
-    const recognizer = recognizerRef.current;
-
-    if (!currentRecording || !recognizer || phase === "analyzing") {
-      return;
-    }
+    if (!recording || phase === "analyzing") return;
 
     setPhase("analyzing");
     setMessage(
@@ -242,7 +218,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
     setWorkerProgress(null);
 
     try {
-      const result = await recognizer.recognize(currentRecording.samples);
+      const result = await getRecognizer().recognize(recording.samples);
       const expectedPhones = tokenizeExpectedIpa(target.ipa);
       const observedPhones = parseObservedPhonemes(result.text);
 
@@ -297,7 +273,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
         <header className="flex items-start justify-between gap-5">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -317,13 +293,9 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
             </p>
             <div className="mt-3 flex flex-wrap items-end gap-x-4 gap-y-2">
               <p className="text-5xl font-semibold tracking-tight">{target.word}</p>
-              <p className="pb-1 font-mono text-xl text-muted-foreground">
-                {target.ipa}
-              </p>
+              <p className="pb-1 font-mono text-xl text-muted-foreground">{target.ipa}</p>
             </div>
-            <p className="mt-4 text-sm leading-6 text-muted-foreground">
-              {target.howTo}
-            </p>
+            <p className="mt-4 text-sm leading-6 text-muted-foreground">{target.howTo}</p>
             {target.vietnameseTip ? (
               <p className="mt-2 text-sm leading-6">{target.vietnameseTip}</p>
             ) : null}
@@ -336,8 +308,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase === "recording" || phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <Mic className="size-4" />
-              Ghi một lượt
+              <Mic className="size-4" /> Ghi một lượt
             </button>
 
             <button
@@ -346,16 +317,13 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase !== "recording"}
               className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <Square className="size-4" />
-              Dừng
+              <Square className="size-4" /> Dừng
             </button>
 
             <button
               type="button"
               onClick={() => void analyze()}
-              disabled={
-                !recording || phase === "recording" || phase === "analyzing"
-              }
+              disabled={!recording || phase === "recording" || phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
               <Cpu className="size-4" />
@@ -368,19 +336,11 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
               disabled={phase === "analyzing"}
               className="inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <RotateCcw className="size-4" />
-              Reset
+              <RotateCcw className="size-4" /> Reset
             </button>
           </div>
 
-          {audioUrl ? (
-            <audio
-              className="mt-6 w-full"
-              controls
-              preload="metadata"
-              src={audioUrl}
-            />
-          ) : null}
+          {audioUrl ? <audio className="mt-6 w-full" controls preload="metadata" src={audioUrl} /> : null}
 
           {message ? (
             <div className="mt-5 rounded-2xl border bg-muted/40 p-4 text-sm leading-6">
@@ -392,9 +352,7 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
             <div className="mt-5 rounded-2xl border p-4">
               <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
                 <span>{workerProgress.status}</span>
-                {progressPercent !== null ? (
-                  <span>{progressPercent.toFixed(0)}%</span>
-                ) : null}
+                {progressPercent !== null ? <span>{progressPercent.toFixed(0)}%</span> : null}
               </div>
               {progressPercent !== null ? (
                 <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
@@ -405,25 +363,19 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                 </div>
               ) : null}
               {workerProgress.file ? (
-                <p className="mt-2 break-all text-xs text-muted-foreground">
-                  {workerProgress.file}
-                </p>
+                <p className="mt-2 break-all text-xs text-muted-foreground">{workerProgress.file}</p>
               ) : null}
             </div>
           ) : null}
 
           {runtimeMessage ? (
-            <p className="mt-4 text-xs leading-5 text-muted-foreground">
-              {runtimeMessage}
-            </p>
+            <p className="mt-4 text-xs leading-5 text-muted-foreground">{runtimeMessage}</p>
           ) : null}
 
           {observation ? (
             <div className="mt-7 space-y-5 rounded-2xl border p-5">
               <div>
-                <p className="text-sm font-semibold">
-                  Candidate phoneme evidence · chưa hiệu chuẩn
-                </p>
+                <p className="text-sm font-semibold">Candidate phoneme evidence · chưa hiệu chuẩn</p>
                 <p className="mt-1 text-sm leading-6 text-muted-foreground">
                   Đây là điều model nghe được, không phải kết luận bạn phát âm đúng hay sai.
                 </p>
@@ -434,17 +386,13 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                     Expected
                   </p>
-                  <p className="mt-2 font-mono text-xl">
-                    {observation.expectedPhones.join(" ")}
-                  </p>
+                  <p className="mt-2 font-mono text-xl">{observation.expectedPhones.join(" ")}</p>
                 </div>
                 <div className="rounded-xl bg-muted/40 p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                     Model observed
                   </p>
-                  <p className="mt-2 font-mono text-xl">
-                    {observation.observedPhones.join(" ")}
-                  </p>
+                  <p className="mt-2 font-mono text-xl">{observation.observedPhones.join(" ")}</p>
                 </div>
               </div>
 
@@ -456,26 +404,18 @@ export function PronunciationFreePreview({ target }: { target: PreviewTarget }) 
                   >
                     <span className="font-mono">{item.expected ?? "—"}</span>
                     <span className="font-mono">{item.observed ?? "—"}</span>
-                    <span
-                      className={
-                        item.kind === "match"
-                          ? "text-muted-foreground"
-                          : "font-medium"
-                      }
-                    >
+                    <span className={item.kind === "match" ? "text-muted-foreground" : "font-medium"}>
                       {alignmentLabel(item)}
                     </span>
                   </div>
                 ))}
               </div>
 
-              <div className="text-xs leading-5 text-muted-foreground">
+              <p className="text-xs leading-5 text-muted-foreground">
                 Model: {observation.model.id} · revision {observation.model.revision}
-                {runtime
-                  ? ` · ${runtime.device}/${runtime.dtype}`
-                  : ""}
+                {runtime ? ` · ${runtime.device}/${runtime.dtype}` : ""}
                 {` · calibration: ${observation.calibration}`}
-              </div>
+              </p>
             </div>
           ) : null}
         </section>

--- a/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
+++ b/src/app/pronunciation-free-preview/PronunciationFreePreview.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { Cpu, Mic, RotateCcw, ShieldCheck, Square } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  LOCAL_PRONUNCIATION_MAX_SECONDS,
+  startLocalPronunciationRecording,
+  type LocalRecordingResult,
+  type LocalRecordingSession,
+} from "@/features/pronunciation-free/audio";
+import {
+  alignPhoneSequences,
+  parseObservedPhonemes,
+  tokenizeExpectedIpa,
+} from "@/features/pronunciation-free/ipa";
+import {
+  BrowserPhonemeRecognizer,
+  type PhonemeWorkerEvent,
+} from "@/features/pronunciation-free/phoneme-worker-client";
+import type {
+  LocalPhonemeObservation,
+  LocalPhonemeRuntime,
+  PhonemeWorkerProgress,
+  PhoneAlignment,
+} from "@/features/pronunciation-free/types";
+
+const MODEL_ID = "onnx-community/wav2vec2-lv-60-espeak-cv-ft-ONNX";
+const MODEL_REVISION = "c69750f";
+
+type Phase =
+  | "idle"
+  | "recording"
+  | "ready"
+  | "analyzing"
+  | "result"
+  | "error";
+
+type PreviewTarget = {
+  word: string;
+  ipa: string;
+  howTo: string;
+  vietnameseTip: string | null;
+};
+
+function alignmentLabel(alignment: PhoneAlignment) {
+  switch (alignment.kind) {
+    case "match":
+      return "khớp";
+    case "substitution":
+      return "model nghi thay âm";
+    case "deletion":
+      return "model nghi thiếu âm";
+    case "insertion":
+      return "model nghi thêm âm";
+  }
+}
+
+function recordingErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+
+  if (message === "microphone_recording_unavailable") {
+    return "Trình duyệt này chưa hỗ trợ cách ghi âm cần cho thử nghiệm.";
+  }
+
+  if (message === "recording_too_short") {
+    return "Đoạn ghi âm quá ngắn. Nói từ mục tiêu rõ một lần rồi dừng.";
+  }
+
+  if (message === "recording_too_long") {
+    return "Đoạn ghi âm dài hơn giới hạn của thử nghiệm.";
+  }
+
+  return "Không hoàn tất được đoạn ghi âm. Kiểm tra quyền microphone rồi thử lại.";
+}
+
+function inferenceErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+
+  if (message.includes("Failed to fetch") || message.includes("fetch")) {
+    return "Không tải được model cục bộ. Kiểm tra mạng hoặc Content Security Policy rồi thử lại.";
+  }
+
+  return "Model phoneme chưa chạy được trên trình duyệt này. Không có điểm phát âm nào được tạo.";
+}
+
+export function PronunciationFreePreview({ target }: { target: PreviewTarget }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [recording, setRecording] = useState<LocalRecordingResult | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [observation, setObservation] = useState<LocalPhonemeObservation | null>(
+    null,
+  );
+  const [workerProgress, setWorkerProgress] =
+    useState<PhonemeWorkerProgress | null>(null);
+  const [runtime, setRuntime] = useState<LocalPhonemeRuntime | null>(null);
+  const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
+
+  const sessionRef = useRef<LocalRecordingSession | null>(null);
+  const recognizerRef = useRef<BrowserPhonemeRecognizer | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handleWorkerEvent = (event: PhonemeWorkerEvent) => {
+      if (event.type === "progress") {
+        setWorkerProgress(event.progress);
+        return;
+      }
+
+      setRuntime(event.runtime);
+
+      if (event.state === "fallback") {
+        setRuntimeMessage(
+          event.runtime.device === "webgpu"
+            ? "WebGPU không dùng được; đang thử WASM trên CPU."
+            : "WASM cũng không khởi tạo được.",
+        );
+        return;
+      }
+
+      if (event.state === "ready") {
+        setRuntimeMessage(
+          event.runtime.device === "webgpu"
+            ? "Model đang chạy cục bộ bằng WebGPU."
+            : "Model đang chạy cục bộ bằng WASM trên CPU.",
+        );
+      }
+    };
+
+    try {
+      recognizerRef.current = new BrowserPhonemeRecognizer(handleWorkerEvent);
+    } catch {
+      setPhase("error");
+      setMessage("Không khởi tạo được Web Worker cho pronunciation sensor.");
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+
+      sessionRef.current?.cancel();
+      sessionRef.current = null;
+
+      recognizerRef.current?.terminate();
+      recognizerRef.current = null;
+
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+        audioUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const revokeAudioUrl = () => {
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+  };
+
+  const stopRecording = async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+
+    clearTimer();
+
+    try {
+      const result = await session.stop();
+      sessionRef.current = null;
+
+      revokeAudioUrl();
+      const nextAudioUrl = URL.createObjectURL(result.recording);
+      audioUrlRef.current = nextAudioUrl;
+
+      setRecording(result);
+      setAudioUrl(nextAudioUrl);
+      setObservation(null);
+      setPhase("ready");
+      setMessage(
+        `Đã chuẩn hóa ${result.durationSeconds.toFixed(2)} giây audio thành mono 16 kHz ngay trong trình duyệt.`,
+      );
+    } catch (error) {
+      sessionRef.current = null;
+      setRecording(null);
+      setObservation(null);
+      setPhase("error");
+      setMessage(recordingErrorMessage(error));
+    }
+  };
+
+  const startRecording = async () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+
+    revokeAudioUrl();
+    setAudioUrl(null);
+    setRecording(null);
+    setObservation(null);
+    setWorkerProgress(null);
+    setMessage(null);
+
+    try {
+      const session = await startLocalPronunciationRecording();
+      sessionRef.current = session;
+      setPhase("recording");
+      setMessage(`Nói “${target.word}” một lần tự nhiên, rồi bấm Dừng.`);
+
+      timerRef.current = setTimeout(() => {
+        void stopRecording();
+      }, LOCAL_PRONUNCIATION_MAX_SECONDS * 1_000);
+    } catch (error) {
+      setPhase("error");
+      setMessage(recordingErrorMessage(error));
+    }
+  };
+
+  const analyze = async () => {
+    const currentRecording = recording;
+    const recognizer = recognizerRef.current;
+
+    if (!currentRecording || !recognizer || phase === "analyzing") {
+      return;
+    }
+
+    setPhase("analyzing");
+    setMessage(
+      "Đang chạy phoneme model trên thiết bị. Lần đầu cần tải model lớn nên có thể chờ khá lâu.",
+    );
+    setObservation(null);
+    setWorkerProgress(null);
+
+    try {
+      const result = await recognizer.recognize(currentRecording.samples);
+      const expectedPhones = tokenizeExpectedIpa(target.ipa);
+      const observedPhones = parseObservedPhonemes(result.text);
+
+      if (observedPhones.length === 0) {
+        throw new Error("empty_phoneme_observation");
+      }
+
+      const nextObservation: LocalPhonemeObservation = {
+        calibration: "unvalidated",
+        model: {
+          id: MODEL_ID,
+          revision: MODEL_REVISION,
+          runtime: result.runtime,
+        },
+        target: {
+          word: target.word,
+          ipa: target.ipa,
+        },
+        expectedPhones,
+        observedPhones,
+        alignment: alignPhoneSequences(expectedPhones, observedPhones),
+      };
+
+      setRuntime(result.runtime);
+      setObservation(nextObservation);
+      setPhase("result");
+      setMessage(null);
+    } catch (error) {
+      setPhase("error");
+      setMessage(inferenceErrorMessage(error));
+    }
+  };
+
+  const reset = () => {
+    clearTimer();
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+
+    revokeAudioUrl();
+    setAudioUrl(null);
+    setRecording(null);
+    setObservation(null);
+    setWorkerProgress(null);
+    setMessage(null);
+    setPhase("idle");
+  };
+
+  const progressPercent =
+    workerProgress?.progress === null || workerProgress?.progress === undefined
+      ? null
+      : Math.min(100, Math.max(0, workerProgress.progress));
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-8 sm:px-6 sm:py-12">
+        <header className="flex items-start justify-between gap-5">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Pronunciation · free sensor V1
+            </p>
+            <h1 className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight sm:text-5xl">
+              Nghe phoneme cục bộ trước, chưa chấm điểm phát âm.
+            </h1>
+          </div>
+          <ShieldCheck className="mt-1 hidden size-8 shrink-0 text-muted-foreground sm:block" />
+        </header>
+
+        <section className="mt-10 rounded-3xl border bg-card p-5 shadow-sm sm:p-8">
+          <div className="rounded-2xl border bg-muted/40 p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Từ thử nghiệm
+            </p>
+            <div className="mt-3 flex flex-wrap items-end gap-x-4 gap-y-2">
+              <p className="text-5xl font-semibold tracking-tight">{target.word}</p>
+              <p className="pb-1 font-mono text-xl text-muted-foreground">
+                {target.ipa}
+              </p>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-muted-foreground">
+              {target.howTo}
+            </p>
+            {target.vietnameseTip ? (
+              <p className="mt-2 text-sm leading-6">{target.vietnameseTip}</p>
+            ) : null}
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={startRecording}
+              disabled={phase === "recording" || phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-semibold text-background disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Mic className="size-4" />
+              Ghi một lượt
+            </button>
+
+            <button
+              type="button"
+              onClick={() => void stopRecording()}
+              disabled={phase !== "recording"}
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Square className="size-4" />
+              Dừng
+            </button>
+
+            <button
+              type="button"
+              onClick={() => void analyze()}
+              disabled={
+                !recording || phase === "recording" || phase === "analyzing"
+              }
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Cpu className="size-4" />
+              {phase === "analyzing" ? "Đang phân tích…" : "Phân tích cục bộ"}
+            </button>
+
+            <button
+              type="button"
+              onClick={reset}
+              disabled={phase === "analyzing"}
+              className="inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCcw className="size-4" />
+              Reset
+            </button>
+          </div>
+
+          {audioUrl ? (
+            <audio
+              className="mt-6 w-full"
+              controls
+              preload="metadata"
+              src={audioUrl}
+            />
+          ) : null}
+
+          {message ? (
+            <div className="mt-5 rounded-2xl border bg-muted/40 p-4 text-sm leading-6">
+              {message}
+            </div>
+          ) : null}
+
+          {phase === "analyzing" && workerProgress ? (
+            <div className="mt-5 rounded-2xl border p-4">
+              <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+                <span>{workerProgress.status}</span>
+                {progressPercent !== null ? (
+                  <span>{progressPercent.toFixed(0)}%</span>
+                ) : null}
+              </div>
+              {progressPercent !== null ? (
+                <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-foreground transition-[width]"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+              ) : null}
+              {workerProgress.file ? (
+                <p className="mt-2 break-all text-xs text-muted-foreground">
+                  {workerProgress.file}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {runtimeMessage ? (
+            <p className="mt-4 text-xs leading-5 text-muted-foreground">
+              {runtimeMessage}
+            </p>
+          ) : null}
+
+          {observation ? (
+            <div className="mt-7 space-y-5 rounded-2xl border p-5">
+              <div>
+                <p className="text-sm font-semibold">
+                  Candidate phoneme evidence · chưa hiệu chuẩn
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  Đây là điều model nghe được, không phải kết luận bạn phát âm đúng hay sai.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl bg-muted/40 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Expected
+                  </p>
+                  <p className="mt-2 font-mono text-xl">
+                    {observation.expectedPhones.join(" ")}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-muted/40 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Model observed
+                  </p>
+                  <p className="mt-2 font-mono text-xl">
+                    {observation.observedPhones.join(" ")}
+                  </p>
+                </div>
+              </div>
+
+              <div className="overflow-hidden rounded-xl border">
+                {observation.alignment.map((item, index) => (
+                  <div
+                    key={`${item.kind}-${index}-${item.expected ?? "none"}-${item.observed ?? "none"}`}
+                    className="grid grid-cols-[1fr_1fr_2fr] gap-3 border-b px-4 py-3 text-sm last:border-b-0"
+                  >
+                    <span className="font-mono">{item.expected ?? "—"}</span>
+                    <span className="font-mono">{item.observed ?? "—"}</span>
+                    <span
+                      className={
+                        item.kind === "match"
+                          ? "text-muted-foreground"
+                          : "font-medium"
+                      }
+                    >
+                      {alignmentLabel(item)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="text-xs leading-5 text-muted-foreground">
+                Model: {observation.model.id} · revision {observation.model.revision}
+                {runtime
+                  ? ` · ${runtime.device}/${runtime.dtype}`
+                  : ""}
+                {` · calibration: ${observation.calibration}`}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm font-semibold">Bài test cố ý</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Ghi một lượt “think”, rồi thử cố ý nói gần “sink” và “tink”. Sensor chỉ đáng đi tiếp nếu chuỗi phoneme thay đổi theo hướng hợp lý.
+            </p>
+          </div>
+          <div className="rounded-2xl border p-5">
+            <p className="text-sm font-semibold">Privacy / chi phí</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Audio được xử lý trên thiết bị và không upload qua API AtoEnglish. Lần đầu trình duyệt vẫn phải tải runtime và model miễn phí, khoảng vài trăm MB.
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/pronunciation-free-preview/page.tsx
+++ b/src/app/pronunciation-free-preview/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { ALL_SOUNDS } from "@/lib/data/ipa-sounds";
 
-import { PronunciationFreePreview } from "./PronunciationFreePreview";
+import { PronunciationEvidencePreview } from "./PronunciationEvidencePreview";
 
 export default function PronunciationFreePreviewPage() {
   const sound = ALL_SOUNDS.find(
@@ -14,7 +14,7 @@ export default function PronunciationFreePreviewPage() {
   }
 
   return (
-    <PronunciationFreePreview
+    <PronunciationEvidencePreview
       target={{
         word: sound.exampleWord,
         ipa: sound.exampleIpa,

--- a/src/app/pronunciation-free-preview/page.tsx
+++ b/src/app/pronunciation-free-preview/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+
+import { ALL_SOUNDS } from "@/lib/data/ipa-sounds";
+
+import { PronunciationFreePreview } from "./PronunciationFreePreview";
+
+export default function PronunciationFreePreviewPage() {
+  const sound = ALL_SOUNDS.find(
+    (candidate) => candidate.id === "th-voiceless",
+  );
+
+  if (!sound) {
+    notFound();
+  }
+
+  return (
+    <PronunciationFreePreview
+      target={{
+        word: sound.exampleWord,
+        ipa: sound.exampleIpa,
+        howTo: sound.howTo,
+        vietnameseTip: sound.vietnameseTip ?? null,
+      }}
+    />
+  );
+}

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -177,6 +177,29 @@ async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
   }
 }
 
+async function openMicrophoneStream() {
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+      video: false,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "OverconstrainedError") {
+      return navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+    }
+
+    throw error;
+  }
+}
+
 export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
   if (
     typeof navigator === "undefined" ||
@@ -186,14 +209,13 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     throw new Error("microphone_recording_unavailable");
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-    },
-    video: false,
-  });
+  const stream = await openMicrophoneStream();
+  const audioTrack = stream.getAudioTracks()[0];
+
+  if (!audioTrack || audioTrack.readyState !== "live") {
+    for (const track of stream.getTracks()) track.stop();
+    throw new Error("microphone_track_unavailable");
+  }
 
   const mimeType = preferredRecorderMimeType();
   const recorder = mimeType
@@ -276,7 +298,7 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     stopTracks();
   };
 
-  recorder.start();
+  recorder.start(250);
 
   return { stop, cancel };
 }

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -3,6 +3,7 @@ const MIN_RECORDING_SECONDS = 0.15;
 const MAX_RECORDING_SECONDS = 8;
 const SILENCE_PEAK_THRESHOLD = 0.001;
 const SILENCE_RMS_THRESHOLD = 0.0001;
+const PROCESSOR_BUFFER_SIZE = 4096;
 
 export type LocalRecordingResult = {
   recording: Blob;
@@ -17,21 +18,6 @@ export type LocalRecordingSession = {
   cancel(): void;
 };
 
-function preferredRecorderMimeType() {
-  if (typeof MediaRecorder === "undefined") return "";
-
-  const candidates = [
-    "audio/webm;codecs=opus",
-    "audio/webm",
-    "audio/ogg;codecs=opus",
-    "audio/mp4",
-  ];
-
-  return (
-    candidates.find((candidate) => MediaRecorder.isTypeSupported(candidate)) ?? ""
-  );
-}
-
 function downmixToMono(audioBuffer: AudioBuffer) {
   const mono = new Float32Array(audioBuffer.length);
 
@@ -44,6 +30,18 @@ function downmixToMono(audioBuffer: AudioBuffer) {
   }
 
   return mono;
+}
+
+function concatenateChunks(chunks: Float32Array[], totalLength: number) {
+  const samples = new Float32Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    samples.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return samples;
 }
 
 async function resampleMono(
@@ -129,62 +127,14 @@ function encodePcm16Wav(samples: Float32Array, sampleRate: number) {
   return new Blob([new Uint8Array(buffer)], { type: "audio/wav" });
 }
 
-async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
-  const AudioContextClass = globalThis.AudioContext;
-
-  if (!AudioContextClass) {
-    throw new Error("audio_context_unavailable");
-  }
-
-  const context = new AudioContextClass();
-
-  try {
-    const encoded = await recording.arrayBuffer();
-    const decoded = await context.decodeAudioData(encoded.slice(0));
-
-    if (!Number.isFinite(decoded.duration) || decoded.duration < MIN_RECORDING_SECONDS) {
-      throw new Error("recording_too_short");
-    }
-
-    if (decoded.duration > MAX_RECORDING_SECONDS + 0.5) {
-      throw new Error("recording_too_long");
-    }
-
-    const mono = downmixToMono(decoded);
-    const samples = await resampleMono(
-      mono,
-      decoded.sampleRate,
-      TARGET_SAMPLE_RATE,
-    );
-    const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
-
-    if (
-      peakAmplitude < SILENCE_PEAK_THRESHOLD &&
-      rmsAmplitude < SILENCE_RMS_THRESHOLD
-    ) {
-      throw new Error("recording_signal_missing");
-    }
-
-    return {
-      recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
-      samples,
-      durationSeconds: samples.length / TARGET_SAMPLE_RATE,
-      peakAmplitude,
-      rmsAmplitude,
-    };
-  } finally {
-    await context.close();
-  }
-}
-
 async function openMicrophoneStream() {
   try {
     return await navigator.mediaDevices.getUserMedia({
       audio: {
-        channelCount: 1,
-        echoCancellation: false,
-        noiseSuppression: false,
-        autoGainControl: false,
+        channelCount: { ideal: 1 },
+        echoCancellation: { ideal: false },
+        noiseSuppression: { ideal: false },
+        autoGainControl: { ideal: false },
       },
       video: false,
     });
@@ -201,10 +151,12 @@ async function openMicrophoneStream() {
 }
 
 export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
+  const AudioContextClass = globalThis.AudioContext;
+
   if (
     typeof navigator === "undefined" ||
     !navigator.mediaDevices?.getUserMedia ||
-    typeof MediaRecorder === "undefined"
+    !AudioContextClass
   ) {
     throw new Error("microphone_recording_unavailable");
   }
@@ -217,71 +169,102 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     throw new Error("microphone_track_unavailable");
   }
 
-  const mimeType = preferredRecorderMimeType();
-  const recorder = mimeType
-    ? new MediaRecorder(stream, { mimeType })
-    : new MediaRecorder(stream);
+  const context = new AudioContextClass();
+  const source = context.createMediaStreamSource(stream);
+  const processor = context.createScriptProcessor(PROCESSOR_BUFFER_SIZE, 1, 1);
+  const mute = context.createGain();
+  mute.gain.value = 0;
 
-  const chunks: Blob[] = [];
+  const chunks: Float32Array[] = [];
+  let totalSamples = 0;
   let finalized = false;
   let stopPromise: Promise<LocalRecordingResult> | null = null;
 
-  const stopTracks = () => {
+  processor.onaudioprocess = (event) => {
+    if (finalized) return;
+
+    const chunk = downmixToMono(event.inputBuffer);
+    chunks.push(chunk);
+    totalSamples += chunk.length;
+  };
+
+  source.connect(processor);
+  processor.connect(mute);
+  mute.connect(context.destination);
+
+  if (context.state === "suspended") {
+    await context.resume();
+  }
+
+  const cleanup = () => {
+    processor.onaudioprocess = null;
+
+    try {
+      source.disconnect();
+      processor.disconnect();
+      mute.disconnect();
+    } catch {
+      // Nodes may already be disconnected during browser teardown.
+    }
+
     for (const track of stream.getTracks()) {
       track.stop();
     }
   };
 
-  recorder.addEventListener("dataavailable", (event) => {
-    if (event.data.size > 0) {
-      chunks.push(event.data);
-    }
-  });
-
   const stop = () => {
     if (stopPromise) return stopPromise;
 
-    if (finalized || recorder.state !== "recording") {
+    if (finalized) {
       return Promise.reject(new Error("recorder_not_recording"));
     }
 
     finalized = true;
 
-    stopPromise = new Promise<LocalRecordingResult>((resolve, reject) => {
-      recorder.addEventListener(
-        "stop",
-        async () => {
-          stopTracks();
+    stopPromise = (async () => {
+      cleanup();
 
-          const recording = new Blob(chunks, {
-            type: recorder.mimeType || chunks[0]?.type || "audio/webm",
-          });
+      try {
+        if (totalSamples === 0) {
+          throw new Error("empty_audio_recording");
+        }
 
-          if (recording.size === 0) {
-            reject(new Error("empty_audio_recording"));
-            return;
-          }
+        const sourceSamples = concatenateChunks(chunks, totalSamples);
+        const sourceDuration = sourceSamples.length / context.sampleRate;
 
-          try {
-            resolve(await decodeRecording(recording));
-          } catch (error) {
-            reject(error);
-          }
-        },
-        { once: true },
-      );
+        if (sourceDuration < MIN_RECORDING_SECONDS) {
+          throw new Error("recording_too_short");
+        }
 
-      recorder.addEventListener(
-        "error",
-        () => {
-          stopTracks();
-          reject(new Error("media_recorder_error"));
-        },
-        { once: true },
-      );
+        if (sourceDuration > MAX_RECORDING_SECONDS + 0.75) {
+          throw new Error("recording_too_long");
+        }
 
-      recorder.stop();
-    });
+        const samples = await resampleMono(
+          sourceSamples,
+          context.sampleRate,
+          TARGET_SAMPLE_RATE,
+        );
+        const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
+
+        if (
+          peakAmplitude < SILENCE_PEAK_THRESHOLD &&
+          rmsAmplitude < SILENCE_RMS_THRESHOLD
+        ) {
+          throw new Error("recording_signal_missing");
+        }
+
+        return {
+          recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
+          samples,
+          durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+          peakAmplitude,
+          rmsAmplitude,
+        };
+      } finally {
+        await context.close();
+      }
+    })();
 
     return stopPromise;
   };
@@ -290,15 +273,9 @@ export async function startLocalPronunciationRecording(): Promise<LocalRecording
     if (finalized) return;
 
     finalized = true;
-
-    if (recorder.state === "recording") {
-      recorder.stop();
-    }
-
-    stopTracks();
+    cleanup();
+    void context.close();
   };
-
-  recorder.start(250);
 
   return { stop, cancel };
 }

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -1,11 +1,15 @@
 const TARGET_SAMPLE_RATE = 16_000;
 const MIN_RECORDING_SECONDS = 0.15;
 const MAX_RECORDING_SECONDS = 8;
+const SILENCE_PEAK_THRESHOLD = 0.001;
+const SILENCE_RMS_THRESHOLD = 0.0001;
 
 export type LocalRecordingResult = {
   recording: Blob;
   samples: Float32Array;
   durationSeconds: number;
+  peakAmplitude: number;
+  rmsAmplitude: number;
 };
 
 export type LocalRecordingSession = {
@@ -72,6 +76,59 @@ async function resampleMono(
   return Float32Array.from(rendered.getChannelData(0));
 }
 
+function measureSignal(samples: Float32Array) {
+  let peakAmplitude = 0;
+  let squareSum = 0;
+
+  for (const sample of samples) {
+    const absolute = Math.abs(sample);
+    if (absolute > peakAmplitude) peakAmplitude = absolute;
+    squareSum += sample * sample;
+  }
+
+  return {
+    peakAmplitude,
+    rmsAmplitude: samples.length > 0 ? Math.sqrt(squareSum / samples.length) : 0,
+  };
+}
+
+function writeAscii(view: DataView, offset: number, value: string) {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+function encodePcm16Wav(samples: Float32Array, sampleRate: number) {
+  const bytesPerSample = 2;
+  const dataSize = samples.length * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (const value of samples) {
+    const sample = Math.max(-1, Math.min(1, value));
+    const pcm = sample < 0 ? Math.round(sample * 0x8000) : Math.round(sample * 0x7fff);
+    view.setInt16(offset, pcm, true);
+    offset += bytesPerSample;
+  }
+
+  return new Blob([new Uint8Array(buffer)], { type: "audio/wav" });
+}
+
 async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
   const AudioContextClass = globalThis.AudioContext;
 
@@ -99,11 +156,21 @@ async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
       decoded.sampleRate,
       TARGET_SAMPLE_RATE,
     );
+    const { peakAmplitude, rmsAmplitude } = measureSignal(samples);
+
+    if (
+      peakAmplitude < SILENCE_PEAK_THRESHOLD &&
+      rmsAmplitude < SILENCE_RMS_THRESHOLD
+    ) {
+      throw new Error("recording_signal_missing");
+    }
 
     return {
-      recording,
+      recording: encodePcm16Wav(samples, TARGET_SAMPLE_RATE),
       samples,
       durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+      peakAmplitude,
+      rmsAmplitude,
     };
   } finally {
     await context.close();

--- a/src/features/pronunciation-free/audio.ts
+++ b/src/features/pronunciation-free/audio.ts
@@ -1,0 +1,217 @@
+const TARGET_SAMPLE_RATE = 16_000;
+const MIN_RECORDING_SECONDS = 0.15;
+const MAX_RECORDING_SECONDS = 8;
+
+export type LocalRecordingResult = {
+  recording: Blob;
+  samples: Float32Array;
+  durationSeconds: number;
+};
+
+export type LocalRecordingSession = {
+  stop(): Promise<LocalRecordingResult>;
+  cancel(): void;
+};
+
+function preferredRecorderMimeType() {
+  if (typeof MediaRecorder === "undefined") return "";
+
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/ogg;codecs=opus",
+    "audio/mp4",
+  ];
+
+  return (
+    candidates.find((candidate) => MediaRecorder.isTypeSupported(candidate)) ?? ""
+  );
+}
+
+function downmixToMono(audioBuffer: AudioBuffer) {
+  const mono = new Float32Array(audioBuffer.length);
+
+  for (let channel = 0; channel < audioBuffer.numberOfChannels; channel += 1) {
+    const channelSamples = audioBuffer.getChannelData(channel);
+
+    for (let index = 0; index < channelSamples.length; index += 1) {
+      mono[index] += channelSamples[index] / audioBuffer.numberOfChannels;
+    }
+  }
+
+  return mono;
+}
+
+async function resampleMono(
+  samples: Float32Array,
+  sourceSampleRate: number,
+  targetSampleRate: number,
+) {
+  if (sourceSampleRate === targetSampleRate) {
+    return Float32Array.from(samples);
+  }
+
+  if (typeof OfflineAudioContext === "undefined") {
+    throw new Error("offline_audio_context_unavailable");
+  }
+
+  const targetLength = Math.ceil(
+    samples.length * (targetSampleRate / sourceSampleRate),
+  );
+
+  const context = new OfflineAudioContext(1, targetLength, targetSampleRate);
+  const sourceBuffer = context.createBuffer(1, samples.length, sourceSampleRate);
+  sourceBuffer.getChannelData(0).set(samples);
+
+  const source = context.createBufferSource();
+  source.buffer = sourceBuffer;
+  source.connect(context.destination);
+  source.start(0);
+
+  const rendered = await context.startRendering();
+  return Float32Array.from(rendered.getChannelData(0));
+}
+
+async function decodeRecording(recording: Blob): Promise<LocalRecordingResult> {
+  const AudioContextClass = globalThis.AudioContext;
+
+  if (!AudioContextClass) {
+    throw new Error("audio_context_unavailable");
+  }
+
+  const context = new AudioContextClass();
+
+  try {
+    const encoded = await recording.arrayBuffer();
+    const decoded = await context.decodeAudioData(encoded.slice(0));
+
+    if (!Number.isFinite(decoded.duration) || decoded.duration < MIN_RECORDING_SECONDS) {
+      throw new Error("recording_too_short");
+    }
+
+    if (decoded.duration > MAX_RECORDING_SECONDS + 0.5) {
+      throw new Error("recording_too_long");
+    }
+
+    const mono = downmixToMono(decoded);
+    const samples = await resampleMono(
+      mono,
+      decoded.sampleRate,
+      TARGET_SAMPLE_RATE,
+    );
+
+    return {
+      recording,
+      samples,
+      durationSeconds: samples.length / TARGET_SAMPLE_RATE,
+    };
+  } finally {
+    await context.close();
+  }
+}
+
+export async function startLocalPronunciationRecording(): Promise<LocalRecordingSession> {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.mediaDevices?.getUserMedia ||
+    typeof MediaRecorder === "undefined"
+  ) {
+    throw new Error("microphone_recording_unavailable");
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+    video: false,
+  });
+
+  const mimeType = preferredRecorderMimeType();
+  const recorder = mimeType
+    ? new MediaRecorder(stream, { mimeType })
+    : new MediaRecorder(stream);
+
+  const chunks: Blob[] = [];
+  let finalized = false;
+  let stopPromise: Promise<LocalRecordingResult> | null = null;
+
+  const stopTracks = () => {
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+  };
+
+  recorder.addEventListener("dataavailable", (event) => {
+    if (event.data.size > 0) {
+      chunks.push(event.data);
+    }
+  });
+
+  const stop = () => {
+    if (stopPromise) return stopPromise;
+
+    if (finalized || recorder.state !== "recording") {
+      return Promise.reject(new Error("recorder_not_recording"));
+    }
+
+    finalized = true;
+
+    stopPromise = new Promise<LocalRecordingResult>((resolve, reject) => {
+      recorder.addEventListener(
+        "stop",
+        async () => {
+          stopTracks();
+
+          const recording = new Blob(chunks, {
+            type: recorder.mimeType || chunks[0]?.type || "audio/webm",
+          });
+
+          if (recording.size === 0) {
+            reject(new Error("empty_audio_recording"));
+            return;
+          }
+
+          try {
+            resolve(await decodeRecording(recording));
+          } catch (error) {
+            reject(error);
+          }
+        },
+        { once: true },
+      );
+
+      recorder.addEventListener(
+        "error",
+        () => {
+          stopTracks();
+          reject(new Error("media_recorder_error"));
+        },
+        { once: true },
+      );
+
+      recorder.stop();
+    });
+
+    return stopPromise;
+  };
+
+  const cancel = () => {
+    if (finalized) return;
+
+    finalized = true;
+
+    if (recorder.state === "recording") {
+      recorder.stop();
+    }
+
+    stopTracks();
+  };
+
+  recorder.start();
+
+  return { stop, cancel };
+}
+
+export const LOCAL_PRONUNCIATION_MAX_SECONDS = MAX_RECORDING_SECONDS;

--- a/src/features/pronunciation-free/ipa.test.ts
+++ b/src/features/pronunciation-free/ipa.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  alignPhoneSequences,
+  parseObservedPhonemes,
+  tokenizeExpectedIpa,
+} from "./ipa";
+
+describe("pronunciation-free IPA utilities", () => {
+  it("tokenizes the canonical think IPA", () => {
+    expect(tokenizeExpectedIpa("/θɪŋk/")).toEqual(["θ", "ɪ", "ŋ", "k"]);
+  });
+
+  it("keeps long vowels and affricates as one phone", () => {
+    expect(tokenizeExpectedIpa("/tʃiːp/")).toEqual(["tʃ", "iː", "p"]);
+  });
+
+  it("parses the model's whitespace-separated phonetic labels", () => {
+    expect(parseObservedPhonemes("s ɪ ŋ k")).toEqual(["s", "ɪ", "ŋ", "k"]);
+  });
+
+  it("normalizes common tie-bar and glyph variants", () => {
+    expect(parseObservedPhonemes("t͡ʃ ɪ ɡ")).toEqual(["tʃ", "ɪ", "g"]);
+  });
+
+  it("diagnoses a theta-to-s substitution without inventing other errors", () => {
+    expect(
+      alignPhoneSequences(["θ", "ɪ", "ŋ", "k"], ["s", "ɪ", "ŋ", "k"]),
+    ).toEqual([
+      { kind: "substitution", expected: "θ", observed: "s" },
+      { kind: "match", expected: "ɪ", observed: "ɪ" },
+      { kind: "match", expected: "ŋ", observed: "ŋ" },
+      { kind: "match", expected: "k", observed: "k" },
+    ]);
+  });
+
+  it("represents a missing final consonant as a deletion", () => {
+    expect(alignPhoneSequences(["s", "t", "ɒ", "p"], ["s", "t", "ɒ"])).toEqual([
+      { kind: "match", expected: "s", observed: "s" },
+      { kind: "match", expected: "t", observed: "t" },
+      { kind: "match", expected: "ɒ", observed: "ɒ" },
+      { kind: "deletion", expected: "p", observed: null },
+    ]);
+  });
+
+  it("represents an added phone as an insertion", () => {
+    expect(alignPhoneSequences(["s", "t", "ɒ", "p"], ["s", "t", "ɒ", "p", "ə"])).toEqual([
+      { kind: "match", expected: "s", observed: "s" },
+      { kind: "match", expected: "t", observed: "t" },
+      { kind: "match", expected: "ɒ", observed: "ɒ" },
+      { kind: "match", expected: "p", observed: "p" },
+      { kind: "insertion", expected: null, observed: "ə" },
+    ]);
+  });
+});

--- a/src/features/pronunciation-free/ipa.ts
+++ b/src/features/pronunciation-free/ipa.ts
@@ -1,0 +1,172 @@
+import type { PhoneAlignment } from "./types";
+
+const MULTI_CHARACTER_PHONES = [
+  "tʃ",
+  "dʒ",
+  "iː",
+  "ɑː",
+  "ɔː",
+  "uː",
+  "ɜː",
+  "eɪ",
+  "aɪ",
+  "ɔɪ",
+  "aʊ",
+  "əʊ",
+  "oʊ",
+  "ɪə",
+  "eə",
+  "ʊə",
+].sort((left, right) => right.length - left.length);
+
+const IPA_MARKS = new Set(["/", "[", "]", "ˈ", "ˌ", ".", " ", "\t", "\n"]);
+
+function normalizePhoneToken(value: string) {
+  return value
+    .normalize("NFC")
+    .replaceAll("t͡ʃ", "tʃ")
+    .replaceAll("d͡ʒ", "dʒ")
+    .replaceAll("ɡ", "g")
+    .trim();
+}
+
+function comparisonPhone(value: string | null) {
+  if (value === null) return null;
+  return normalizePhoneToken(value);
+}
+
+export function tokenizeExpectedIpa(ipa: string) {
+  const normalized = normalizePhoneToken(ipa);
+  const phones: string[] = [];
+
+  let index = 0;
+
+  while (index < normalized.length) {
+    const current = normalized[index];
+
+    if (IPA_MARKS.has(current)) {
+      index += 1;
+      continue;
+    }
+
+    const multiPhone = MULTI_CHARACTER_PHONES.find((candidate) =>
+      normalized.startsWith(candidate, index),
+    );
+
+    if (multiPhone) {
+      phones.push(multiPhone);
+      index += multiPhone.length;
+      continue;
+    }
+
+    const codePoint = normalized.codePointAt(index);
+    if (codePoint === undefined) break;
+
+    const phone = String.fromCodePoint(codePoint);
+    phones.push(phone);
+    index += phone.length;
+  }
+
+  return phones.filter(Boolean);
+}
+
+export function parseObservedPhonemes(value: string) {
+  const normalized = normalizePhoneToken(value);
+
+  if (!normalized) return [];
+
+  const whitespaceTokens = normalized
+    .split(/\s+/u)
+    .map(normalizePhoneToken)
+    .filter(Boolean);
+
+  if (whitespaceTokens.length > 1) {
+    return whitespaceTokens;
+  }
+
+  return tokenizeExpectedIpa(normalized);
+}
+
+function substitutionCost(expected: string, observed: string) {
+  return comparisonPhone(expected) === comparisonPhone(observed) ? 0 : 1;
+}
+
+export function alignPhoneSequences(
+  expectedPhones: readonly string[],
+  observedPhones: readonly string[],
+): PhoneAlignment[] {
+  const rows = expectedPhones.length + 1;
+  const columns = observedPhones.length + 1;
+  const matrix = Array.from({ length: rows }, () =>
+    Array<number>(columns).fill(0),
+  );
+
+  for (let row = 1; row < rows; row += 1) {
+    matrix[row][0] = row;
+  }
+
+  for (let column = 1; column < columns; column += 1) {
+    matrix[0][column] = column;
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let column = 1; column < columns; column += 1) {
+      const substitution =
+        matrix[row - 1][column - 1] +
+        substitutionCost(expectedPhones[row - 1], observedPhones[column - 1]);
+      const deletion = matrix[row - 1][column] + 1;
+      const insertion = matrix[row][column - 1] + 1;
+
+      matrix[row][column] = Math.min(substitution, deletion, insertion);
+    }
+  }
+
+  const alignment: PhoneAlignment[] = [];
+  let row = expectedPhones.length;
+  let column = observedPhones.length;
+
+  while (row > 0 || column > 0) {
+    if (row > 0 && column > 0) {
+      const expected = expectedPhones[row - 1];
+      const observed = observedPhones[column - 1];
+      const diagonalCost =
+        matrix[row - 1][column - 1] + substitutionCost(expected, observed);
+
+      if (matrix[row][column] === diagonalCost) {
+        alignment.push({
+          kind:
+            comparisonPhone(expected) === comparisonPhone(observed)
+              ? "match"
+              : "substitution",
+          expected,
+          observed,
+        });
+        row -= 1;
+        column -= 1;
+        continue;
+      }
+    }
+
+    if (row > 0 && matrix[row][column] === matrix[row - 1][column] + 1) {
+      alignment.push({
+        kind: "deletion",
+        expected: expectedPhones[row - 1],
+        observed: null,
+      });
+      row -= 1;
+      continue;
+    }
+
+    if (column > 0) {
+      alignment.push({
+        kind: "insertion",
+        expected: null,
+        observed: observedPhones[column - 1],
+      });
+      column -= 1;
+      continue;
+    }
+  }
+
+  return alignment.reverse();
+}

--- a/src/features/pronunciation-free/phoneme-worker-client.ts
+++ b/src/features/pronunciation-free/phoneme-worker-client.ts
@@ -40,7 +40,7 @@ function parseRuntime(value: unknown): LocalPhonemeRuntime | null {
     return { device, dtype };
   }
 
-  if (device === "wasm" && dtype === "q4") {
+  if (device === "wasm" && dtype === "q8") {
     return { device, dtype };
   }
 

--- a/src/features/pronunciation-free/phoneme-worker-client.ts
+++ b/src/features/pronunciation-free/phoneme-worker-client.ts
@@ -1,0 +1,175 @@
+import type {
+  LocalPhonemeRuntime,
+  PhonemeWorkerProgress,
+} from "./types";
+
+export type PhonemeWorkerEvent =
+  | {
+      type: "progress";
+      progress: PhonemeWorkerProgress;
+    }
+  | {
+      type: "runtime";
+      state: "loading" | "ready" | "fallback";
+      runtime: LocalPhonemeRuntime;
+      message: string | null;
+    };
+
+export type PhonemeRecognitionResult = {
+  text: string;
+  runtime: LocalPhonemeRuntime;
+};
+
+type PendingRequest = {
+  resolve(value: PhonemeRecognitionResult): void;
+  reject(error: Error): void;
+};
+
+type WorkerMessage = Record<string, unknown>;
+
+function isWorkerMessage(value: unknown): value is WorkerMessage {
+  return typeof value === "object" && value !== null;
+}
+
+function parseRuntime(value: unknown): LocalPhonemeRuntime | null {
+  if (!isWorkerMessage(value)) return null;
+
+  const { device, dtype } = value;
+
+  if (device === "webgpu" && dtype === "q4f16") {
+    return { device, dtype };
+  }
+
+  if (device === "wasm" && dtype === "q4") {
+    return { device, dtype };
+  }
+
+  return null;
+}
+
+function parseProgress(value: unknown): PhonemeWorkerProgress | null {
+  if (!isWorkerMessage(value) || typeof value.status !== "string") {
+    return null;
+  }
+
+  return {
+    status: value.status,
+    file: typeof value.file === "string" ? value.file : null,
+    progress:
+      typeof value.progress === "number" && Number.isFinite(value.progress)
+        ? value.progress
+        : null,
+  };
+}
+
+export class BrowserPhonemeRecognizer {
+  private readonly worker: Worker;
+  private readonly pending = new Map<number, PendingRequest>();
+  private requestId = 0;
+
+  constructor(onEvent?: (event: PhonemeWorkerEvent) => void) {
+    this.worker = new Worker("/workers/pronunciation-phoneme-worker.mjs", {
+      type: "module",
+      name: "atoenglish-pronunciation-phoneme",
+    });
+
+    this.worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+      const message = event.data;
+      if (!isWorkerMessage(message) || typeof message.type !== "string") return;
+
+      if (message.type === "progress") {
+        const progress = parseProgress(message.progress);
+        if (progress) onEvent?.({ type: "progress", progress });
+        return;
+      }
+
+      if (message.type === "runtime") {
+        const runtime = parseRuntime(message.runtime);
+        const state = message.state;
+
+        if (
+          runtime &&
+          (state === "loading" || state === "ready" || state === "fallback")
+        ) {
+          onEvent?.({
+            type: "runtime",
+            state,
+            runtime,
+            message: typeof message.message === "string" ? message.message : null,
+          });
+        }
+        return;
+      }
+
+      const id = message.id;
+      if (typeof id !== "number") return;
+
+      const request = this.pending.get(id);
+      if (!request) return;
+
+      if (message.type === "result") {
+        const runtime = parseRuntime(message.runtime);
+        const text = message.text;
+
+        if (!runtime || typeof text !== "string") {
+          this.pending.delete(id);
+          request.reject(new Error("invalid_phoneme_worker_result"));
+          return;
+        }
+
+        this.pending.delete(id);
+        request.resolve({ text, runtime });
+        return;
+      }
+
+      if (message.type === "error") {
+        this.pending.delete(id);
+        request.reject(
+          new Error(
+            typeof message.message === "string"
+              ? message.message
+              : "phoneme_worker_error",
+          ),
+        );
+      }
+    });
+
+    this.worker.addEventListener("error", () => {
+      const error = new Error("phoneme_worker_crashed");
+
+      for (const request of this.pending.values()) {
+        request.reject(error);
+      }
+
+      this.pending.clear();
+    });
+  }
+
+  recognize(samples: Float32Array) {
+    if (samples.length === 0) {
+      return Promise.reject(new Error("empty_phoneme_audio"));
+    }
+
+    const id = ++this.requestId;
+
+    return new Promise<PhonemeRecognitionResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage({
+        type: "recognize",
+        id,
+        sampleRate: 16_000,
+        samples,
+      });
+    });
+  }
+
+  terminate() {
+    this.worker.terminate();
+
+    const error = new Error("phoneme_worker_terminated");
+    for (const request of this.pending.values()) {
+      request.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/features/pronunciation-free/phoneme-worker-client.ts
+++ b/src/features/pronunciation-free/phoneme-worker-client.ts
@@ -1,4 +1,6 @@
 import type {
+  LocalCtcPosteriorSummary,
+  LocalObservedPhone,
   LocalPhonemeRuntime,
   PhonemeWorkerProgress,
 } from "./types";
@@ -17,6 +19,8 @@ export type PhonemeWorkerEvent =
 
 export type PhonemeRecognitionResult = {
   text: string;
+  observations: LocalObservedPhone[];
+  posterior: LocalCtcPosteriorSummary;
   runtime: LocalPhonemeRuntime;
 };
 
@@ -59,6 +63,111 @@ function parseProgress(value: unknown): PhonemeWorkerProgress | null {
       typeof value.progress === "number" && Number.isFinite(value.progress)
         ? value.progress
         : null,
+  };
+}
+
+function finiteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function unitNumber(value: unknown) {
+  const number = finiteNumber(value);
+  return number !== null && number >= 0 && number <= 1 ? number : null;
+}
+
+function nonNegativeNumber(value: unknown) {
+  const number = finiteNumber(value);
+  return number !== null && number >= 0 ? number : null;
+}
+
+function positiveInteger(value: unknown) {
+  const number = finiteNumber(value);
+  return number !== null && Number.isInteger(number) && number > 0
+    ? number
+    : null;
+}
+
+function nonNegativeInteger(value: unknown) {
+  const number = finiteNumber(value);
+  return number !== null && Number.isInteger(number) && number >= 0
+    ? number
+    : null;
+}
+
+function parseObservation(value: unknown): LocalObservedPhone | null {
+  if (!isWorkerMessage(value) || !Array.isArray(value.candidates)) return null;
+
+  const startMs = nonNegativeNumber(value.startMs);
+  const endMs = nonNegativeNumber(value.endMs);
+  if (startMs === null || endMs === null || endMs <= startMs) return null;
+
+  const candidates = value.candidates
+    .map((candidate) => {
+      if (!isWorkerMessage(candidate) || typeof candidate.phone !== "string") {
+        return null;
+      }
+      const phone = candidate.phone.normalize("NFC").trim();
+      const probability = unitNumber(candidate.probability);
+      if (!phone || probability === null) return null;
+      return { phone, probability };
+    })
+    .filter(
+      (candidate): candidate is { phone: string; probability: number } =>
+        candidate !== null,
+    );
+
+  if (candidates.length === 0 || candidates.length > 32) return null;
+
+  const probabilityMass = candidates.reduce(
+    (sum, candidate) => sum + candidate.probability,
+    0,
+  );
+  if (probabilityMass > 1.001) return null;
+
+  return {
+    candidates,
+    startMs,
+    endMs,
+    source: typeof value.source === "string" ? value.source : null,
+  };
+}
+
+function parsePosterior(value: unknown): LocalCtcPosteriorSummary | null {
+  if (!isWorkerMessage(value)) return null;
+
+  const frameCount = positiveInteger(value.frameCount);
+  const vocabularySize = positiveInteger(value.vocabularySize);
+  const blankTokenId = nonNegativeInteger(value.blankTokenId);
+  const meanEntropy = nonNegativeNumber(value.meanEntropy);
+  const normalizedMeanEntropy = unitNumber(value.normalizedMeanEntropy);
+  const meanPeakPosterior = unitNumber(value.meanPeakPosterior);
+  const meanTop2Margin = unitNumber(value.meanTop2Margin);
+  const meanBlankPosterior =
+    value.meanBlankPosterior === null ? null : unitNumber(value.meanBlankPosterior);
+
+  if (
+    frameCount === null ||
+    vocabularySize === null ||
+    blankTokenId === null ||
+    blankTokenId >= vocabularySize ||
+    meanEntropy === null ||
+    normalizedMeanEntropy === null ||
+    meanPeakPosterior === null ||
+    meanTop2Margin === null ||
+    meanBlankPosterior === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    frameCount,
+    vocabularySize,
+    blankTokenId,
+    meanEntropy,
+    normalizedMeanEntropy,
+    meanPeakPosterior,
+    meanTop2Margin,
+    meanBlankPosterior,
   };
 }
 
@@ -110,15 +219,29 @@ export class BrowserPhonemeRecognizer {
       if (message.type === "result") {
         const runtime = parseRuntime(message.runtime);
         const text = message.text;
+        const observations = Array.isArray(message.observations)
+          ? message.observations
+              .map(parseObservation)
+              .filter(
+                (observation): observation is LocalObservedPhone =>
+                  observation !== null,
+              )
+          : [];
+        const posterior = parsePosterior(message.posterior);
 
-        if (!runtime || typeof text !== "string") {
+        if (
+          !runtime ||
+          typeof text !== "string" ||
+          observations.length === 0 ||
+          !posterior
+        ) {
           this.pending.delete(id);
           request.reject(new Error("invalid_phoneme_worker_result"));
           return;
         }
 
         this.pending.delete(id);
-        request.resolve({ text, runtime });
+        request.resolve({ text, observations, posterior, runtime });
         return;
       }
 

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -14,7 +14,7 @@ export type PhoneAlignment = {
 
 export type LocalPhonemeRuntime = {
   device: "webgpu" | "wasm";
-  dtype: "q4f16" | "q4";
+  dtype: "q4f16" | "q8";
 };
 
 export type LocalPhonemeObservation = {

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -1,0 +1,40 @@
+export type PronunciationSensorCalibration = "unvalidated";
+
+export type PhoneAlignmentKind =
+  | "match"
+  | "substitution"
+  | "deletion"
+  | "insertion";
+
+export type PhoneAlignment = {
+  kind: PhoneAlignmentKind;
+  expected: string | null;
+  observed: string | null;
+};
+
+export type LocalPhonemeRuntime = {
+  device: "webgpu" | "wasm";
+  dtype: "q4f16" | "q4";
+};
+
+export type LocalPhonemeObservation = {
+  calibration: PronunciationSensorCalibration;
+  model: {
+    id: string;
+    revision: string;
+    runtime: LocalPhonemeRuntime;
+  };
+  target: {
+    word: string;
+    ipa: string;
+  };
+  expectedPhones: string[];
+  observedPhones: string[];
+  alignment: PhoneAlignment[];
+};
+
+export type PhonemeWorkerProgress = {
+  status: string;
+  file: string | null;
+  progress: number | null;
+};

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -17,6 +17,30 @@ export type LocalPhonemeRuntime = {
   dtype: "q4f16" | "q8";
 };
 
+export type LocalPhoneCandidate = {
+  phone: string;
+  /** Real posterior probability from the CTC model; top-k is not renormalized. */
+  probability: number;
+};
+
+export type LocalObservedPhone = {
+  candidates: LocalPhoneCandidate[];
+  startMs: number;
+  endMs: number;
+  source: string | null;
+};
+
+export type LocalCtcPosteriorSummary = {
+  frameCount: number;
+  vocabularySize: number;
+  blankTokenId: number;
+  meanEntropy: number;
+  normalizedMeanEntropy: number;
+  meanPeakPosterior: number;
+  meanTop2Margin: number;
+  meanBlankPosterior: number | null;
+};
+
 export type LocalPhonemeObservation = {
   calibration: PronunciationSensorCalibration;
   model: {
@@ -30,6 +54,9 @@ export type LocalPhonemeObservation = {
   };
   expectedPhones: string[];
   observedPhones: string[];
+  /** Top-k CTC segment evidence with original posterior mass preserved. */
+  phoneEvidence: LocalObservedPhone[];
+  posterior: LocalCtcPosteriorSummary;
   alignment: PhoneAlignment[];
 };
 

--- a/src/features/pronunciation-free/types.ts
+++ b/src/features/pronunciation-free/types.ts
@@ -54,9 +54,12 @@ export type LocalPhonemeObservation = {
   };
   expectedPhones: string[];
   observedPhones: string[];
-  /** Top-k CTC segment evidence with original posterior mass preserved. */
-  phoneEvidence: LocalObservedPhone[];
-  posterior: LocalCtcPosteriorSummary;
+  /**
+   * V2 CTC evidence. Optional only while the old top-1 preview is being
+   * replaced; BrowserPhonemeRecognizer itself requires these fields.
+   */
+  phoneEvidence?: LocalObservedPhone[];
+  posterior?: LocalCtcPosteriorSummary;
   alignment: PhoneAlignment[];
 };
 

--- a/src/lib/pronunciation-engine/alignment-probability.test.ts
+++ b/src/lib/pronunciation-engine/alignment-probability.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { alignCanonicalPronunciation } from "./alignment";
+
+describe("pronunciation-engine posterior mass handling", () => {
+  it("preserves real top-k probabilities instead of renormalizing them", () => {
+    const result = alignCanonicalPronunciation(
+      { id: "theta", phones: ["θ"] },
+      [
+        {
+          candidates: [
+            { phone: "θ", probability: 0.4 },
+            { phone: "s", probability: 0.3 },
+          ],
+        },
+      ],
+    );
+
+    expect(result.alignment[0]?.observedProbability).toBeCloseTo(0.4, 10);
+    expect(result.alignment[0]?.posteriorMargin).toBeCloseTo(0.1, 10);
+  });
+
+  it("penalizes omitted posterior mass conservatively", () => {
+    const complete = alignCanonicalPronunciation(
+      { id: "theta", phones: ["θ"] },
+      [
+        {
+          candidates: [
+            { phone: "θ", probability: 0.7 },
+            { phone: "s", probability: 0.3 },
+          ],
+        },
+      ],
+    );
+
+    const truncated = alignCanonicalPronunciation(
+      { id: "theta", phones: ["θ"] },
+      [
+        {
+          candidates: [
+            { phone: "θ", probability: 0.4 },
+            { phone: "s", probability: 0.3 },
+          ],
+        },
+      ],
+    );
+
+    expect(truncated.normalizedCost).toBeGreaterThan(complete.normalizedCost);
+  });
+
+  it("rejects impossible probability mass", () => {
+    expect(() =>
+      alignCanonicalPronunciation(
+        { id: "theta", phones: ["θ"] },
+        [
+          {
+            candidates: [
+              { phone: "θ", probability: 0.8 },
+              { phone: "s", probability: 0.5 },
+            ],
+          },
+        ],
+      ),
+    ).toThrow("phone_observation_probability_mass_exceeds_one");
+  });
+});

--- a/src/lib/pronunciation-engine/alignment.test.ts
+++ b/src/lib/pronunciation-engine/alignment.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  alignCanonicalPronunciation,
+  selectBestCanonicalPronunciation,
+} from "./alignment";
+import { deriveUncalibratedSegmentalEvidence } from "./evidence";
+import type { CanonicalPronunciation, ObservedPhone } from "./types";
+
+function top1(phone: string): ObservedPhone {
+  return { candidates: [{ phone, probability: null }] };
+}
+
+const THINK: CanonicalPronunciation = {
+  id: "think-general",
+  phones: ["θ", "ɪ", "ŋ", "k"],
+};
+
+describe("pronunciation-engine alignment", () => {
+  it("aligns an exact production at zero cost", () => {
+    const result = alignCanonicalPronunciation(THINK, [
+      top1("θ"),
+      top1("ɪ"),
+      top1("ŋ"),
+      top1("k"),
+    ]);
+
+    expect(result.normalizedCost).toBe(0);
+    expect(result.alignment.map((item) => item.kind)).toEqual([
+      "match",
+      "match",
+      "match",
+      "match",
+    ]);
+  });
+
+  it("diagnoses a deliberate theta-to-s substitution", () => {
+    const result = alignCanonicalPronunciation(THINK, [
+      top1("s"),
+      top1("ɪ"),
+      top1("ŋ"),
+      top1("k"),
+    ]);
+
+    expect(result.alignment[0]).toMatchObject({
+      kind: "substitution",
+      expected: "θ",
+      observed: "s",
+      observedProbability: null,
+      posteriorMargin: null,
+      articulatoryDelta: {
+        place: { expected: "dental", observed: "alveolar" },
+      },
+    });
+
+    expect(result.alignment.slice(1).every((item) => item.kind === "match")).toBe(
+      true,
+    );
+  });
+
+  it("uses the full candidate distribution instead of only top-1", () => {
+    const expected: CanonicalPronunciation = {
+      id: "theta",
+      phones: ["θ"],
+    };
+
+    const mostlyTheta = alignCanonicalPronunciation(expected, [
+      {
+        candidates: [
+          { phone: "θ", probability: 0.7 },
+          { phone: "s", probability: 0.3 },
+        ],
+      },
+    ]);
+
+    const mostlyS = alignCanonicalPronunciation(expected, [
+      {
+        candidates: [
+          { phone: "s", probability: 0.7 },
+          { phone: "θ", probability: 0.3 },
+        ],
+      },
+    ]);
+
+    expect(mostlyTheta.normalizedCost).toBeLessThan(mostlyS.normalizedCost);
+    expect(mostlyTheta.alignment[0]?.observedProbability).toBeCloseTo(0.7);
+    expect(mostlyTheta.alignment[0]?.posteriorMargin).toBeCloseTo(0.4);
+  });
+
+  it("does not invent probabilities for rank-only sensor candidates", () => {
+    const result = alignCanonicalPronunciation(
+      { id: "theta", phones: ["θ"] },
+      [
+        {
+          candidates: [
+            { phone: "s", probability: null },
+            { phone: "θ", probability: null },
+          ],
+        },
+      ],
+    );
+
+    expect(result.alignment[0]?.observed).toBe("s");
+    expect(result.alignment[0]?.observedProbability).toBeNull();
+    expect(result.alignment[0]?.posteriorMargin).toBeNull();
+  });
+
+  it("keeps deletion and insertion as distinct error types", () => {
+    const missingFinal = alignCanonicalPronunciation(THINK, [
+      top1("θ"),
+      top1("ɪ"),
+      top1("ŋ"),
+    ]);
+
+    expect(missingFinal.alignment.at(-1)).toMatchObject({
+      kind: "deletion",
+      expected: "k",
+      observed: null,
+    });
+
+    const epenthesis = alignCanonicalPronunciation(
+      { id: "stop", phones: ["s", "t", "ɒ", "p"] },
+      [top1("s"), top1("t"), top1("ɒ"), top1("p"), top1("ə")],
+    );
+
+    expect(epenthesis.alignment.at(-1)).toMatchObject({
+      kind: "insertion",
+      expected: null,
+      observed: "ə",
+    });
+  });
+
+  it("selects the canonical variant best supported by the observation", () => {
+    const result = selectBestCanonicalPronunciation(
+      [
+        { id: "goat-us", phones: ["g", "oʊ", "t"] },
+        { id: "goat-uk", phones: ["g", "əʊ", "t"] },
+      ],
+      [top1("g"), top1("oʊ"), top1("t")],
+    );
+
+    expect(result.pronunciationId).toBe("goat-us");
+    expect(result.normalizedCost).toBe(0);
+  });
+
+  it("derives research evidence without turning it into a validated score", () => {
+    const result = alignCanonicalPronunciation(THINK, [
+      top1("s"),
+      top1("ɪ"),
+      top1("ŋ"),
+    ]);
+    const evidence = deriveUncalibratedSegmentalEvidence(result);
+
+    expect(evidence.calibration).toBe("unvalidated");
+    expect(evidence.substitutionCount).toBe(1);
+    expect(evidence.deletionCount).toBe(1);
+    expect(evidence.insertionCount).toBe(0);
+    expect(evidence.rawCompletenessSignal).toBeCloseTo(0.75);
+    expect(evidence.rawAccuracySignal).toBeGreaterThanOrEqual(0);
+    expect(evidence.rawAccuracySignal).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/lib/pronunciation-engine/alignment.ts
+++ b/src/lib/pronunciation-engine/alignment.ts
@@ -1,0 +1,340 @@
+import {
+  articulatoryDeltaForPhones,
+  normalizeEnglishPhone,
+  phonologicalDistance,
+} from "./phonology";
+import type {
+  CanonicalPronunciation,
+  ObservedPhone,
+  PhoneAlignmentEvidence,
+  PhoneCandidate,
+  PronunciationAlignmentResult,
+} from "./types";
+
+const DEFAULT_DELETION_COST = 0.95;
+const DEFAULT_INSERTION_COST = 0.9;
+const COST_EPSILON = 1e-9;
+
+type WeightedCandidate = {
+  phone: string;
+  weight: number;
+  probability: number | null;
+};
+
+type CandidateView = {
+  weighted: WeightedCandidate[];
+  topPhone: string;
+  topProbability: number | null;
+  posteriorMargin: number | null;
+};
+
+type AlignmentOptions = {
+  deletionCost?: number;
+  insertionCost?: number;
+};
+
+type TraceOperation = "diagonal" | "deletion" | "insertion" | null;
+
+type MatrixCell = {
+  cost: number;
+  operation: TraceOperation;
+};
+
+function clampUnit(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): CandidateView {
+  const cleaned = candidates
+    .map((candidate) => ({
+      phone: normalizeEnglishPhone(candidate.phone),
+      probability:
+        candidate.probability !== null &&
+        Number.isFinite(candidate.probability) &&
+        candidate.probability >= 0 &&
+        candidate.probability <= 1
+          ? candidate.probability
+          : null,
+    }))
+    .filter((candidate) => candidate.phone.length > 0);
+
+  if (cleaned.length === 0) {
+    throw new Error("phone_observation_has_no_candidates");
+  }
+
+  const hasCompleteProbabilityDistribution = cleaned.every(
+    (candidate) => candidate.probability !== null,
+  );
+
+  if (hasCompleteProbabilityDistribution) {
+    const merged = new Map<string, number>();
+
+    for (const candidate of cleaned) {
+      merged.set(
+        candidate.phone,
+        (merged.get(candidate.phone) ?? 0) + (candidate.probability ?? 0),
+      );
+    }
+
+    const total = [...merged.values()].reduce((sum, value) => sum + value, 0);
+
+    if (total > 0) {
+      const ranked = [...merged.entries()]
+        .map(([phone, probability]) => ({
+          phone,
+          probability: probability / total,
+        }))
+        .sort((left, right) => right.probability - left.probability);
+
+      const first = ranked[0];
+      if (!first) throw new Error("phone_observation_has_no_candidates");
+
+      const second = ranked[1];
+
+      return {
+        weighted: ranked.map((candidate) => ({
+          phone: candidate.phone,
+          weight: candidate.probability,
+          probability: candidate.probability,
+        })),
+        topPhone: first.phone,
+        topProbability: first.probability,
+        posteriorMargin: clampUnit(
+          first.probability - (second?.probability ?? 0),
+        ),
+      };
+    }
+  }
+
+  // Rank-only sensors are still useful evidence, but these weights are an
+  // internal alignment prior. They are never surfaced as probabilities.
+  const deduplicated: string[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of cleaned) {
+    if (!seen.has(candidate.phone)) {
+      seen.add(candidate.phone);
+      deduplicated.push(candidate.phone);
+    }
+  }
+
+  const rawWeights = deduplicated.map((_, index) => Math.pow(0.55, index));
+  const totalWeight = rawWeights.reduce((sum, value) => sum + value, 0);
+  const topPhone = deduplicated[0];
+
+  if (!topPhone) throw new Error("phone_observation_has_no_candidates");
+
+  return {
+    weighted: deduplicated.map((phone, index) => ({
+      phone,
+      weight: rawWeights[index] / totalWeight,
+      probability: null,
+    })),
+    topPhone,
+    topProbability: null,
+    posteriorMargin: null,
+  };
+}
+
+function substitutionEvidence(expected: string, observed: ObservedPhone) {
+  const candidates = normalizePhoneCandidates(observed.candidates);
+  const cost = candidates.weighted.reduce(
+    (sum, candidate) =>
+      sum + candidate.weight * phonologicalDistance(expected, candidate.phone),
+    0,
+  );
+
+  return {
+    cost: clampUnit(cost),
+    topPhone: candidates.topPhone,
+    topProbability: candidates.topProbability,
+    posteriorMargin: candidates.posteriorMargin,
+  };
+}
+
+function insertionEvidence(observed: ObservedPhone, cost: number): PhoneAlignmentEvidence {
+  const candidates = normalizePhoneCandidates(observed.candidates);
+
+  return {
+    kind: "insertion",
+    expected: null,
+    observed: candidates.topPhone,
+    cost,
+    observedProbability: candidates.topProbability,
+    posteriorMargin: candidates.posteriorMargin,
+    articulatoryDelta: null,
+  };
+}
+
+function chooseOperation(
+  diagonal: number,
+  deletion: number,
+  insertion: number,
+): MatrixCell {
+  const minimum = Math.min(diagonal, deletion, insertion);
+
+  // Prefer a direct acoustic/phonological comparison on ties. This avoids a
+  // substitution being represented as a deletion+insertion pair when both
+  // explanations have effectively identical cost.
+  if (Math.abs(diagonal - minimum) <= COST_EPSILON) {
+    return { cost: diagonal, operation: "diagonal" };
+  }
+
+  if (Math.abs(deletion - minimum) <= COST_EPSILON) {
+    return { cost: deletion, operation: "deletion" };
+  }
+
+  return { cost: insertion, operation: "insertion" };
+}
+
+export function alignCanonicalPronunciation(
+  pronunciation: CanonicalPronunciation,
+  observations: readonly ObservedPhone[],
+  options: AlignmentOptions = {},
+): PronunciationAlignmentResult {
+  const deletionCost = clampUnit(options.deletionCost ?? DEFAULT_DELETION_COST);
+  const insertionCost = clampUnit(options.insertionCost ?? DEFAULT_INSERTION_COST);
+  const expectedPhones = pronunciation.phones.map(normalizeEnglishPhone);
+
+  const rows = expectedPhones.length + 1;
+  const columns = observations.length + 1;
+  const matrix: MatrixCell[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: columns }, () => ({ cost: 0, operation: null })),
+  );
+
+  for (let row = 1; row < rows; row += 1) {
+    matrix[row][0] = {
+      cost: matrix[row - 1][0].cost + deletionCost,
+      operation: "deletion",
+    };
+  }
+
+  for (let column = 1; column < columns; column += 1) {
+    matrix[0][column] = {
+      cost: matrix[0][column - 1].cost + insertionCost,
+      operation: "insertion",
+    };
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let column = 1; column < columns; column += 1) {
+      const expected = expectedPhones[row - 1];
+      const observed = observations[column - 1];
+
+      if (!expected || !observed) {
+        throw new Error("invalid_alignment_matrix_state");
+      }
+
+      const substitution = substitutionEvidence(expected, observed);
+      const diagonal =
+        matrix[row - 1][column - 1].cost + substitution.cost;
+      const deletion = matrix[row - 1][column].cost + deletionCost;
+      const insertion = matrix[row][column - 1].cost + insertionCost;
+
+      matrix[row][column] = chooseOperation(diagonal, deletion, insertion);
+    }
+  }
+
+  const alignment: PhoneAlignmentEvidence[] = [];
+  let row = expectedPhones.length;
+  let column = observations.length;
+
+  while (row > 0 || column > 0) {
+    const cell = matrix[row][column];
+
+    if (cell.operation === "diagonal" && row > 0 && column > 0) {
+      const expected = expectedPhones[row - 1];
+      const observed = observations[column - 1];
+
+      if (!expected || !observed) {
+        throw new Error("invalid_alignment_backtrace_state");
+      }
+
+      const evidence = substitutionEvidence(expected, observed);
+      const normalizedObserved = normalizeEnglishPhone(evidence.topPhone);
+      const isMatch = normalizeEnglishPhone(expected) === normalizedObserved;
+
+      alignment.push({
+        kind: isMatch ? "match" : "substitution",
+        expected,
+        observed: normalizedObserved,
+        cost: evidence.cost,
+        observedProbability: evidence.topProbability,
+        posteriorMargin: evidence.posteriorMargin,
+        articulatoryDelta: isMatch
+          ? null
+          : articulatoryDeltaForPhones(expected, normalizedObserved),
+      });
+
+      row -= 1;
+      column -= 1;
+      continue;
+    }
+
+    if (cell.operation === "deletion" && row > 0) {
+      alignment.push({
+        kind: "deletion",
+        expected: expectedPhones[row - 1] ?? null,
+        observed: null,
+        cost: deletionCost,
+        observedProbability: null,
+        posteriorMargin: null,
+        articulatoryDelta: null,
+      });
+      row -= 1;
+      continue;
+    }
+
+    if (cell.operation === "insertion" && column > 0) {
+      const observed = observations[column - 1];
+      if (!observed) throw new Error("invalid_alignment_backtrace_state");
+      alignment.push(insertionEvidence(observed, insertionCost));
+      column -= 1;
+      continue;
+    }
+
+    throw new Error("alignment_backtrace_failed");
+  }
+
+  alignment.reverse();
+
+  const totalCost = matrix[expectedPhones.length][observations.length].cost;
+  const normalizationLength = Math.max(expectedPhones.length, observations.length, 1);
+
+  return {
+    pronunciationId: pronunciation.id,
+    totalCost,
+    normalizedCost: clampUnit(totalCost / normalizationLength),
+    alignment,
+  };
+}
+
+export function selectBestCanonicalPronunciation(
+  pronunciations: readonly CanonicalPronunciation[],
+  observations: readonly ObservedPhone[],
+  options: AlignmentOptions = {},
+) {
+  if (pronunciations.length === 0) {
+    throw new Error("canonical_pronunciation_required");
+  }
+
+  let best: PronunciationAlignmentResult | null = null;
+
+  for (const pronunciation of pronunciations) {
+    const result = alignCanonicalPronunciation(
+      pronunciation,
+      observations,
+      options,
+    );
+
+    if (
+      !best ||
+      result.normalizedCost < best.normalizedCost - COST_EPSILON
+    ) {
+      best = result;
+    }
+  }
+
+  if (!best) throw new Error("canonical_pronunciation_required");
+  return best;
+}

--- a/src/lib/pronunciation-engine/alignment.ts
+++ b/src/lib/pronunciation-engine/alignment.ts
@@ -14,10 +14,13 @@ import type {
 const DEFAULT_DELETION_COST = 0.95;
 const DEFAULT_INSERTION_COST = 0.9;
 const COST_EPSILON = 1e-9;
+const PROBABILITY_MASS_EPSILON = 1e-3;
 
 type WeightedCandidate = {
   phone: string;
+  /** Weight used by the alignment expectation. */
   weight: number;
+  /** Original sensor probability. Never renormalized for learner evidence. */
   probability: number | null;
 };
 
@@ -26,6 +29,8 @@ type CandidateView = {
   topPhone: string;
   topProbability: number | null;
   posteriorMargin: number | null;
+  /** Sum of probability mass actually supplied by the sensor. */
+  capturedProbabilityMass: number | null;
 };
 
 type AlignmentOptions = {
@@ -62,11 +67,11 @@ function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): Candid
     throw new Error("phone_observation_has_no_candidates");
   }
 
-  const hasCompleteProbabilityDistribution = cleaned.every(
+  const hasProbabilities = cleaned.every(
     (candidate) => candidate.probability !== null,
   );
 
-  if (hasCompleteProbabilityDistribution) {
+  if (hasProbabilities) {
     const merged = new Map<string, number>();
 
     for (const candidate of cleaned) {
@@ -78,12 +83,13 @@ function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): Candid
 
     const total = [...merged.values()].reduce((sum, value) => sum + value, 0);
 
+    if (total > 1 + PROBABILITY_MASS_EPSILON) {
+      throw new Error("phone_observation_probability_mass_exceeds_one");
+    }
+
     if (total > 0) {
       const ranked = [...merged.entries()]
-        .map(([phone, probability]) => ({
-          phone,
-          probability: probability / total,
-        }))
+        .map(([phone, probability]) => ({ phone, probability }))
         .sort((left, right) => right.probability - left.probability);
 
       const first = ranked[0];
@@ -92,6 +98,9 @@ function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): Candid
       const second = ranked[1];
 
       return {
+        // The weights intentionally preserve the original probability mass.
+        // If a worker returns top-k only, omitted mass is handled conservatively
+        // in substitutionEvidence instead of being silently renormalized to 1.
         weighted: ranked.map((candidate) => ({
           phone: candidate.phone,
           weight: candidate.probability,
@@ -102,6 +111,7 @@ function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): Candid
         posteriorMargin: clampUnit(
           first.probability - (second?.probability ?? 0),
         ),
+        capturedProbabilityMass: clampUnit(total),
       };
     }
   }
@@ -133,16 +143,28 @@ function normalizePhoneCandidates(candidates: readonly PhoneCandidate[]): Candid
     topPhone,
     topProbability: null,
     posteriorMargin: null,
+    capturedProbabilityMass: null,
   };
 }
 
 function substitutionEvidence(expected: string, observed: ObservedPhone) {
   const candidates = normalizePhoneCandidates(observed.candidates);
-  const cost = candidates.weighted.reduce(
+  const knownCost = candidates.weighted.reduce(
     (sum, candidate) =>
       sum + candidate.weight * phonologicalDistance(expected, candidate.phone),
     0,
   );
+
+  // For top-k posterior evidence, unknown tail mass must not disappear. A
+  // conservative unit-distance tail prevents a truncated list such as 0.4/0.3
+  // from masquerading as a complete 57%/43% distribution. Full distributions
+  // have captured mass 1 and therefore no tail penalty. Rank-only observations
+  // keep their internal normalized heuristic weights and expose no probability.
+  const omittedProbabilityMass =
+    candidates.capturedProbabilityMass === null
+      ? 0
+      : 1 - candidates.capturedProbabilityMass;
+  const cost = knownCost + omittedProbabilityMass;
 
   return {
     cost: clampUnit(cost),

--- a/src/lib/pronunciation-engine/assessment.test.ts
+++ b/src/lib/pronunciation-engine/assessment.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { alignCanonicalPronunciation } from "./alignment";
+import { composeUnvalidatedPronunciationAssessment } from "./assessment";
+import { deriveUncalibratedSegmentalEvidence } from "./evidence";
+import { analyzeSignalQuality } from "./signal";
+
+function sineWave(durationSeconds = 0.5, sampleRate = 16_000) {
+  const samples = new Float32Array(Math.round(durationSeconds * sampleRate));
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] =
+      0.2 * Math.sin((2 * Math.PI * 200 * index) / sampleRate);
+  }
+  return samples;
+}
+
+function segmentalWithThetaCandidates(
+  thetaProbability: number | null,
+  sProbability: number | null,
+) {
+  const alignment = alignCanonicalPronunciation(
+    { id: "think", phones: ["θ", "ɪ", "ŋ", "k"] },
+    [
+      {
+        candidates: [
+          { phone: "θ", probability: thetaProbability },
+          { phone: "s", probability: sProbability },
+        ],
+      },
+      { candidates: [{ phone: "ɪ", probability: thetaProbability === null ? null : 1 }] },
+      { candidates: [{ phone: "ŋ", probability: thetaProbability === null ? null : 1 }] },
+      { candidates: [{ phone: "k", probability: thetaProbability === null ? null : 1 }] },
+    ],
+  );
+
+  return deriveUncalibratedSegmentalEvidence(alignment);
+}
+
+describe("pronunciation-engine assessment composition", () => {
+  it("keeps all learner-facing numeric scores null while unvalidated", () => {
+    const assessment = composeUnvalidatedPronunciationAssessment({
+      signalQuality: analyzeSignalQuality(sineWave(), 16_000),
+      segmental: segmentalWithThetaCandidates(0.8, 0.2),
+    });
+
+    expect(assessment.calibration).toBe("unvalidated");
+    expect(assessment.decision).toBe("evidence");
+    expect(assessment.scores).toEqual({
+      pronunciation: null,
+      completeness: null,
+      stress: null,
+      fluency: null,
+      prosody: null,
+      total: null,
+    });
+  });
+
+  it("abstains when the signal-quality gate fails", () => {
+    const assessment = composeUnvalidatedPronunciationAssessment({
+      signalQuality: analyzeSignalQuality(new Float32Array(8_000), 16_000),
+      segmental: segmentalWithThetaCandidates(0.8, 0.2),
+    });
+
+    expect(assessment.decision).toBe("abstain");
+    expect(assessment.uncertainty.reasons).toContain("signal_quality");
+  });
+
+  it("records rank-only model output as uncertain without inventing a probability", () => {
+    const assessment = composeUnvalidatedPronunciationAssessment({
+      signalQuality: analyzeSignalQuality(sineWave(), 16_000),
+      segmental: segmentalWithThetaCandidates(null, null),
+    });
+
+    expect(assessment.decision).toBe("evidence");
+    expect(assessment.uncertainty.meanPosteriorMargin).toBeNull();
+    expect(assessment.uncertainty.reasons).toContain(
+      "sensor_probabilities_unavailable",
+    );
+  });
+
+  it("can abstain on a weak calibrated posterior margin when an experiment supplies a threshold", () => {
+    const assessment = composeUnvalidatedPronunciationAssessment(
+      {
+        signalQuality: analyzeSignalQuality(sineWave(), 16_000),
+        segmental: segmentalWithThetaCandidates(0.55, 0.45),
+      },
+      { minPosteriorMargin: 0.2 },
+    );
+
+    expect(assessment.decision).toBe("abstain");
+    expect(assessment.uncertainty.reasons).toContain("weak_sensor_margin");
+  });
+});

--- a/src/lib/pronunciation-engine/assessment.ts
+++ b/src/lib/pronunciation-engine/assessment.ts
@@ -19,6 +19,7 @@ export type UnvalidatedPronunciationAssessment = {
   uncertainty: {
     reasons: PronunciationUncertaintyReason[];
     meanPosteriorMargin: number | null;
+    minimumPosteriorMargin: number | null;
   };
   /**
    * Numeric learner-facing scores stay null until a human-rated calibration
@@ -36,8 +37,9 @@ export type UnvalidatedPronunciationAssessment = {
 
 export type UnvalidatedAssessmentOptions = {
   /**
-   * Optional research threshold. Leave null until a sensor has calibrated
-   * probabilities and a validation split establishes a useful operating point.
+   * Optional research threshold applied to the weakest observed phone margin.
+   * Leave null until a sensor has calibrated probabilities and a validation
+   * split establishes a useful operating point.
    */
   minPosteriorMargin?: number | null;
 };
@@ -46,7 +48,7 @@ export type UnvalidatedAssessmentOptions = {
  * Composes independent evidence streams without pretending they are already a
  * calibrated pronunciation score. Signal-quality failure forces abstention;
  * model uncertainty is exposed explicitly and can also trigger abstention when
- * a validated margin threshold is supplied by an experiment.
+ * a validated weakest-phone margin threshold is supplied by an experiment.
  */
 export function composeUnvalidatedPronunciationAssessment(
   input: {
@@ -67,8 +69,8 @@ export function composeUnvalidatedPronunciationAssessment(
   const minPosteriorMargin = options.minPosteriorMargin ?? null;
   if (
     minPosteriorMargin !== null &&
-    input.segmental.meanPosteriorMargin !== null &&
-    input.segmental.meanPosteriorMargin < minPosteriorMargin
+    input.segmental.minimumPosteriorMargin !== null &&
+    input.segmental.minimumPosteriorMargin < minPosteriorMargin
   ) {
     reasons.push("weak_sensor_margin");
   }
@@ -86,6 +88,7 @@ export function composeUnvalidatedPronunciationAssessment(
     uncertainty: {
       reasons,
       meanPosteriorMargin: input.segmental.meanPosteriorMargin,
+      minimumPosteriorMargin: input.segmental.minimumPosteriorMargin,
     },
     scores: {
       pronunciation: null,

--- a/src/lib/pronunciation-engine/assessment.ts
+++ b/src/lib/pronunciation-engine/assessment.ts
@@ -1,0 +1,99 @@
+import type { ProsodySummary } from "./prosody";
+import type { SignalQualityEvidence } from "./signal";
+import type {
+  PronunciationDecision,
+  UncalibratedSegmentalEvidence,
+} from "./types";
+
+export type PronunciationUncertaintyReason =
+  | "signal_quality"
+  | "sensor_probabilities_unavailable"
+  | "weak_sensor_margin";
+
+export type UnvalidatedPronunciationAssessment = {
+  calibration: "unvalidated";
+  decision: Extract<PronunciationDecision, "evidence" | "abstain">;
+  signalQuality: SignalQualityEvidence;
+  segmental: UncalibratedSegmentalEvidence;
+  prosody: ProsodySummary | null;
+  uncertainty: {
+    reasons: PronunciationUncertaintyReason[];
+    meanPosteriorMargin: number | null;
+  };
+  /**
+   * Numeric learner-facing scores stay null until a human-rated calibration
+   * protocol validates each aspect independently.
+   */
+  scores: {
+    pronunciation: null;
+    completeness: null;
+    stress: null;
+    fluency: null;
+    prosody: null;
+    total: null;
+  };
+};
+
+export type UnvalidatedAssessmentOptions = {
+  /**
+   * Optional research threshold. Leave null until a sensor has calibrated
+   * probabilities and a validation split establishes a useful operating point.
+   */
+  minPosteriorMargin?: number | null;
+};
+
+/**
+ * Composes independent evidence streams without pretending they are already a
+ * calibrated pronunciation score. Signal-quality failure forces abstention;
+ * model uncertainty is exposed explicitly and can also trigger abstention when
+ * a validated margin threshold is supplied by an experiment.
+ */
+export function composeUnvalidatedPronunciationAssessment(
+  input: {
+    signalQuality: SignalQualityEvidence;
+    segmental: UncalibratedSegmentalEvidence;
+    prosody?: ProsodySummary | null;
+  },
+  options: UnvalidatedAssessmentOptions = {},
+): UnvalidatedPronunciationAssessment {
+  const reasons: PronunciationUncertaintyReason[] = [];
+
+  if (input.signalQuality.recommendAbstain) reasons.push("signal_quality");
+
+  if (input.segmental.meanPosteriorMargin === null) {
+    reasons.push("sensor_probabilities_unavailable");
+  }
+
+  const minPosteriorMargin = options.minPosteriorMargin ?? null;
+  if (
+    minPosteriorMargin !== null &&
+    input.segmental.meanPosteriorMargin !== null &&
+    input.segmental.meanPosteriorMargin < minPosteriorMargin
+  ) {
+    reasons.push("weak_sensor_margin");
+  }
+
+  const shouldAbstain =
+    input.signalQuality.recommendAbstain ||
+    reasons.includes("weak_sensor_margin");
+
+  return {
+    calibration: "unvalidated",
+    decision: shouldAbstain ? "abstain" : "evidence",
+    signalQuality: input.signalQuality,
+    segmental: input.segmental,
+    prosody: input.prosody ?? null,
+    uncertainty: {
+      reasons,
+      meanPosteriorMargin: input.segmental.meanPosteriorMargin,
+    },
+    scores: {
+      pronunciation: null,
+      completeness: null,
+      stress: null,
+      fluency: null,
+      prosody: null,
+      total: null,
+    },
+  };
+}

--- a/src/lib/pronunciation-engine/benchmark.test.ts
+++ b/src/lib/pronunciation-engine/benchmark.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertSpeakerDisjointBenchmark,
+  evaluatePronunciationSensorBenchmark,
+  fitValidationOperatingPoint,
+  type PronunciationSensorBenchmarkExample,
+} from "./benchmark";
+
+const examples: PronunciationSensorBenchmarkExample[] = [
+  {
+    id: "v1",
+    speakerId: "speaker-validation-a",
+    split: "validation",
+    expectedPhone: "θ",
+    target: 0,
+    mispronunciationProbability: 0.1,
+    l1: "vi",
+  },
+  {
+    id: "v2",
+    speakerId: "speaker-validation-a",
+    split: "validation",
+    expectedPhone: "θ",
+    target: 1,
+    mispronunciationProbability: 0.9,
+    referenceObservedPhone: "s",
+    predictedObservedPhone: "s",
+    l1: "vi",
+  },
+  {
+    id: "t1",
+    speakerId: "speaker-test-a",
+    split: "test",
+    expectedPhone: "θ",
+    target: 0,
+    mispronunciationProbability: 0.2,
+    l1: "vi",
+  },
+  {
+    id: "t2",
+    speakerId: "speaker-test-a",
+    split: "test",
+    expectedPhone: "θ",
+    target: 1,
+    mispronunciationProbability: 0.8,
+    referenceObservedPhone: "s",
+    predictedObservedPhone: "s",
+    l1: "vi",
+  },
+  {
+    id: "t3",
+    speakerId: "speaker-test-b",
+    split: "test",
+    expectedPhone: "ð",
+    target: 1,
+    mispronunciationProbability: null,
+    referenceObservedPhone: "d",
+    predictedObservedPhone: null,
+    l1: "vi",
+  },
+];
+
+describe("pronunciation-engine sensor benchmark", () => {
+  it("fits a threshold on validation only and evaluates the frozen test split", () => {
+    const operatingPoint = fitValidationOperatingPoint(examples, {
+      objective: "mcc",
+    });
+    const summary = evaluatePronunciationSensorBenchmark(
+      examples,
+      operatingPoint.threshold,
+      "test",
+    );
+
+    expect(operatingPoint.threshold).toBe(0.5);
+    expect(summary.total).toBe(3);
+    expect(summary.scored).toBe(2);
+    expect(summary.coverage).toBeCloseTo(2 / 3, 8);
+    expect(summary.classification?.matthewsCorrelationCoefficient).toBe(1);
+    expect(summary.diagnosis.eligible).toBe(2);
+    expect(summary.diagnosis.emitted).toBe(1);
+    expect(summary.diagnosis.accuracyWhenEmitted).toBe(1);
+    expect(summary.diagnosis.endToEndAccuracy).toBe(0.5);
+    expect(summary.byExpectedPhone["θ"]?.coverage).toBe(1);
+    expect(summary.byExpectedPhone["ð"]?.coverage).toBe(0);
+    expect(summary.byL1.vi?.total).toBe(3);
+  });
+
+  it("exposes abstention asymmetry instead of hiding it in aggregate accuracy", () => {
+    const summary = evaluatePronunciationSensorBenchmark(examples, 0.5);
+
+    expect(summary.abstentionRateCorrect).toBe(0);
+    expect(summary.abstentionRateMispronounced).toBe(0.5);
+  });
+
+  it("rejects speaker leakage across validation and test", () => {
+    const leaked: PronunciationSensorBenchmarkExample[] = [
+      ...examples,
+      {
+        id: "leak",
+        speakerId: "speaker-validation-a",
+        split: "test",
+        expectedPhone: "s",
+        target: 0,
+        mispronunciationProbability: 0.1,
+      },
+    ];
+
+    expect(() => assertSpeakerDisjointBenchmark(leaked)).toThrow(
+      "benchmark_speaker_split_leakage",
+    );
+  });
+
+  it("rejects duplicate examples and invalid probabilities", () => {
+    expect(() =>
+      assertSpeakerDisjointBenchmark([examples[0]!, examples[0]!]),
+    ).toThrow("benchmark_example_ids_must_be_unique");
+
+    expect(() =>
+      assertSpeakerDisjointBenchmark([
+        {
+          ...examples[0]!,
+          id: "bad-probability",
+          mispronunciationProbability: 1.2,
+        },
+      ]),
+    ).toThrow("benchmark_probability_out_of_range");
+  });
+});

--- a/src/lib/pronunciation-engine/benchmark.ts
+++ b/src/lib/pronunciation-engine/benchmark.ts
@@ -1,0 +1,299 @@
+import {
+  binaryClassificationMetrics,
+  brierScore,
+  expectedCalibrationError,
+  rocAuc,
+  thresholdProbabilities,
+  type BinaryClassificationMetrics,
+  type BinaryLabel,
+} from "./metrics";
+import {
+  selectOperatingThreshold,
+  type OperatingPoint,
+  type OperatingPointOptions,
+} from "./operating-point";
+
+export type PronunciationBenchmarkSplit = "train" | "validation" | "test";
+
+export type PronunciationSensorBenchmarkExample = {
+  id: string;
+  speakerId: string;
+  split: PronunciationBenchmarkSplit;
+  expectedPhone: string;
+  /** Positive means the human reference labels this phone as mispronounced. */
+  target: BinaryLabel;
+  /** Null means the sensor abstained or did not expose calibrated probability. */
+  mispronunciationProbability: number | null;
+  /** Human-perceived realized phone when diagnosis labels are available. */
+  referenceObservedPhone?: string | null;
+  /** Sensor diagnosis; null means no diagnosis was emitted. */
+  predictedObservedPhone?: string | null;
+  /** Optional L1 label for subgroup auditing, e.g. "vi". */
+  l1?: string | null;
+};
+
+export type PronunciationSensorBenchmarkSummary = {
+  split: PronunciationBenchmarkSplit;
+  threshold: number;
+  total: number;
+  scored: number;
+  abstained: number;
+  coverage: number;
+  abstentionRateCorrect: number | null;
+  abstentionRateMispronounced: number | null;
+  classification: BinaryClassificationMetrics | null;
+  probabilityQuality: {
+    brier: number | null;
+    expectedCalibrationError: number | null;
+    rocAuc: number | null;
+  };
+  diagnosis: {
+    eligible: number;
+    emitted: number;
+    correct: number;
+    coverage: number | null;
+    accuracyWhenEmitted: number | null;
+    endToEndAccuracy: number | null;
+  };
+  byExpectedPhone: Record<
+    string,
+    {
+      total: number;
+      scored: number;
+      coverage: number;
+      classification: BinaryClassificationMetrics | null;
+    }
+  >;
+  byL1: Record<
+    string,
+    {
+      total: number;
+      scored: number;
+      coverage: number;
+      classification: BinaryClassificationMetrics | null;
+    }
+  >;
+};
+
+function safeDivide(numerator: number, denominator: number) {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+function validateProbability(probability: number | null) {
+  if (
+    probability !== null &&
+    (!Number.isFinite(probability) || probability < 0 || probability > 1)
+  ) {
+    throw new Error("benchmark_probability_out_of_range");
+  }
+}
+
+function normalizeLabel(value: string | null | undefined) {
+  const normalized = value?.normalize("NFC").trim();
+  return normalized ? normalized : null;
+}
+
+/**
+ * Prevents speaker leakage, a common source of inflated speech-model results.
+ * One speaker may contribute many utterances, but only to exactly one split.
+ */
+export function assertSpeakerDisjointBenchmark(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+) {
+  if (examples.length === 0) throw new Error("benchmark_examples_required");
+
+  const ids = new Set<string>();
+  const speakerSplit = new Map<string, PronunciationBenchmarkSplit>();
+
+  for (const example of examples) {
+    const id = example.id.trim();
+    const speakerId = example.speakerId.trim();
+    const expectedPhone = example.expectedPhone.trim();
+
+    if (!id || !speakerId || !expectedPhone) {
+      throw new Error("benchmark_identity_fields_required");
+    }
+    if (ids.has(id)) throw new Error("benchmark_example_ids_must_be_unique");
+    ids.add(id);
+
+    validateProbability(example.mispronunciationProbability);
+
+    const previousSplit = speakerSplit.get(speakerId);
+    if (previousSplit && previousSplit !== example.split) {
+      throw new Error("benchmark_speaker_split_leakage");
+    }
+    speakerSplit.set(speakerId, example.split);
+  }
+}
+
+function scoredExamples(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+) {
+  return examples.filter(
+    (example): example is PronunciationSensorBenchmarkExample & {
+      mispronunciationProbability: number;
+    } => example.mispronunciationProbability !== null,
+  );
+}
+
+/**
+ * Tunes an operating point only on the validation split. The resulting
+ * threshold must be frozen before held-out test evaluation.
+ */
+export function fitValidationOperatingPoint(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+  options: OperatingPointOptions = {},
+): OperatingPoint {
+  assertSpeakerDisjointBenchmark(examples);
+  const validation = scoredExamples(
+    examples.filter((example) => example.split === "validation"),
+  );
+
+  if (validation.length === 0) {
+    throw new Error("benchmark_validation_probabilities_required");
+  }
+
+  return selectOperatingThreshold(
+    validation.map((example) => example.mispronunciationProbability),
+    validation.map((example) => example.target),
+    options,
+  );
+}
+
+function classificationForGroup(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+  threshold: number,
+) {
+  const scored = scoredExamples(examples);
+  if (scored.length === 0) return null;
+
+  const probabilities = scored.map(
+    (example) => example.mispronunciationProbability,
+  );
+  const targets = scored.map((example) => example.target);
+  const predictions = thresholdProbabilities(probabilities, threshold);
+  return binaryClassificationMetrics(predictions, targets);
+}
+
+function subgroupSummary(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+  threshold: number,
+  key: (example: PronunciationSensorBenchmarkExample) => string | null,
+) {
+  const groups = new Map<string, PronunciationSensorBenchmarkExample[]>();
+
+  for (const example of examples) {
+    const groupKey = key(example);
+    if (!groupKey) continue;
+    const group = groups.get(groupKey) ?? [];
+    group.push(example);
+    groups.set(groupKey, group);
+  }
+
+  return Object.fromEntries(
+    [...groups.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([groupKey, group]) => {
+        const scored = scoredExamples(group);
+        return [
+          groupKey,
+          {
+            total: group.length,
+            scored: scored.length,
+            coverage: group.length === 0 ? 0 : scored.length / group.length,
+            classification: classificationForGroup(group, threshold),
+          },
+        ];
+      }),
+  );
+}
+
+/**
+ * Evaluates one frozen operating point on a named split. This function never
+ * searches thresholds, protecting the held-out test set from silent tuning.
+ */
+export function evaluatePronunciationSensorBenchmark(
+  examples: readonly PronunciationSensorBenchmarkExample[],
+  threshold: number,
+  split: PronunciationBenchmarkSplit = "test",
+): PronunciationSensorBenchmarkSummary {
+  assertSpeakerDisjointBenchmark(examples);
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new Error("benchmark_threshold_out_of_range");
+  }
+
+  const selected = examples.filter((example) => example.split === split);
+  if (selected.length === 0) throw new Error("benchmark_split_examples_required");
+
+  const scored = scoredExamples(selected);
+  const abstained = selected.length - scored.length;
+  const correct = selected.filter((example) => example.target === 0);
+  const mispronounced = selected.filter((example) => example.target === 1);
+  const correctAbstained = correct.filter(
+    (example) => example.mispronunciationProbability === null,
+  ).length;
+  const mispronouncedAbstained = mispronounced.filter(
+    (example) => example.mispronunciationProbability === null,
+  ).length;
+
+  const probabilities = scored.map(
+    (example) => example.mispronunciationProbability,
+  );
+  const targets = scored.map((example) => example.target);
+
+  const diagnosisEligible = selected.filter(
+    (example) =>
+      example.target === 1 && normalizeLabel(example.referenceObservedPhone),
+  );
+  let diagnosisEmitted = 0;
+  let diagnosisCorrect = 0;
+
+  for (const example of diagnosisEligible) {
+    const reference = normalizeLabel(example.referenceObservedPhone);
+    const predicted = normalizeLabel(example.predictedObservedPhone);
+    if (!predicted) continue;
+    diagnosisEmitted += 1;
+    if (predicted === reference) diagnosisCorrect += 1;
+  }
+
+  return {
+    split,
+    threshold,
+    total: selected.length,
+    scored: scored.length,
+    abstained,
+    coverage: scored.length / selected.length,
+    abstentionRateCorrect: safeDivide(correctAbstained, correct.length),
+    abstentionRateMispronounced: safeDivide(
+      mispronouncedAbstained,
+      mispronounced.length,
+    ),
+    classification: classificationForGroup(selected, threshold),
+    probabilityQuality: {
+      brier:
+        probabilities.length === 0 ? null : brierScore(probabilities, targets),
+      expectedCalibrationError:
+        probabilities.length === 0
+          ? null
+          : expectedCalibrationError(probabilities, targets),
+      rocAuc: probabilities.length === 0 ? null : rocAuc(probabilities, targets),
+    },
+    diagnosis: {
+      eligible: diagnosisEligible.length,
+      emitted: diagnosisEmitted,
+      correct: diagnosisCorrect,
+      coverage: safeDivide(diagnosisEmitted, diagnosisEligible.length),
+      accuracyWhenEmitted: safeDivide(diagnosisCorrect, diagnosisEmitted),
+      endToEndAccuracy: safeDivide(diagnosisCorrect, diagnosisEligible.length),
+    },
+    byExpectedPhone: subgroupSummary(
+      selected,
+      threshold,
+      (example) => example.expectedPhone.trim(),
+    ),
+    byL1: subgroupSummary(selected, threshold, (example) => {
+      const l1 = example.l1?.trim().toLowerCase();
+      return l1 || null;
+    }),
+  };
+}

--- a/src/lib/pronunciation-engine/calibration.test.ts
+++ b/src/lib/pronunciation-engine/calibration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyIsotonicCalibration,
+  conformalInterval,
+  fitConformalAbsoluteResidual,
+  fitIsotonicCalibration,
+} from "./calibration";
+
+describe("pronunciation-engine calibration", () => {
+  it("pools adjacent monotonicity violations with PAVA", () => {
+    const model = fitIsotonicCalibration([
+      { raw: 0, target: 0 },
+      { raw: 1, target: 1 },
+      { raw: 2, target: 0 },
+    ]);
+
+    expect(model.blocks).toEqual([
+      { minRaw: 0, maxRaw: 0, calibrated: 0, weight: 1 },
+      { minRaw: 1, maxRaw: 2, calibrated: 0.5, weight: 2 },
+    ]);
+  });
+
+  it("groups identical raw values before fitting", () => {
+    const model = fitIsotonicCalibration([
+      { raw: 0.5, target: 0.2 },
+      { raw: 0.5, target: 0.6 },
+      { raw: 0.9, target: 0.8 },
+    ]);
+
+    expect(model.blocks[0]).toMatchObject({
+      minRaw: 0.5,
+      maxRaw: 0.5,
+      calibrated: 0.4,
+      weight: 2,
+    });
+  });
+
+  it("interpolates between monotonic calibration blocks", () => {
+    const model = fitIsotonicCalibration([
+      { raw: 0, target: 0.1 },
+      { raw: 1, target: 0.9 },
+    ]);
+
+    expect(applyIsotonicCalibration(model, -1)).toBeCloseTo(0.1);
+    expect(applyIsotonicCalibration(model, 0.5)).toBeCloseTo(0.5);
+    expect(applyIsotonicCalibration(model, 2)).toBeCloseTo(0.9);
+  });
+
+  it("uses the finite-sample conformal quantile", () => {
+    const calibration = fitConformalAbsoluteResidual(
+      [0, 0, 0, 0],
+      [0, 1, 2, 3],
+      0.25,
+    );
+
+    expect(calibration).toEqual({
+      miscoverage: 0.25,
+      radius: 3,
+      calibrationSize: 4,
+    });
+
+    expect(conformalInterval(5, calibration)).toEqual({ lower: 2, upper: 8 });
+    expect(
+      conformalInterval(5, calibration, { min: 0, max: 6 }),
+    ).toEqual({ lower: 2, upper: 6 });
+  });
+
+  it("rejects invalid calibration inputs instead of fabricating output", () => {
+    expect(() => fitIsotonicCalibration([])).toThrow(
+      "calibration_samples_required",
+    );
+    expect(() =>
+      fitConformalAbsoluteResidual([0.1], [0.2], 0),
+    ).toThrow("conformal_miscoverage_must_be_between_zero_and_one");
+  });
+});

--- a/src/lib/pronunciation-engine/calibration.ts
+++ b/src/lib/pronunciation-engine/calibration.ts
@@ -1,0 +1,214 @@
+export type CalibrationSample = {
+  raw: number;
+  target: number;
+  weight?: number;
+};
+
+export type IsotonicCalibrationBlock = {
+  minRaw: number;
+  maxRaw: number;
+  calibrated: number;
+  weight: number;
+};
+
+export type IsotonicCalibrationModel = {
+  blocks: readonly IsotonicCalibrationBlock[];
+};
+
+type MutableBlock = {
+  minRaw: number;
+  maxRaw: number;
+  weight: number;
+  weightedTargetSum: number;
+};
+
+function blockMean(block: MutableBlock) {
+  return block.weightedTargetSum / block.weight;
+}
+
+function assertFinite(value: number, name: string) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${name}_must_be_finite`);
+  }
+}
+
+/**
+ * Fits a monotonic non-decreasing calibrator with the pooled-adjacent-violators
+ * algorithm (PAVA). This is deliberately dependency-free so research scores
+ * can be calibrated to human ratings without assuming a linear relationship.
+ */
+export function fitIsotonicCalibration(
+  samples: readonly CalibrationSample[],
+): IsotonicCalibrationModel {
+  if (samples.length === 0) {
+    throw new Error("calibration_samples_required");
+  }
+
+  const sorted = samples
+    .map((sample) => {
+      assertFinite(sample.raw, "calibration_raw");
+      assertFinite(sample.target, "calibration_target");
+
+      const weight = sample.weight ?? 1;
+      assertFinite(weight, "calibration_weight");
+      if (weight <= 0) throw new Error("calibration_weight_must_be_positive");
+
+      return { ...sample, weight };
+    })
+    .sort((left, right) => left.raw - right.raw);
+
+  // Group identical x-values first. A mathematical function cannot map the
+  // same raw value to multiple calibrated outputs.
+  const grouped: MutableBlock[] = [];
+
+  for (const sample of sorted) {
+    const previous = grouped[grouped.length - 1];
+
+    if (previous && previous.maxRaw === sample.raw) {
+      previous.weight += sample.weight;
+      previous.weightedTargetSum += sample.weight * sample.target;
+      continue;
+    }
+
+    grouped.push({
+      minRaw: sample.raw,
+      maxRaw: sample.raw,
+      weight: sample.weight,
+      weightedTargetSum: sample.weight * sample.target,
+    });
+  }
+
+  const blocks: MutableBlock[] = [];
+
+  for (const next of grouped) {
+    blocks.push({ ...next });
+
+    while (blocks.length >= 2) {
+      const right = blocks[blocks.length - 1];
+      const left = blocks[blocks.length - 2];
+
+      if (!left || !right || blockMean(left) <= blockMean(right)) break;
+
+      blocks.splice(blocks.length - 2, 2, {
+        minRaw: left.minRaw,
+        maxRaw: right.maxRaw,
+        weight: left.weight + right.weight,
+        weightedTargetSum:
+          left.weightedTargetSum + right.weightedTargetSum,
+      });
+    }
+  }
+
+  return {
+    blocks: blocks.map((block) => ({
+      minRaw: block.minRaw,
+      maxRaw: block.maxRaw,
+      calibrated: blockMean(block),
+      weight: block.weight,
+    })),
+  };
+}
+
+export function applyIsotonicCalibration(
+  model: IsotonicCalibrationModel,
+  raw: number,
+) {
+  assertFinite(raw, "calibration_raw");
+
+  const blocks = model.blocks;
+  const first = blocks[0];
+  const last = blocks[blocks.length - 1];
+
+  if (!first || !last) throw new Error("invalid_isotonic_model");
+  if (raw <= first.maxRaw) return first.calibrated;
+  if (raw >= last.minRaw) return last.calibrated;
+
+  for (let index = 1; index < blocks.length; index += 1) {
+    const right = blocks[index];
+    const left = blocks[index - 1];
+    if (!left || !right) continue;
+
+    if (raw >= right.minRaw && raw <= right.maxRaw) {
+      return right.calibrated;
+    }
+
+    if (raw > left.maxRaw && raw < right.minRaw) {
+      const span = right.minRaw - left.maxRaw;
+      if (span <= 0) return right.calibrated;
+
+      const fraction = (raw - left.maxRaw) / span;
+      return (
+        left.calibrated + fraction * (right.calibrated - left.calibrated)
+      );
+    }
+  }
+
+  return last.calibrated;
+}
+
+export type ConformalCalibration = {
+  miscoverage: number;
+  radius: number;
+  calibrationSize: number;
+};
+
+/**
+ * Split-conformal absolute-residual radius. Fit this only on a calibration
+ * split whose speakers are disjoint from model training and final test.
+ */
+export function fitConformalAbsoluteResidual(
+  predictions: readonly number[],
+  targets: readonly number[],
+  miscoverage = 0.1,
+): ConformalCalibration {
+  if (predictions.length === 0 || predictions.length !== targets.length) {
+    throw new Error("conformal_pairs_required");
+  }
+
+  if (!Number.isFinite(miscoverage) || miscoverage <= 0 || miscoverage >= 1) {
+    throw new Error("conformal_miscoverage_must_be_between_zero_and_one");
+  }
+
+  const residuals = predictions
+    .map((prediction, index) => {
+      const target = targets[index];
+      if (target === undefined) throw new Error("conformal_pairs_required");
+      assertFinite(prediction, "conformal_prediction");
+      assertFinite(target, "conformal_target");
+      return Math.abs(prediction - target);
+    })
+    .sort((left, right) => left - right);
+
+  const finiteSampleRank = Math.ceil(
+    (residuals.length + 1) * (1 - miscoverage),
+  );
+  const index = Math.min(residuals.length - 1, Math.max(0, finiteSampleRank - 1));
+  const radius = residuals[index];
+
+  if (radius === undefined) throw new Error("conformal_pairs_required");
+
+  return {
+    miscoverage,
+    radius,
+    calibrationSize: residuals.length,
+  };
+}
+
+export function conformalInterval(
+  prediction: number,
+  calibration: ConformalCalibration,
+  bounds?: { min?: number; max?: number },
+) {
+  assertFinite(prediction, "conformal_prediction");
+  assertFinite(calibration.radius, "conformal_radius");
+
+  const lower = prediction - calibration.radius;
+  const upper = prediction + calibration.radius;
+
+  return {
+    lower:
+      bounds?.min === undefined ? lower : Math.max(bounds.min, lower),
+    upper:
+      bounds?.max === undefined ? upper : Math.min(bounds.max, upper),
+  };
+}

--- a/src/lib/pronunciation-engine/ctc-lattice.test.ts
+++ b/src/lib/pronunciation-engine/ctc-lattice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CtcPosteriorMatrix } from "./ctc";
-import { canonicalCtcLogLikelihood } from "./ctc-lattice";
+import { canonicalCtcForwardBackward, canonicalCtcLogLikelihood } from "./ctc-lattice";
 
 describe("canonical CTC lattice", () => {
   it("matches the exact path sum for a one-phone target", () => {
@@ -111,5 +111,105 @@ describe("canonical CTC lattice", () => {
     expect(() => canonicalCtcLogLikelihood(matrix, [2])).toThrow(
       "ctc_canonical_target_has_zero_probability_mass",
     );
+  });
+});
+
+describe("canonical CTC forward-backward", () => {
+  const matrix: CtcPosteriorMatrix = {
+    tokenLabels: ["<pad>", "θ", "s"],
+    blankTokenId: 0,
+    audioDurationMs: 40,
+    frames: [[0.6, 0.4, 0], [0.7, 0.3, 0]],
+  };
+
+  it("matches manually enumerated path posteriors and occupancy duration", () => {
+    const result = canonicalCtcForwardBackward(matrix, [1]);
+    // Valid paths: θθ (0.12), θ_ (0.28), _θ (0.18).
+    const mass = 0.58;
+    const expected = [[0.18 / mass, 0.4 / mass, 0], [0, 0.3 / mass, 0.28 / mass]];
+    result.statePosteriors.forEach((row, t) => {
+      row.forEach((value, s) => expect(value).toBeCloseTo(expected[t][s], 12));
+      expect(row.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 12);
+    });
+    expect(result.extendedTarget).toEqual([0, 1, 0]);
+    expect(result.canonicalPhonePositionByState).toEqual([null, 0, null]);
+    expect(result.minimumRequiredFrames).toBe(1);
+    expect(result.phones[0]).toMatchObject({ canonicalPhonePosition: 0, tokenId: 1, stateIndex: 1, peakSupportFrame: 0 });
+    expect(result.phones[0].expectedOccupiedFrames).toBeCloseTo(0.7 / mass, 12);
+    expect(result.phones[0].expectedDurationMs).toBeCloseTo(20 * 0.7 / mass, 12);
+    expect(result.phones[0].peakPosterior).toBeCloseTo(0.4 / mass, 12);
+  });
+
+  it("retains phone occupancy under blank-dominant and competitor-dominant frames", () => {
+    for (const frame of [[0.6, 0.35, 0.05], [0.05, 0.05, 0.9]]) {
+      const result = canonicalCtcForwardBackward({ ...matrix, frames: [frame, frame, frame] }, [1]);
+      expect(result.phones[0].expectedOccupiedFrames).toBeGreaterThan(0);
+      for (const row of result.statePosteriors) {
+        expect(row[1]).toBeGreaterThan(0);
+        expect(row.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 12);
+      }
+    }
+  });
+
+  it("requires an intervening blank and keeps repeated phone positions distinct", () => {
+    const repeated = { ...matrix, frames: [[0.1, 0.9, 0], [0.8, 0.2, 0], [0.1, 0.9, 0]], audioDurationMs: 90 };
+    const result = canonicalCtcForwardBackward(repeated, [1, 1]);
+    expect(result.minimumRequiredFrames).toBe(3);
+    expect(result.canonicalPhonePositionByState).toEqual([null, 0, null, 1, null]);
+    const onlyLegalStates = [1, 2, 3];
+    result.statePosteriors.forEach((row, t) => row.forEach((value, s) => {
+      expect(value).toBeCloseTo(s === onlyLegalStates[t] ? 1 : 0, 12);
+    }));
+    result.phones.forEach((phone, position) => {
+      expect(phone.canonicalPhonePosition).toBe(position);
+      expect(phone.expectedOccupiedFrames).toBeCloseTo(1, 12);
+      expect(phone.expectedDurationMs).toBeCloseTo(30, 12);
+    });
+    expect(() => canonicalCtcForwardBackward(matrix, [1, 1])).toThrow("ctc_canonical_target_requires_more_frames");
+    expect(() => canonicalCtcForwardBackward({ ...repeated, frames: [[0, 1, 0], [0, 1, 0], [0, 1, 0]] }, [1, 1])).toThrow("ctc_canonical_target_has_zero_probability_mass");
+  });
+
+  it("handles a single frame and adjacent distinct labels with a nonzero blank ID", () => {
+    const input = { tokenLabels: ["θ", "s", "<pad>"], blankTokenId: 2, audioDurationMs: 20, frames: [[0.4, 0.2, 0.4]] };
+    const single = canonicalCtcForwardBackward(input, [0]);
+    expect(single.statePosteriors).toEqual([[0, 1, 0]]);
+    expect(single.phones[0].expectedDurationMs).toBe(20);
+    const adjacent = canonicalCtcForwardBackward({ ...input, frames: [[0.4, 0.2, 0.4], [0.3, 0.5, 0.2]] }, [0, 1]);
+    adjacent.statePosteriors.forEach((row, t) => row.forEach((value, s) => {
+      expect(value).toBeCloseTo(s === 2 * t + 1 ? 1 : 0, 12);
+    }));
+  });
+
+  it.each([[1], [2], [1, 2], [1, 1], [1, 2, 1]])("agrees with forward likelihood and conserves frame mass for %j", (...target) => {
+    const input = { ...matrix, frames: [[0.6, 0.3, 0.1], [0.2, 0.3, 0.5], [0.7, 0.1, 0.2], [0.1, 0.6, 0.3], [0.5, 0.2, 0.3]] };
+    const result = canonicalCtcForwardBackward(input, target);
+    expect(result.logLikelihood).toBeCloseTo(canonicalCtcLogLikelihood(input, target).logLikelihood, 12);
+    for (const row of result.statePosteriors) {
+      expect(row.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 12);
+      row.forEach((value) => { expect(value).toBeGreaterThanOrEqual(0); expect(value).toBeLessThanOrEqual(1 + 1e-12); });
+    }
+  });
+
+  it("stays finite when complete path probabilities underflow outside log space", () => {
+    const input = { ...matrix, frames: Array.from({ length: 400 }, () => [0.1, 0.01, 0.89]) };
+    const result = canonicalCtcForwardBackward(input, [1]);
+    expect(Math.exp(result.logLikelihood)).toBe(0);
+    expect(Number.isFinite(result.logLikelihood)).toBe(true);
+    result.statePosteriors.forEach((row) => {
+      expect(row.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 9);
+    });
+    expect(Number.isFinite(result.phones[0].expectedDurationMs)).toBe(true);
+  });
+
+  it("preserves explicit rejection of invalid inputs and zero mass", () => {
+    for (const target of [[], [0], [3], [-1], [1.5], [NaN], [2]]) {
+      let expectedError = "";
+      try { canonicalCtcLogLikelihood(matrix, target); } catch (error) { expectedError = (error as Error).message; }
+      expect(expectedError).not.toBe("");
+      expect(() => canonicalCtcForwardBackward(matrix, target)).toThrow(expectedError);
+    }
+    expect(() => canonicalCtcForwardBackward({ ...matrix, frames: [] }, [1])).toThrow("ctc_frames_required");
+    expect(() => canonicalCtcForwardBackward({ ...matrix, audioDurationMs: 0 }, [1])).toThrow("ctc_audio_duration_required");
+    expect(() => canonicalCtcForwardBackward({ ...matrix, frames: [[NaN, 1, 0]] }, [1])).toThrow("ctc_probability_out_of_range");
   });
 });

--- a/src/lib/pronunciation-engine/ctc-lattice.test.ts
+++ b/src/lib/pronunciation-engine/ctc-lattice.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { CtcPosteriorMatrix } from "./ctc";
+import { canonicalCtcLogLikelihood } from "./ctc-lattice";
+
+describe("canonical CTC lattice", () => {
+  it("matches the exact path sum for a one-phone target", () => {
+    const matrix: CtcPosteriorMatrix = {
+      tokenLabels: ["<pad>", "θ"],
+      blankTokenId: 0,
+      audioDurationMs: 40,
+      frames: [
+        [0.6, 0.4],
+        [0.7, 0.3],
+      ],
+    };
+
+    const result = canonicalCtcLogLikelihood(matrix, [1]);
+    const exactProbability = 0.4 * 0.3 + 0.4 * 0.7 + 0.6 * 0.3;
+
+    expect(Math.exp(result.logLikelihood)).toBeCloseTo(exactProbability, 12);
+  });
+
+  it("recovers target evidence even when greedy top-1 is blank on every frame", () => {
+    const matrix: CtcPosteriorMatrix = {
+      tokenLabels: ["<pad>", "θ", "s"],
+      blankTokenId: 0,
+      audioDurationMs: 60,
+      frames: [
+        [0.6, 0.35, 0.05],
+        [0.6, 0.35, 0.05],
+        [0.6, 0.35, 0.05],
+      ],
+    };
+
+    const result = canonicalCtcLogLikelihood(matrix, [1]);
+
+    expect(Number.isFinite(result.logLikelihood)).toBe(true);
+    expect(result.extendedTarget).toEqual([0, 1, 0]);
+    expect(result.minimumRequiredFrames).toBe(1);
+  });
+
+  it("assigns higher sequence likelihood to the acoustically supported canonical target", () => {
+    const matrix: CtcPosteriorMatrix = {
+      tokenLabels: ["<pad>", "θ", "s", "ɪ"],
+      blankTokenId: 0,
+      audioDurationMs: 60,
+      frames: [
+        [0.1, 0.8, 0.1, 0],
+        [0.8, 0.1, 0.05, 0.05],
+        [0.1, 0.05, 0.05, 0.8],
+      ],
+    };
+
+    const thinkLike = canonicalCtcLogLikelihood(matrix, [1, 3]);
+    const sinkLike = canonicalCtcLogLikelihood(matrix, [2, 3]);
+
+    expect(thinkLike.logLikelihood).toBeGreaterThan(sinkLike.logLikelihood);
+  });
+
+  it("requires an intervening blank for repeated canonical labels", () => {
+    const tooShort: CtcPosteriorMatrix = {
+      tokenLabels: ["<pad>", "θ"],
+      blankTokenId: 0,
+      audioDurationMs: 40,
+      frames: [
+        [0.1, 0.9],
+        [0.1, 0.9],
+      ],
+    };
+
+    expect(() => canonicalCtcLogLikelihood(tooShort, [1, 1])).toThrow(
+      "ctc_canonical_target_requires_more_frames",
+    );
+
+    const valid: CtcPosteriorMatrix = {
+      ...tooShort,
+      audioDurationMs: 60,
+      frames: [
+        [0.05, 0.95],
+        [0.95, 0.05],
+        [0.05, 0.95],
+      ],
+    };
+
+    expect(
+      Number.isFinite(canonicalCtcLogLikelihood(valid, [1, 1]).logLikelihood),
+    ).toBe(true);
+  });
+
+  it("rejects invalid canonical targets and zero-probability paths", () => {
+    const matrix: CtcPosteriorMatrix = {
+      tokenLabels: ["<pad>", "θ", "s"],
+      blankTokenId: 0,
+      audioDurationMs: 40,
+      frames: [
+        [0.5, 0.5, 0],
+        [0.5, 0.5, 0],
+      ],
+    };
+
+    expect(() => canonicalCtcLogLikelihood(matrix, [])).toThrow(
+      "ctc_canonical_target_required",
+    );
+    expect(() => canonicalCtcLogLikelihood(matrix, [0])).toThrow(
+      "ctc_canonical_target_cannot_contain_blank",
+    );
+    expect(() => canonicalCtcLogLikelihood(matrix, [3])).toThrow(
+      "ctc_canonical_token_out_of_range",
+    );
+    expect(() => canonicalCtcLogLikelihood(matrix, [2])).toThrow(
+      "ctc_canonical_target_has_zero_probability_mass",
+    );
+  });
+});

--- a/src/lib/pronunciation-engine/ctc-lattice.ts
+++ b/src/lib/pronunciation-engine/ctc-lattice.ts
@@ -11,6 +11,26 @@ export type CanonicalCtcForwardResult = {
   minimumRequiredFrames: number;
 };
 
+export type CanonicalCtcPhoneOccupancy = {
+  /** Zero-based position in the canonical target, including repeated tokens. */
+  canonicalPhonePosition: number;
+  tokenId: number;
+  stateIndex: number;
+  expectedOccupiedFrames: number;
+  expectedDurationMs: number;
+  /** Earliest frame wins when posterior support is tied. */
+  peakSupportFrame: number;
+  peakPosterior: number;
+};
+
+export type CanonicalCtcForwardBackwardResult = CanonicalCtcForwardResult & {
+  /** gamma[frame][extended-state], conditional on the complete target. */
+  statePosteriors: number[][];
+  /** Indexed by extended state; null denotes a blank state. */
+  canonicalPhonePositionByState: (number | null)[];
+  phones: CanonicalCtcPhoneOccupancy[];
+};
+
 function logProbability(probability: number) {
   return probability <= 0 ? NEGATIVE_INFINITY : Math.log(probability);
 }
@@ -104,6 +124,14 @@ export function canonicalCtcLogLikelihood(
   matrix: CtcPosteriorMatrix,
   targetTokenIds: readonly number[],
 ): CanonicalCtcForwardResult {
+  return forwardLattice(matrix, targetTokenIds);
+}
+
+function forwardLattice(
+  matrix: CtcPosteriorMatrix,
+  targetTokenIds: readonly number[],
+  retainRow?: (row: number[]) => void,
+): CanonicalCtcForwardResult {
   validateCtcPosteriorMatrix(matrix);
 
   const minimumFrames = validateTarget(matrix, targetTokenIds);
@@ -132,6 +160,7 @@ export function canonicalCtcLogLikelihood(
 
     previous[1] = logProbability(firstFrame[firstTargetToken] ?? 0);
   }
+  retainRow?.(previous);
 
   for (
     let frameIndex = 1;
@@ -173,6 +202,7 @@ export function canonicalCtcLogLikelihood(
     }
 
     previous = current;
+    retainRow?.(current);
   }
 
   const finalBlankState = stateCount - 1;
@@ -192,4 +222,83 @@ export function canonicalCtcLogLikelihood(
     extendedTarget,
     minimumRequiredFrames: minimumFrames,
   };
+}
+
+/**
+ * Research-only state occupancy conditional on the supplied canonical target.
+ * Alpha includes the current emission; beta excludes it. Neither gamma nor the
+ * input emissions are post-hoc normalized. Occupancy is not correctness evidence:
+ * even an acoustically unlikely target is conditioned to have been uttered here.
+ * Timing assumes uniformly spaced frames, as in the existing CTC matrix contract.
+ */
+export function canonicalCtcForwardBackward(
+  matrix: CtcPosteriorMatrix,
+  targetTokenIds: readonly number[],
+): CanonicalCtcForwardBackwardResult {
+  const alpha: number[][] = [];
+  const forward = forwardLattice(matrix, targetTokenIds, (row) => alpha.push(row));
+  const { extendedTarget, logLikelihood } = forward;
+  const stateCount = extendedTarget.length;
+  const frameCount = matrix.frames.length;
+  const statePosteriors: number[][] = Array(frameCount);
+
+  let beta = Array<number>(stateCount).fill(NEGATIVE_INFINITY);
+  beta[stateCount - 1] = 0;
+  beta[stateCount - 2] = 0;
+
+  for (let frameIndex = frameCount - 1; frameIndex >= 0; frameIndex -= 1) {
+    statePosteriors[frameIndex] = alpha[frameIndex].map((value, state) =>
+      Math.exp(value + beta[state] - logLikelihood),
+    );
+    if (frameIndex === 0) break;
+
+    // Moving beta back one frame consumes this frame's destination emission.
+    const frame = matrix.frames[frameIndex];
+    const previousBeta = Array<number>(stateCount).fill(NEGATIVE_INFINITY);
+    for (let state = 0; state < stateCount; state += 1) {
+      const suffixes = [logProbability(frame[extendedTarget[state]]) + beta[state]];
+      if (state + 1 < stateCount) {
+        suffixes.push(logProbability(frame[extendedTarget[state + 1]]) + beta[state + 1]);
+      }
+      if (
+        state + 2 < stateCount &&
+        extendedTarget[state + 2] !== matrix.blankTokenId &&
+        extendedTarget[state + 2] !== extendedTarget[state]
+      ) {
+        suffixes.push(logProbability(frame[extendedTarget[state + 2]]) + beta[state + 2]);
+      }
+      previousBeta[state] = logSumExp(suffixes);
+    }
+    beta = previousBeta;
+  }
+
+  const canonicalPhonePositionByState = extendedTarget.map((tokenId, state) =>
+    tokenId === matrix.blankTokenId ? null : (state - 1) / 2,
+  );
+  const frameDurationMs = matrix.audioDurationMs / frameCount;
+  const phones = targetTokenIds.map((tokenId, canonicalPhonePosition) => {
+    const stateIndex = canonicalPhonePosition * 2 + 1;
+    let expectedOccupiedFrames = 0;
+    let peakSupportFrame = 0;
+    let peakPosterior = 0;
+    for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+      const posterior = statePosteriors[frameIndex][stateIndex];
+      expectedOccupiedFrames += posterior;
+      if (posterior > peakPosterior) {
+        peakPosterior = posterior;
+        peakSupportFrame = frameIndex;
+      }
+    }
+    return {
+      canonicalPhonePosition,
+      tokenId,
+      stateIndex,
+      expectedOccupiedFrames,
+      expectedDurationMs: expectedOccupiedFrames * frameDurationMs,
+      peakSupportFrame,
+      peakPosterior,
+    };
+  });
+
+  return { ...forward, statePosteriors, canonicalPhonePositionByState, phones };
 }

--- a/src/lib/pronunciation-engine/ctc-lattice.ts
+++ b/src/lib/pronunciation-engine/ctc-lattice.ts
@@ -1,0 +1,195 @@
+import {
+  validateCtcPosteriorMatrix,
+  type CtcPosteriorMatrix,
+} from "./ctc";
+
+const NEGATIVE_INFINITY = Number.NEGATIVE_INFINITY;
+
+export type CanonicalCtcForwardResult = {
+  logLikelihood: number;
+  extendedTarget: number[];
+  minimumRequiredFrames: number;
+};
+
+function logProbability(probability: number) {
+  return probability <= 0 ? NEGATIVE_INFINITY : Math.log(probability);
+}
+
+function logSumExp(values: readonly number[]) {
+  let maximum = NEGATIVE_INFINITY;
+
+  for (const value of values) {
+    if (value > maximum) maximum = value;
+  }
+
+  if (maximum === NEGATIVE_INFINITY) {
+    return NEGATIVE_INFINITY;
+  }
+
+  let sum = 0;
+
+  for (const value of values) {
+    if (value !== NEGATIVE_INFINITY) {
+      sum += Math.exp(value - maximum);
+    }
+  }
+
+  return maximum + Math.log(sum);
+}
+
+function buildExtendedTarget(
+  targetTokenIds: readonly number[],
+  blankTokenId: number,
+) {
+  const extended: number[] = [blankTokenId];
+
+  for (const tokenId of targetTokenIds) {
+    extended.push(tokenId);
+    extended.push(blankTokenId);
+  }
+
+  return extended;
+}
+
+function minimumRequiredFrames(targetTokenIds: readonly number[]) {
+  let frames = targetTokenIds.length;
+
+  for (let index = 1; index < targetTokenIds.length; index += 1) {
+    if (targetTokenIds[index] === targetTokenIds[index - 1]) {
+      frames += 1;
+    }
+  }
+
+  return frames;
+}
+
+function validateTarget(
+  matrix: CtcPosteriorMatrix,
+  targetTokenIds: readonly number[],
+) {
+  if (targetTokenIds.length === 0) {
+    throw new Error("ctc_canonical_target_required");
+  }
+
+  for (const tokenId of targetTokenIds) {
+    if (
+      !Number.isInteger(tokenId) ||
+      tokenId < 0 ||
+      tokenId >= matrix.tokenLabels.length
+    ) {
+      throw new Error("ctc_canonical_token_out_of_range");
+    }
+
+    if (tokenId === matrix.blankTokenId) {
+      throw new Error("ctc_canonical_target_cannot_contain_blank");
+    }
+  }
+
+  const minimumFrames = minimumRequiredFrames(targetTokenIds);
+
+  if (matrix.frames.length < minimumFrames) {
+    throw new Error("ctc_canonical_target_requires_more_frames");
+  }
+
+  return minimumFrames;
+}
+
+/**
+ * Computes log P(canonical target | acoustic frames) by summing every valid
+ * CTC path instead of relying on the greedy top-1 path.
+ *
+ * This is research evidence only. It is not a pronunciation score.
+ */
+export function canonicalCtcLogLikelihood(
+  matrix: CtcPosteriorMatrix,
+  targetTokenIds: readonly number[],
+): CanonicalCtcForwardResult {
+  validateCtcPosteriorMatrix(matrix);
+
+  const minimumFrames = validateTarget(matrix, targetTokenIds);
+  const extendedTarget = buildExtendedTarget(
+    targetTokenIds,
+    matrix.blankTokenId,
+  );
+
+  const stateCount = extendedTarget.length;
+  const firstFrame = matrix.frames[0];
+
+  if (!firstFrame) {
+    throw new Error("ctc_frames_required");
+  }
+
+  let previous = Array<number>(stateCount).fill(NEGATIVE_INFINITY);
+
+  previous[0] = logProbability(firstFrame[matrix.blankTokenId] ?? 0);
+
+  if (stateCount > 1) {
+    const firstTargetToken = extendedTarget[1];
+
+    if (firstTargetToken === undefined) {
+      throw new Error("ctc_invalid_extended_target");
+    }
+
+    previous[1] = logProbability(firstFrame[firstTargetToken] ?? 0);
+  }
+
+  for (
+    let frameIndex = 1;
+    frameIndex < matrix.frames.length;
+    frameIndex += 1
+  ) {
+    const frame = matrix.frames[frameIndex];
+
+    if (!frame) {
+      throw new Error("ctc_invalid_frame_state");
+    }
+
+    const current = Array<number>(stateCount).fill(NEGATIVE_INFINITY);
+
+    for (let state = 0; state < stateCount; state += 1) {
+      const tokenId = extendedTarget[state];
+
+      if (tokenId === undefined) {
+        throw new Error("ctc_invalid_extended_target");
+      }
+
+      const predecessors: number[] = [previous[state] ?? NEGATIVE_INFINITY];
+
+      if (state > 0) {
+        predecessors.push(previous[state - 1] ?? NEGATIVE_INFINITY);
+      }
+
+      if (
+        state > 1 &&
+        tokenId !== matrix.blankTokenId &&
+        tokenId !== extendedTarget[state - 2]
+      ) {
+        predecessors.push(previous[state - 2] ?? NEGATIVE_INFINITY);
+      }
+
+      current[state] =
+        logProbability(frame[tokenId] ?? 0) +
+        logSumExp(predecessors);
+    }
+
+    previous = current;
+  }
+
+  const finalBlankState = stateCount - 1;
+  const finalLabelState = stateCount - 2;
+
+  const logLikelihood = logSumExp([
+    previous[finalBlankState] ?? NEGATIVE_INFINITY,
+    previous[finalLabelState] ?? NEGATIVE_INFINITY,
+  ]);
+
+  if (!Number.isFinite(logLikelihood)) {
+    throw new Error("ctc_canonical_target_has_zero_probability_mass");
+  }
+
+  return {
+    logLikelihood,
+    extendedTarget,
+    minimumRequiredFrames: minimumFrames,
+  };
+}

--- a/src/lib/pronunciation-engine/ctc.test.ts
+++ b/src/lib/pronunciation-engine/ctc.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { collapseCtcPosteriorSegments } from "./ctc";
+
+describe("pronunciation-engine CTC posterior collapse", () => {
+  it("collapses repeated tokens and separates repetitions across blank", () => {
+    const segments = collapseCtcPosteriorSegments({
+      tokenLabels: ["<pad>", "θ", "s"],
+      blankTokenId: 0,
+      audioDurationMs: 100,
+      frames: [
+        [0.05, 0.9, 0.05],
+        [0.05, 0.9, 0.05],
+        [0.9, 0.05, 0.05],
+        [0.05, 0.9, 0.05],
+        [0.05, 0.9, 0.05],
+      ],
+    });
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      tokenId: 1,
+      startFrame: 0,
+      endFrameExclusive: 2,
+      startMs: 0,
+      endMs: 40,
+    });
+    expect(segments[1]).toMatchObject({
+      tokenId: 1,
+      startFrame: 3,
+      endFrameExclusive: 5,
+      startMs: 60,
+      endMs: 100,
+    });
+  });
+
+  it("keeps real top-k posterior probabilities without renormalizing", () => {
+    const [segment] = collapseCtcPosteriorSegments(
+      {
+        tokenLabels: ["<pad>", "θ", "s", "t"],
+        blankTokenId: 0,
+        audioDurationMs: 40,
+        frames: [
+          [0.1, 0.5, 0.3, 0.1],
+          [0.1, 0.4, 0.35, 0.15],
+        ],
+      },
+      { topK: 2 },
+    );
+
+    expect(segment?.candidates).toEqual([
+      { phone: "θ", probability: 0.45 },
+      { phone: "s", probability: 0.325 },
+    ]);
+    expect(segment?.capturedProbabilityMass).toBeCloseTo(0.775, 10);
+  });
+
+  it("uses segment-average evidence rather than one lucky frame", () => {
+    const [segment] = collapseCtcPosteriorSegments({
+      tokenLabels: ["<pad>", "θ", "s"],
+      blankTokenId: 0,
+      audioDurationMs: 60,
+      frames: [
+        [0.05, 0.9, 0.05],
+        [0.05, 0.51, 0.44],
+        [0.05, 0.52, 0.43],
+      ],
+    });
+
+    expect(segment?.candidates[0]?.phone).toBe("θ");
+    expect(segment?.candidates[0]?.probability).toBeCloseTo(
+      (0.9 + 0.51 + 0.52) / 3,
+      10,
+    );
+    expect(segment?.candidates[1]?.phone).toBe("s");
+  });
+
+  it("suppresses special tokens from phone candidates", () => {
+    const [segment] = collapseCtcPosteriorSegments({
+      tokenLabels: ["<pad>", "θ", "<unk>", "s"],
+      blankTokenId: 0,
+      audioDurationMs: 20,
+      frames: [[0.05, 0.55, 0.3, 0.1]],
+    });
+
+    expect(segment?.candidates.map((candidate) => candidate.phone)).toEqual([
+      "θ",
+      "s",
+    ]);
+  });
+
+  it("rejects invalid posterior matrices", () => {
+    expect(() =>
+      collapseCtcPosteriorSegments({
+        tokenLabels: ["<pad>", "θ"],
+        blankTokenId: 0,
+        audioDurationMs: 20,
+        frames: [[0.4, 0.4]],
+      }),
+    ).toThrow("ctc_frame_must_sum_to_one");
+  });
+});

--- a/src/lib/pronunciation-engine/ctc.test.ts
+++ b/src/lib/pronunciation-engine/ctc.test.ts
@@ -48,10 +48,10 @@ describe("pronunciation-engine CTC posterior collapse", () => {
       { topK: 2 },
     );
 
-    expect(segment?.candidates).toEqual([
-      { phone: "θ", probability: 0.45 },
-      { phone: "s", probability: 0.325 },
-    ]);
+    expect(segment?.candidates[0]?.phone).toBe("θ");
+    expect(segment?.candidates[0]?.probability).toBeCloseTo(0.45, 10);
+    expect(segment?.candidates[1]?.phone).toBe("s");
+    expect(segment?.candidates[1]?.probability).toBeCloseTo(0.325, 10);
     expect(segment?.capturedProbabilityMass).toBeCloseTo(0.775, 10);
   });
 

--- a/src/lib/pronunciation-engine/ctc.ts
+++ b/src/lib/pronunciation-engine/ctc.ts
@@ -1,0 +1,194 @@
+import type { ObservedPhone, PhoneCandidate } from "./types";
+
+export type CtcPosteriorMatrix = {
+  tokenLabels: readonly string[];
+  blankTokenId: number;
+  frames: readonly (readonly number[])[];
+  audioDurationMs: number;
+  source?: string | null;
+};
+
+export type CtcPosteriorSegment = ObservedPhone & {
+  tokenId: number;
+  startFrame: number;
+  endFrameExclusive: number;
+  capturedProbabilityMass: number;
+};
+
+export type CtcCollapseOptions = {
+  topK?: number;
+  /** Additional token IDs to suppress from phone candidates. */
+  ignoredTokenIds?: readonly number[];
+};
+
+const ROW_SUM_TOLERANCE = 1e-3;
+
+function normalizeTokenLabel(value: string) {
+  return value.normalize("NFC").trim();
+}
+
+function validateMatrix(matrix: CtcPosteriorMatrix) {
+  if (matrix.tokenLabels.length < 2) {
+    throw new Error("ctc_vocabulary_too_small");
+  }
+  if (
+    !Number.isInteger(matrix.blankTokenId) ||
+    matrix.blankTokenId < 0 ||
+    matrix.blankTokenId >= matrix.tokenLabels.length
+  ) {
+    throw new Error("ctc_blank_token_out_of_range");
+  }
+  if (
+    !Number.isFinite(matrix.audioDurationMs) ||
+    matrix.audioDurationMs <= 0
+  ) {
+    throw new Error("ctc_audio_duration_required");
+  }
+  if (matrix.frames.length === 0) throw new Error("ctc_frames_required");
+
+  for (const frame of matrix.frames) {
+    if (frame.length !== matrix.tokenLabels.length) {
+      throw new Error("ctc_frame_vocabulary_mismatch");
+    }
+
+    let sum = 0;
+    for (const probability of frame) {
+      if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+        throw new Error("ctc_probability_out_of_range");
+      }
+      sum += probability;
+    }
+
+    if (Math.abs(sum - 1) > ROW_SUM_TOLERANCE) {
+      throw new Error("ctc_frame_must_sum_to_one");
+    }
+  }
+}
+
+function argmax(values: readonly number[]) {
+  let bestIndex = 0;
+  let bestValue = values[0] ?? -Infinity;
+
+  for (let index = 1; index < values.length; index += 1) {
+    const value = values[index] ?? -Infinity;
+    if (value > bestValue) {
+      bestValue = value;
+      bestIndex = index;
+    }
+  }
+
+  return bestIndex;
+}
+
+function isCandidateLabel(label: string) {
+  return label.length > 0 && !(label.startsWith("<") && label.endsWith(">"));
+}
+
+function segmentCandidates(
+  matrix: CtcPosteriorMatrix,
+  startFrame: number,
+  endFrameExclusive: number,
+  ignoredTokenIds: ReadonlySet<number>,
+  topK: number,
+) {
+  const frameCount = endFrameExclusive - startFrame;
+  const averages = Array<number>(matrix.tokenLabels.length).fill(0);
+
+  for (let frameIndex = startFrame; frameIndex < endFrameExclusive; frameIndex += 1) {
+    const frame = matrix.frames[frameIndex] as readonly number[];
+    for (let tokenId = 0; tokenId < frame.length; tokenId += 1) {
+      averages[tokenId] += (frame[tokenId] ?? 0) / frameCount;
+    }
+  }
+
+  const candidates: PhoneCandidate[] = averages
+    .map((probability, tokenId) => ({
+      tokenId,
+      probability,
+      phone: normalizeTokenLabel(matrix.tokenLabels[tokenId] ?? ""),
+    }))
+    .filter(
+      (candidate) =>
+        !ignoredTokenIds.has(candidate.tokenId) &&
+        isCandidateLabel(candidate.phone) &&
+        candidate.probability > 0,
+    )
+    .sort((left, right) => right.probability - left.probability)
+    .slice(0, topK)
+    .map(({ phone, probability }) => ({ phone, probability }));
+
+  const capturedProbabilityMass = candidates.reduce(
+    (sum, candidate) => sum + (candidate.probability ?? 0),
+    0,
+  );
+
+  return { candidates, capturedProbabilityMass };
+}
+
+/**
+ * Greedy CTC collapse that keeps real posterior mass for each emitted run.
+ * Repeated top-1 IDs are merged until a blank/other token breaks the run. The
+ * returned top-k probabilities are averages from the original softmax rows and
+ * are deliberately NOT renormalized after truncation.
+ *
+ * This is a diagnostic bridge from a browser CTC model to the pronunciation
+ * evidence engine. It is not a replacement for future canonical CTC lattice
+ * alignment, which can recover evidence hidden under blank-heavy greedy paths.
+ */
+export function collapseCtcPosteriorSegments(
+  matrix: CtcPosteriorMatrix,
+  options: CtcCollapseOptions = {},
+): CtcPosteriorSegment[] {
+  validateMatrix(matrix);
+
+  const topK = options.topK ?? 5;
+  if (!Number.isInteger(topK) || topK < 1 || topK > 32) {
+    throw new Error("ctc_top_k_out_of_range");
+  }
+
+  const ignoredTokenIds = new Set<number>([
+    matrix.blankTokenId,
+    ...(options.ignoredTokenIds ?? []),
+  ]);
+  const frameDurationMs = matrix.audioDurationMs / matrix.frames.length;
+  const topIds = matrix.frames.map(argmax);
+  const segments: CtcPosteriorSegment[] = [];
+
+  let cursor = 0;
+  while (cursor < topIds.length) {
+    const tokenId = topIds[cursor] as number;
+    let end = cursor + 1;
+
+    while (end < topIds.length && topIds[end] === tokenId) end += 1;
+
+    if (!ignoredTokenIds.has(tokenId)) {
+      const topLabel = normalizeTokenLabel(matrix.tokenLabels[tokenId] ?? "");
+      if (isCandidateLabel(topLabel)) {
+        const { candidates, capturedProbabilityMass } = segmentCandidates(
+          matrix,
+          cursor,
+          end,
+          ignoredTokenIds,
+          topK,
+        );
+
+        if (candidates.length > 0) {
+          segments.push({
+            tokenId,
+            startFrame: cursor,
+            endFrameExclusive: end,
+            startMs: cursor * frameDurationMs,
+            endMs: end * frameDurationMs,
+            source: matrix.source ?? null,
+            candidates,
+            capturedProbabilityMass,
+          });
+        }
+      }
+    }
+
+    cursor = end;
+  }
+
+  return segments;
+}

--- a/src/lib/pronunciation-engine/ctc.ts
+++ b/src/lib/pronunciation-engine/ctc.ts
@@ -27,7 +27,7 @@ function normalizeTokenLabel(value: string) {
   return value.normalize("NFC").trim();
 }
 
-function validateMatrix(matrix: CtcPosteriorMatrix) {
+export function validateCtcPosteriorMatrix(matrix: CtcPosteriorMatrix) {
   if (matrix.tokenLabels.length < 2) {
     throw new Error("ctc_vocabulary_too_small");
   }
@@ -139,7 +139,7 @@ export function collapseCtcPosteriorSegments(
   matrix: CtcPosteriorMatrix,
   options: CtcCollapseOptions = {},
 ): CtcPosteriorSegment[] {
-  validateMatrix(matrix);
+  validateCtcPosteriorMatrix(matrix);
 
   const topK = options.topK ?? 5;
   if (!Number.isInteger(topK) || topK < 1 || topK > 32) {

--- a/src/lib/pronunciation-engine/evidence.ts
+++ b/src/lib/pronunciation-engine/evidence.ts
@@ -47,6 +47,8 @@ export function deriveUncalibratedSegmentalEvidence(
       ? null
       : posteriorMargins.reduce((sum, value) => sum + value, 0) /
         posteriorMargins.length;
+  const minimumPosteriorMargin =
+    posteriorMargins.length === 0 ? null : Math.min(...posteriorMargins);
 
   return {
     calibration: "unvalidated",
@@ -57,6 +59,7 @@ export function deriveUncalibratedSegmentalEvidence(
         ? 0
         : clampUnit(retainedCanonicalPhones / expectedPhoneCount),
     meanPosteriorMargin,
+    minimumPosteriorMargin,
     deletionCount,
     insertionCount,
     substitutionCount,

--- a/src/lib/pronunciation-engine/evidence.ts
+++ b/src/lib/pronunciation-engine/evidence.ts
@@ -1,0 +1,65 @@
+import type {
+  PronunciationAlignmentResult,
+  UncalibratedSegmentalEvidence,
+} from "./types";
+
+function clampUnit(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Converts an alignment into research-only segmental evidence.
+ *
+ * These values are intentionally not learner-facing scores. They become usable
+ * for feedback only after calibration against speaker-disjoint human ratings.
+ */
+export function deriveUncalibratedSegmentalEvidence(
+  result: PronunciationAlignmentResult,
+): UncalibratedSegmentalEvidence {
+  let deletionCount = 0;
+  let insertionCount = 0;
+  let substitutionCount = 0;
+  let expectedPhoneCount = 0;
+  const posteriorMargins: number[] = [];
+
+  for (const item of result.alignment) {
+    if (item.expected !== null) expectedPhoneCount += 1;
+
+    if (item.kind === "deletion") deletionCount += 1;
+    if (item.kind === "insertion") insertionCount += 1;
+    if (item.kind === "substitution") substitutionCount += 1;
+
+    if (
+      item.posteriorMargin !== null &&
+      Number.isFinite(item.posteriorMargin)
+    ) {
+      posteriorMargins.push(clampUnit(item.posteriorMargin));
+    }
+  }
+
+  const retainedCanonicalPhones = Math.max(
+    0,
+    expectedPhoneCount - deletionCount,
+  );
+
+  const meanPosteriorMargin =
+    posteriorMargins.length === 0
+      ? null
+      : posteriorMargins.reduce((sum, value) => sum + value, 0) /
+        posteriorMargins.length;
+
+  return {
+    calibration: "unvalidated",
+    selectedPronunciationId: result.pronunciationId,
+    rawAccuracySignal: clampUnit(1 - result.normalizedCost),
+    rawCompletenessSignal:
+      expectedPhoneCount === 0
+        ? 0
+        : clampUnit(retainedCanonicalPhones / expectedPhoneCount),
+    meanPosteriorMargin,
+    deletionCount,
+    insertionCount,
+    substitutionCount,
+    alignment: result.alignment,
+  };
+}

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -3,4 +3,6 @@ export * from "./calibration";
 export * from "./evidence";
 export * from "./metrics";
 export * from "./phonology";
+export * from "./prosody";
+export * from "./signal";
 export type * from "./types";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -1,5 +1,6 @@
 export * from "./alignment";
 export * from "./assessment";
+export * from "./benchmark";
 export * from "./calibration";
 export * from "./evidence";
 export * from "./metrics";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -3,6 +3,7 @@ export * from "./assessment";
 export * from "./benchmark";
 export * from "./calibration";
 export * from "./ctc";
+export * from "./ctc-lattice";
 export * from "./evidence";
 export * from "./metrics";
 export * from "./operating-point";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -1,0 +1,6 @@
+export * from "./alignment";
+export * from "./calibration";
+export * from "./evidence";
+export * from "./metrics";
+export * from "./phonology";
+export type * from "./types";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -5,6 +5,7 @@ export * from "./evidence";
 export * from "./metrics";
 export * from "./operating-point";
 export * from "./phonology";
+export * from "./posterior";
 export * from "./prosody";
 export * from "./signal";
 export type * from "./types";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -2,6 +2,7 @@ export * from "./alignment";
 export * from "./assessment";
 export * from "./benchmark";
 export * from "./calibration";
+export * from "./ctc";
 export * from "./evidence";
 export * from "./metrics";
 export * from "./operating-point";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -1,4 +1,5 @@
 export * from "./alignment";
+export * from "./assessment";
 export * from "./calibration";
 export * from "./evidence";
 export * from "./metrics";

--- a/src/lib/pronunciation-engine/index.ts
+++ b/src/lib/pronunciation-engine/index.ts
@@ -3,6 +3,7 @@ export * from "./assessment";
 export * from "./calibration";
 export * from "./evidence";
 export * from "./metrics";
+export * from "./operating-point";
 export * from "./phonology";
 export * from "./prosody";
 export * from "./signal";

--- a/src/lib/pronunciation-engine/metrics.test.ts
+++ b/src/lib/pronunciation-engine/metrics.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  binaryClassificationMetrics,
+  brierScore,
+  expectedCalibrationError,
+  meanAbsoluteError,
+  pearsonCorrelation,
+  rocAuc,
+  rootMeanSquaredError,
+  spearmanCorrelation,
+  thresholdProbabilities,
+} from "./metrics";
+
+describe("pronunciation-engine research metrics", () => {
+  it("computes regression errors and correlations", () => {
+    expect(meanAbsoluteError([1, 2, 3], [1, 1, 5])).toBeCloseTo(1);
+    expect(rootMeanSquaredError([1, 2, 3], [1, 1, 5])).toBeCloseTo(
+      Math.sqrt(5 / 3),
+    );
+    expect(pearsonCorrelation([1, 2, 3], [2, 4, 6])).toBeCloseTo(1);
+    expect(spearmanCorrelation([10, 20, 20, 40], [1, 2, 2, 4])).toBeCloseTo(1);
+  });
+
+  it("returns null correlation when variance is undefined", () => {
+    expect(pearsonCorrelation([1, 1], [1, 2])).toBeNull();
+  });
+
+  it("reports MDD false acceptance and false rejection explicitly", () => {
+    const metrics = binaryClassificationMetrics([1, 1, 0, 0], [1, 0, 1, 0]);
+
+    expect(metrics).toMatchObject({
+      truePositive: 1,
+      trueNegative: 1,
+      falsePositive: 1,
+      falseNegative: 1,
+      precision: 0.5,
+      recall: 0.5,
+      specificity: 0.5,
+      f1: 0.5,
+      matthewsCorrelationCoefficient: 0,
+      falseAcceptanceRate: 0.5,
+      falseRejectionRate: 0.5,
+    });
+  });
+
+  it("thresholds calibrated mispronunciation probabilities", () => {
+    expect(thresholdProbabilities([0.1, 0.49, 0.5, 0.9], 0.5)).toEqual([
+      0, 0, 1, 1,
+    ]);
+  });
+
+  it("computes probability calibration metrics", () => {
+    expect(brierScore([0.1, 0.9], [0, 1])).toBeCloseTo(0.01);
+    expect(expectedCalibrationError([0.1, 0.9], [0, 1], 2)).toBeCloseTo(
+      0.1,
+    );
+  });
+
+  it("computes tie-aware ROC AUC", () => {
+    expect(rocAuc([0.1, 0.9], [0, 1])).toBe(1);
+    expect(rocAuc([0.5, 0.5], [0, 1])).toBe(0.5);
+    expect(rocAuc([0.1, 0.2], [0, 0])).toBeNull();
+  });
+
+  it("rejects invalid probabilities and thresholds", () => {
+    expect(() => thresholdProbabilities([0.5], 1.1)).toThrow(
+      "classification_threshold_must_be_between_zero_and_one",
+    );
+    expect(() => brierScore([1.2], [1])).toThrow(
+      "probability_must_be_between_zero_and_one",
+    );
+  });
+});

--- a/src/lib/pronunciation-engine/metrics.ts
+++ b/src/lib/pronunciation-engine/metrics.ts
@@ -314,7 +314,7 @@ export function rocAuc(
   if (positiveCount === 0 || negativeCount === 0) return null;
 
   const ranks = averageRanks(probabilities);
-  const positiveRankSum = targets.reduce(
+  const positiveRankSum = targets.reduce<number>(
     (sum, target, index) => sum + (target === 1 ? (ranks[index] as number) : 0),
     0,
   );

--- a/src/lib/pronunciation-engine/metrics.ts
+++ b/src/lib/pronunciation-engine/metrics.ts
@@ -1,0 +1,326 @@
+export type BinaryLabel = 0 | 1;
+
+export type ConfusionMatrix = {
+  truePositive: number;
+  trueNegative: number;
+  falsePositive: number;
+  falseNegative: number;
+};
+
+export type BinaryClassificationMetrics = ConfusionMatrix & {
+  precision: number | null;
+  recall: number | null;
+  specificity: number | null;
+  f1: number | null;
+  matthewsCorrelationCoefficient: number | null;
+  /**
+   * MDD convention used here: an actually mispronounced phone is accepted as
+   * correct. Equivalent to the false-negative rate when positive=mispronounced.
+   */
+  falseAcceptanceRate: number | null;
+  /**
+   * MDD convention used here: an actually correct phone is rejected as a
+   * mispronunciation. Equivalent to the false-positive rate.
+   */
+  falseRejectionRate: number | null;
+};
+
+function assertPairedLength(left: readonly unknown[], right: readonly unknown[]) {
+  if (left.length === 0 || left.length !== right.length) {
+    throw new Error("paired_metric_values_required");
+  }
+}
+
+function assertFiniteValues(values: readonly number[]) {
+  if (values.some((value) => !Number.isFinite(value))) {
+    throw new Error("metric_values_must_be_finite");
+  }
+}
+
+function safeDivide(numerator: number, denominator: number) {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+export function meanAbsoluteError(
+  predictions: readonly number[],
+  targets: readonly number[],
+) {
+  assertPairedLength(predictions, targets);
+  assertFiniteValues(predictions);
+  assertFiniteValues(targets);
+
+  return (
+    predictions.reduce(
+      (sum, prediction, index) =>
+        sum + Math.abs(prediction - (targets[index] as number)),
+      0,
+    ) / predictions.length
+  );
+}
+
+export function rootMeanSquaredError(
+  predictions: readonly number[],
+  targets: readonly number[],
+) {
+  assertPairedLength(predictions, targets);
+  assertFiniteValues(predictions);
+  assertFiniteValues(targets);
+
+  const mse =
+    predictions.reduce((sum, prediction, index) => {
+      const difference = prediction - (targets[index] as number);
+      return sum + difference * difference;
+    }, 0) / predictions.length;
+
+  return Math.sqrt(mse);
+}
+
+export function pearsonCorrelation(
+  left: readonly number[],
+  right: readonly number[],
+): number | null {
+  assertPairedLength(left, right);
+  assertFiniteValues(left);
+  assertFiniteValues(right);
+
+  const leftMean = left.reduce((sum, value) => sum + value, 0) / left.length;
+  const rightMean = right.reduce((sum, value) => sum + value, 0) / right.length;
+
+  let covariance = 0;
+  let leftVariance = 0;
+  let rightVariance = 0;
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftDelta = (left[index] as number) - leftMean;
+    const rightDelta = (right[index] as number) - rightMean;
+    covariance += leftDelta * rightDelta;
+    leftVariance += leftDelta * leftDelta;
+    rightVariance += rightDelta * rightDelta;
+  }
+
+  const denominator = Math.sqrt(leftVariance * rightVariance);
+  return denominator === 0 ? null : covariance / denominator;
+}
+
+function averageRanks(values: readonly number[]) {
+  const indexed = values
+    .map((value, index) => ({ value, index }))
+    .sort((left, right) => left.value - right.value);
+  const ranks = Array<number>(values.length).fill(0);
+
+  let cursor = 0;
+  while (cursor < indexed.length) {
+    let end = cursor + 1;
+    while (
+      end < indexed.length &&
+      indexed[end]?.value === indexed[cursor]?.value
+    ) {
+      end += 1;
+    }
+
+    // Ranks are 1-based; tied values receive the mean rank.
+    const averageRank = ((cursor + 1) + end) / 2;
+
+    for (let index = cursor; index < end; index += 1) {
+      const originalIndex = indexed[index]?.index;
+      if (originalIndex !== undefined) ranks[originalIndex] = averageRank;
+    }
+
+    cursor = end;
+  }
+
+  return ranks;
+}
+
+export function spearmanCorrelation(
+  left: readonly number[],
+  right: readonly number[],
+) {
+  assertPairedLength(left, right);
+  assertFiniteValues(left);
+  assertFiniteValues(right);
+  return pearsonCorrelation(averageRanks(left), averageRanks(right));
+}
+
+export function confusionMatrix(
+  predictions: readonly BinaryLabel[],
+  targets: readonly BinaryLabel[],
+): ConfusionMatrix {
+  assertPairedLength(predictions, targets);
+
+  let truePositive = 0;
+  let trueNegative = 0;
+  let falsePositive = 0;
+  let falseNegative = 0;
+
+  for (let index = 0; index < predictions.length; index += 1) {
+    const prediction = predictions[index];
+    const target = targets[index];
+
+    if (prediction === 1 && target === 1) truePositive += 1;
+    else if (prediction === 0 && target === 0) trueNegative += 1;
+    else if (prediction === 1 && target === 0) falsePositive += 1;
+    else falseNegative += 1;
+  }
+
+  return { truePositive, trueNegative, falsePositive, falseNegative };
+}
+
+export function binaryClassificationMetrics(
+  predictions: readonly BinaryLabel[],
+  targets: readonly BinaryLabel[],
+): BinaryClassificationMetrics {
+  const matrix = confusionMatrix(predictions, targets);
+  const { truePositive, trueNegative, falsePositive, falseNegative } = matrix;
+
+  const precision = safeDivide(truePositive, truePositive + falsePositive);
+  const recall = safeDivide(truePositive, truePositive + falseNegative);
+  const specificity = safeDivide(trueNegative, trueNegative + falsePositive);
+  const f1 =
+    precision === null || recall === null || precision + recall === 0
+      ? null
+      : (2 * precision * recall) / (precision + recall);
+
+  const mccDenominator = Math.sqrt(
+    (truePositive + falsePositive) *
+      (truePositive + falseNegative) *
+      (trueNegative + falsePositive) *
+      (trueNegative + falseNegative),
+  );
+
+  return {
+    ...matrix,
+    precision,
+    recall,
+    specificity,
+    f1,
+    matthewsCorrelationCoefficient:
+      mccDenominator === 0
+        ? null
+        : (truePositive * trueNegative - falsePositive * falseNegative) /
+          mccDenominator,
+    falseAcceptanceRate: safeDivide(
+      falseNegative,
+      truePositive + falseNegative,
+    ),
+    falseRejectionRate: safeDivide(
+      falsePositive,
+      trueNegative + falsePositive,
+    ),
+  };
+}
+
+export function thresholdProbabilities(
+  probabilities: readonly number[],
+  threshold: number,
+): BinaryLabel[] {
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new Error("classification_threshold_must_be_between_zero_and_one");
+  }
+
+  assertFiniteValues(probabilities);
+
+  return probabilities.map((probability) => {
+    if (probability < 0 || probability > 1) {
+      throw new Error("probability_must_be_between_zero_and_one");
+    }
+    return probability >= threshold ? 1 : 0;
+  });
+}
+
+export function brierScore(
+  probabilities: readonly number[],
+  targets: readonly BinaryLabel[],
+) {
+  assertPairedLength(probabilities, targets);
+  assertFiniteValues(probabilities);
+
+  return (
+    probabilities.reduce((sum, probability, index) => {
+      if (probability < 0 || probability > 1) {
+        throw new Error("probability_must_be_between_zero_and_one");
+      }
+      const difference = probability - (targets[index] as BinaryLabel);
+      return sum + difference * difference;
+    }, 0) / probabilities.length
+  );
+}
+
+export function expectedCalibrationError(
+  probabilities: readonly number[],
+  targets: readonly BinaryLabel[],
+  binCount = 10,
+) {
+  assertPairedLength(probabilities, targets);
+  assertFiniteValues(probabilities);
+
+  if (!Number.isInteger(binCount) || binCount < 2 || binCount > 100) {
+    throw new Error("calibration_bin_count_out_of_range");
+  }
+
+  const bins = Array.from({ length: binCount }, () => ({
+    count: 0,
+    confidenceSum: 0,
+    targetSum: 0,
+  }));
+
+  for (let index = 0; index < probabilities.length; index += 1) {
+    const probability = probabilities[index] as number;
+    const target = targets[index] as BinaryLabel;
+
+    if (probability < 0 || probability > 1) {
+      throw new Error("probability_must_be_between_zero_and_one");
+    }
+
+    const binIndex = Math.min(binCount - 1, Math.floor(probability * binCount));
+    const bin = bins[binIndex];
+    if (!bin) continue;
+
+    bin.count += 1;
+    bin.confidenceSum += probability;
+    bin.targetSum += target;
+  }
+
+  return bins.reduce((ece, bin) => {
+    if (bin.count === 0) return ece;
+    const meanConfidence = bin.confidenceSum / bin.count;
+    const empiricalFrequency = bin.targetSum / bin.count;
+    return (
+      ece +
+      (bin.count / probabilities.length) *
+        Math.abs(meanConfidence - empiricalFrequency)
+    );
+  }, 0);
+}
+
+/**
+ * Tie-aware ROC AUC using average ranks. Positive labels mean mispronounced.
+ */
+export function rocAuc(
+  probabilities: readonly number[],
+  targets: readonly BinaryLabel[],
+): number | null {
+  assertPairedLength(probabilities, targets);
+  assertFiniteValues(probabilities);
+
+  for (const probability of probabilities) {
+    if (probability < 0 || probability > 1) {
+      throw new Error("probability_must_be_between_zero_and_one");
+    }
+  }
+
+  const positiveCount = targets.filter((target) => target === 1).length;
+  const negativeCount = targets.length - positiveCount;
+  if (positiveCount === 0 || negativeCount === 0) return null;
+
+  const ranks = averageRanks(probabilities);
+  const positiveRankSum = targets.reduce(
+    (sum, target, index) => sum + (target === 1 ? (ranks[index] as number) : 0),
+    0,
+  );
+
+  const mannWhitneyU =
+    positiveRankSum - (positiveCount * (positiveCount + 1)) / 2;
+
+  return mannWhitneyU / (positiveCount * negativeCount);
+}

--- a/src/lib/pronunciation-engine/operating-point.test.ts
+++ b/src/lib/pronunciation-engine/operating-point.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { selectOperatingThreshold } from "./operating-point";
+
+describe("pronunciation-engine operating point", () => {
+  it("finds a perfect separating validation threshold when one exists", () => {
+    const result = selectOperatingThreshold(
+      [0.1, 0.2, 0.8, 0.9],
+      [0, 0, 1, 1],
+      { objective: "mcc" },
+    );
+
+    expect(result.threshold).toBe(0.5);
+    expect(result.objectiveValue).toBe(1);
+    expect(result.metrics.matthewsCorrelationCoefficient).toBe(1);
+    expect(result.metrics.falseAcceptanceRate).toBe(0);
+    expect(result.metrics.falseRejectionRate).toBe(0);
+  });
+
+  it("moves the operating point according to asymmetric MDD error costs", () => {
+    const probabilities = [0.2, 0.4, 0.6, 0.8];
+    const targets = [0, 1, 0, 1] as const;
+
+    const protectAgainstFalseAcceptance = selectOperatingThreshold(
+      probabilities,
+      targets,
+      {
+        objective: "cost",
+        falseAcceptanceCost: 10,
+        falseRejectionCost: 1,
+      },
+    );
+
+    const protectAgainstFalseRejection = selectOperatingThreshold(
+      probabilities,
+      targets,
+      {
+        objective: "cost",
+        falseAcceptanceCost: 1,
+        falseRejectionCost: 10,
+      },
+    );
+
+    expect(protectAgainstFalseAcceptance.threshold).toBeLessThan(
+      protectAgainstFalseRejection.threshold,
+    );
+    expect(protectAgainstFalseAcceptance.metrics.falseAcceptanceRate).toBe(0);
+    expect(protectAgainstFalseRejection.metrics.falseRejectionRate).toBe(0);
+  });
+
+  it("rejects invalid validation pairs and costs", () => {
+    expect(() => selectOperatingThreshold([], [])).toThrow(
+      "operating_point_pairs_required",
+    );
+    expect(() =>
+      selectOperatingThreshold([0.5], [1], { falseAcceptanceCost: -1 }),
+    ).toThrow("operating_point_costs_must_be_non_negative");
+  });
+});

--- a/src/lib/pronunciation-engine/operating-point.ts
+++ b/src/lib/pronunciation-engine/operating-point.ts
@@ -24,6 +24,11 @@ export type OperatingPoint = {
   metrics: BinaryClassificationMetrics;
 };
 
+type OperatingPointCosts = {
+  falseAcceptanceCost: number;
+  falseRejectionCost: number;
+};
+
 function candidateThresholds(probabilities: readonly number[]) {
   const unique = [...new Set(probabilities)].sort((left, right) => left - right);
   const candidates = new Set<number>([0, 1]);
@@ -50,7 +55,7 @@ function finiteMetric(value: number | null, fallback: number) {
 function objectiveValue(
   metrics: BinaryClassificationMetrics,
   objective: OperatingPointObjective,
-  options: Required<Pick<OperatingPointOptions, "falseAcceptanceCost" | "falseRejectionCost">>,
+  costs: OperatingPointCosts,
 ) {
   switch (objective) {
     case "mcc":
@@ -66,9 +71,9 @@ function objectiveValue(
       const far = finiteMetric(metrics.falseAcceptanceRate, 1);
       const frr = finiteMetric(metrics.falseRejectionRate, 1);
       return -(
-        options.falseAcceptanceCost * far +
-        options.falseRejectionCost * frr
+        costs.falseAcceptanceCost * far + costs.falseRejectionCost * frr
       );
+    }
   }
 }
 
@@ -135,7 +140,8 @@ export function selectOperatingThreshold(
       if (
         candidateError < bestError - 1e-12 ||
         (Math.abs(candidateError - bestError) <= 1e-12 &&
-          Math.abs(candidate.threshold - 0.5) < Math.abs(best.threshold - 0.5))
+          Math.abs(candidate.threshold - 0.5) <
+            Math.abs(best.threshold - 0.5))
       ) {
         best = candidate;
       }

--- a/src/lib/pronunciation-engine/operating-point.ts
+++ b/src/lib/pronunciation-engine/operating-point.ts
@@ -1,0 +1,147 @@
+import {
+  binaryClassificationMetrics,
+  thresholdProbabilities,
+  type BinaryClassificationMetrics,
+  type BinaryLabel,
+} from "./metrics";
+
+export type OperatingPointObjective =
+  | "mcc"
+  | "f1"
+  | "balanced_error"
+  | "cost";
+
+export type OperatingPointOptions = {
+  objective?: OperatingPointObjective;
+  falseAcceptanceCost?: number;
+  falseRejectionCost?: number;
+};
+
+export type OperatingPoint = {
+  threshold: number;
+  objective: OperatingPointObjective;
+  objectiveValue: number;
+  metrics: BinaryClassificationMetrics;
+};
+
+function candidateThresholds(probabilities: readonly number[]) {
+  const unique = [...new Set(probabilities)].sort((left, right) => left - right);
+  const candidates = new Set<number>([0, 1]);
+
+  for (const value of unique) {
+    candidates.add(value);
+  }
+
+  for (let index = 1; index < unique.length; index += 1) {
+    const left = unique[index - 1];
+    const right = unique[index];
+    if (left !== undefined && right !== undefined) {
+      candidates.add((left + right) / 2);
+    }
+  }
+
+  return [...candidates].sort((left, right) => left - right);
+}
+
+function finiteMetric(value: number | null, fallback: number) {
+  return value === null || !Number.isFinite(value) ? fallback : value;
+}
+
+function objectiveValue(
+  metrics: BinaryClassificationMetrics,
+  objective: OperatingPointObjective,
+  options: Required<Pick<OperatingPointOptions, "falseAcceptanceCost" | "falseRejectionCost">>,
+) {
+  switch (objective) {
+    case "mcc":
+      return finiteMetric(metrics.matthewsCorrelationCoefficient, -1);
+    case "f1":
+      return finiteMetric(metrics.f1, 0);
+    case "balanced_error": {
+      const far = finiteMetric(metrics.falseAcceptanceRate, 1);
+      const frr = finiteMetric(metrics.falseRejectionRate, 1);
+      return -((far + frr) / 2);
+    }
+    case "cost": {
+      const far = finiteMetric(metrics.falseAcceptanceRate, 1);
+      const frr = finiteMetric(metrics.falseRejectionRate, 1);
+      return -(
+        options.falseAcceptanceCost * far +
+        options.falseRejectionCost * frr
+      );
+  }
+}
+
+function secondaryError(metrics: BinaryClassificationMetrics) {
+  return (
+    finiteMetric(metrics.falseAcceptanceRate, 1) +
+    finiteMetric(metrics.falseRejectionRate, 1)
+  );
+}
+
+/**
+ * Selects an MDD operating point on validation/calibration data only.
+ * Positive=mispronounced. The returned threshold must be frozen before final
+ * test evaluation; this utility should never be run against the held-out test
+ * split to improve reported metrics.
+ */
+export function selectOperatingThreshold(
+  probabilities: readonly number[],
+  targets: readonly BinaryLabel[],
+  options: OperatingPointOptions = {},
+): OperatingPoint {
+  if (probabilities.length === 0 || probabilities.length !== targets.length) {
+    throw new Error("operating_point_pairs_required");
+  }
+
+  const objective = options.objective ?? "mcc";
+  const falseAcceptanceCost = options.falseAcceptanceCost ?? 1;
+  const falseRejectionCost = options.falseRejectionCost ?? 1;
+
+  if (
+    !Number.isFinite(falseAcceptanceCost) ||
+    !Number.isFinite(falseRejectionCost) ||
+    falseAcceptanceCost < 0 ||
+    falseRejectionCost < 0
+  ) {
+    throw new Error("operating_point_costs_must_be_non_negative");
+  }
+
+  let best: OperatingPoint | null = null;
+
+  for (const threshold of candidateThresholds(probabilities)) {
+    const predictions = thresholdProbabilities(probabilities, threshold);
+    const metrics = binaryClassificationMetrics(predictions, targets);
+    const value = objectiveValue(metrics, objective, {
+      falseAcceptanceCost,
+      falseRejectionCost,
+    });
+    const candidate: OperatingPoint = {
+      threshold,
+      objective,
+      objectiveValue: value,
+      metrics,
+    };
+
+    if (!best || candidate.objectiveValue > best.objectiveValue + 1e-12) {
+      best = candidate;
+      continue;
+    }
+
+    if (Math.abs(candidate.objectiveValue - best.objectiveValue) <= 1e-12) {
+      const candidateError = secondaryError(candidate.metrics);
+      const bestError = secondaryError(best.metrics);
+
+      if (
+        candidateError < bestError - 1e-12 ||
+        (Math.abs(candidateError - bestError) <= 1e-12 &&
+          Math.abs(candidate.threshold - 0.5) < Math.abs(best.threshold - 0.5))
+      ) {
+        best = candidate;
+      }
+    }
+  }
+
+  if (!best) throw new Error("operating_point_pairs_required");
+  return best;
+}

--- a/src/lib/pronunciation-engine/phonology.test.ts
+++ b/src/lib/pronunciation-engine/phonology.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  articulatoryDeltaForPhones,
+  isKnownEnglishPhone,
+  normalizeEnglishPhone,
+  phonologicalDistance,
+} from "./phonology";
+
+describe("pronunciation-engine phonology", () => {
+  it("normalizes common English IPA variants", () => {
+    expect(normalizeEnglishPhone(" t͡ʃ ")).toBe("tʃ");
+    expect(normalizeEnglishPhone("ɡ")).toBe("g");
+    expect(normalizeEnglishPhone("r")).toBe("ɹ");
+  });
+
+  it("assigns zero distance to the same phone", () => {
+    expect(phonologicalDistance("θ", "θ")).toBe(0);
+    expect(phonologicalDistance("t͡ʃ", "tʃ")).toBe(0);
+  });
+
+  it("treats a nearby theta-to-s change as closer than theta-to-m", () => {
+    expect(phonologicalDistance("θ", "s")).toBeLessThan(
+      phonologicalDistance("θ", "m"),
+    );
+  });
+
+  it("treats a voicing-only stop contrast as relatively small", () => {
+    expect(phonologicalDistance("t", "d")).toBeLessThan(0.25);
+    expect(phonologicalDistance("t", "d")).toBeLessThan(
+      phonologicalDistance("t", "ʃ"),
+    );
+  });
+
+  it("treats a near high-front vowel contrast as closer than a distant vowel", () => {
+    expect(phonologicalDistance("iː", "ɪ")).toBeLessThan(
+      phonologicalDistance("iː", "ɑ"),
+    );
+  });
+
+  it("describes the articulatory change for theta-to-s", () => {
+    expect(articulatoryDeltaForPhones("θ", "s")).toEqual({
+      place: { expected: "dental", observed: "alveolar" },
+      manner: null,
+      voicing: null,
+    });
+  });
+
+  it("distinguishes known and unknown phone symbols", () => {
+    expect(isKnownEnglishPhone("ð")).toBe(true);
+    expect(isKnownEnglishPhone("🦊")).toBe(false);
+  });
+});

--- a/src/lib/pronunciation-engine/phonology.ts
+++ b/src/lib/pronunciation-engine/phonology.ts
@@ -1,0 +1,411 @@
+import type { ArticulatoryDelta } from "./types";
+
+type ConsonantManner =
+  | "stop"
+  | "affricate"
+  | "fricative"
+  | "nasal"
+  | "approximant"
+  | "lateral"
+  | "tap";
+
+type ConsonantPlace =
+  | "bilabial"
+  | "labiodental"
+  | "dental"
+  | "alveolar"
+  | "postalveolar"
+  | "palatal"
+  | "velar"
+  | "glottal"
+  | "labial-velar";
+
+type ConsonantFeatures = {
+  kind: "consonant";
+  place: ConsonantPlace;
+  manner: ConsonantManner;
+  voiced: boolean;
+  nasal: boolean;
+  lateral: boolean;
+  sonorant: boolean;
+};
+
+type VowelPoint = {
+  /** 0 = close, 1 = open. */
+  height: number;
+  /** 0 = front, 0.5 = central, 1 = back. */
+  backness: number;
+  rounded: boolean;
+  rhotic: boolean;
+};
+
+type VowelFeatures = {
+  kind: "vowel";
+  start: VowelPoint;
+  end: VowelPoint;
+  /** 0 = short/lax proxy, 1 = explicitly long. */
+  length: number;
+};
+
+type EnglishPhoneFeatures = ConsonantFeatures | VowelFeatures;
+
+const placeCoordinate: Record<Exclude<ConsonantPlace, "labial-velar">, number> = {
+  bilabial: 0,
+  labiodental: 0.7,
+  dental: 1.6,
+  alveolar: 2.2,
+  postalveolar: 3.1,
+  palatal: 4,
+  velar: 5,
+  glottal: 6,
+};
+
+function consonant(
+  place: ConsonantPlace,
+  manner: ConsonantManner,
+  voiced: boolean,
+): ConsonantFeatures {
+  const nasal = manner === "nasal";
+  const lateral = manner === "lateral";
+  const sonorant =
+    nasal || lateral || manner === "approximant" || manner === "tap";
+
+  return {
+    kind: "consonant",
+    place,
+    manner,
+    voiced,
+    nasal,
+    lateral,
+    sonorant,
+  };
+}
+
+function point(
+  height: number,
+  backness: number,
+  rounded = false,
+  rhotic = false,
+): VowelPoint {
+  return { height, backness, rounded, rhotic };
+}
+
+function vowel(
+  start: VowelPoint,
+  end: VowelPoint = start,
+  length = 0,
+): VowelFeatures {
+  return { kind: "vowel", start, end, length };
+}
+
+const VOWEL_POINTS = {
+  i: point(0, 0),
+  ɪ: point(0.16, 0.08),
+  e: point(0.32, 0.05),
+  ɛ: point(0.64, 0.05),
+  æ: point(0.86, 0.08),
+  a: point(0.98, 0.35),
+  ɑ: point(1, 0.95),
+  ɒ: point(0.96, 1, true),
+  ɔ: point(0.66, 1, true),
+  o: point(0.34, 1, true),
+  ʊ: point(0.18, 0.92, true),
+  u: point(0, 1, true),
+  ʌ: point(0.66, 0.62),
+  ɜ: point(0.62, 0.5),
+  ə: point(0.5, 0.5),
+  ɐ: point(0.78, 0.5),
+  ɚ: point(0.5, 0.5, false, true),
+  ɝ: point(0.62, 0.5, false, true),
+} as const;
+
+const PHONE_FEATURES: Record<string, EnglishPhoneFeatures> = {
+  p: consonant("bilabial", "stop", false),
+  b: consonant("bilabial", "stop", true),
+  t: consonant("alveolar", "stop", false),
+  d: consonant("alveolar", "stop", true),
+  k: consonant("velar", "stop", false),
+  g: consonant("velar", "stop", true),
+  ʔ: consonant("glottal", "stop", false),
+  f: consonant("labiodental", "fricative", false),
+  v: consonant("labiodental", "fricative", true),
+  θ: consonant("dental", "fricative", false),
+  ð: consonant("dental", "fricative", true),
+  s: consonant("alveolar", "fricative", false),
+  z: consonant("alveolar", "fricative", true),
+  ʃ: consonant("postalveolar", "fricative", false),
+  ʒ: consonant("postalveolar", "fricative", true),
+  h: consonant("glottal", "fricative", false),
+  tʃ: consonant("postalveolar", "affricate", false),
+  dʒ: consonant("postalveolar", "affricate", true),
+  m: consonant("bilabial", "nasal", true),
+  n: consonant("alveolar", "nasal", true),
+  ŋ: consonant("velar", "nasal", true),
+  l: consonant("alveolar", "lateral", true),
+  ɹ: consonant("alveolar", "approximant", true),
+  j: consonant("palatal", "approximant", true),
+  w: consonant("labial-velar", "approximant", true),
+  ɾ: consonant("alveolar", "tap", true),
+
+  i: vowel(VOWEL_POINTS.i, VOWEL_POINTS.i, 0.6),
+  "iː": vowel(VOWEL_POINTS.i, VOWEL_POINTS.i, 1),
+  ɪ: vowel(VOWEL_POINTS.ɪ, VOWEL_POINTS.ɪ, 0),
+  e: vowel(VOWEL_POINTS.e, VOWEL_POINTS.e, 0.45),
+  ɛ: vowel(VOWEL_POINTS.ɛ, VOWEL_POINTS.ɛ, 0),
+  æ: vowel(VOWEL_POINTS.æ, VOWEL_POINTS.æ, 0),
+  a: vowel(VOWEL_POINTS.a, VOWEL_POINTS.a, 0.2),
+  ɑ: vowel(VOWEL_POINTS.ɑ, VOWEL_POINTS.ɑ, 0.5),
+  "ɑː": vowel(VOWEL_POINTS.ɑ, VOWEL_POINTS.ɑ, 1),
+  ɒ: vowel(VOWEL_POINTS.ɒ, VOWEL_POINTS.ɒ, 0),
+  ɔ: vowel(VOWEL_POINTS.ɔ, VOWEL_POINTS.ɔ, 0.5),
+  "ɔː": vowel(VOWEL_POINTS.ɔ, VOWEL_POINTS.ɔ, 1),
+  o: vowel(VOWEL_POINTS.o, VOWEL_POINTS.o, 0.5),
+  ʊ: vowel(VOWEL_POINTS.ʊ, VOWEL_POINTS.ʊ, 0),
+  u: vowel(VOWEL_POINTS.u, VOWEL_POINTS.u, 0.6),
+  "uː": vowel(VOWEL_POINTS.u, VOWEL_POINTS.u, 1),
+  ʌ: vowel(VOWEL_POINTS.ʌ, VOWEL_POINTS.ʌ, 0),
+  ɜ: vowel(VOWEL_POINTS.ɜ, VOWEL_POINTS.ɜ, 0.5),
+  "ɜː": vowel(VOWEL_POINTS.ɜ, VOWEL_POINTS.ɜ, 1),
+  ə: vowel(VOWEL_POINTS.ə, VOWEL_POINTS.ə, 0),
+  ɐ: vowel(VOWEL_POINTS.ɐ, VOWEL_POINTS.ɐ, 0),
+  ɚ: vowel(VOWEL_POINTS.ɚ, VOWEL_POINTS.ɚ, 0),
+  ɝ: vowel(VOWEL_POINTS.ɝ, VOWEL_POINTS.ɝ, 0.8),
+
+  eɪ: vowel(VOWEL_POINTS.e, VOWEL_POINTS.ɪ, 0.75),
+  aɪ: vowel(VOWEL_POINTS.a, VOWEL_POINTS.ɪ, 0.75),
+  ɔɪ: vowel(VOWEL_POINTS.ɔ, VOWEL_POINTS.ɪ, 0.75),
+  aʊ: vowel(VOWEL_POINTS.a, VOWEL_POINTS.ʊ, 0.75),
+  oʊ: vowel(VOWEL_POINTS.o, VOWEL_POINTS.ʊ, 0.75),
+  əʊ: vowel(VOWEL_POINTS.ə, VOWEL_POINTS.ʊ, 0.75),
+  ɪə: vowel(VOWEL_POINTS.ɪ, VOWEL_POINTS.ə, 0.65),
+  eə: vowel(VOWEL_POINTS.e, VOWEL_POINTS.ə, 0.65),
+  ɛə: vowel(VOWEL_POINTS.ɛ, VOWEL_POINTS.ə, 0.65),
+  ʊə: vowel(VOWEL_POINTS.ʊ, VOWEL_POINTS.ə, 0.65),
+};
+
+export function normalizeEnglishPhone(value: string) {
+  return value
+    .normalize("NFC")
+    .replaceAll("t͡ʃ", "tʃ")
+    .replaceAll("d͡ʒ", "dʒ")
+    .replaceAll("ɡ", "g")
+    .replaceAll("r", "ɹ")
+    .replace(/[\/\[\]ˈˌ.\s]/gu, "")
+    .trim();
+}
+
+function placeDistance(left: ConsonantPlace, right: ConsonantPlace) {
+  if (left === right) return 0;
+
+  const coordinate = (place: ConsonantPlace) => {
+    if (place === "labial-velar") {
+      return [placeCoordinate.bilabial, placeCoordinate.velar];
+    }
+
+    return [placeCoordinate[place]];
+  };
+
+  const leftCoordinates = coordinate(left);
+  const rightCoordinates = coordinate(right);
+  let minimum = 1;
+
+  for (const leftCoordinate of leftCoordinates) {
+    for (const rightCoordinate of rightCoordinates) {
+      minimum = Math.min(
+        minimum,
+        Math.abs(leftCoordinate - rightCoordinate) / placeCoordinate.glottal,
+      );
+    }
+  }
+
+  // Complex labial-velar articulation should not be considered identical to
+  // either of its component places merely because one coordinate overlaps.
+  if (minimum === 0 && (left === "labial-velar" || right === "labial-velar")) {
+    return 0.2;
+  }
+
+  return minimum;
+}
+
+function mannerDistance(left: ConsonantManner, right: ConsonantManner) {
+  if (left === right) return 0;
+
+  const pair = new Set([left, right]);
+
+  if (pair.has("stop") && pair.has("affricate")) return 0.45;
+  if (pair.has("affricate") && pair.has("fricative")) return 0.35;
+  if (pair.has("stop") && pair.has("tap")) return 0.25;
+  if (pair.has("approximant") && pair.has("lateral")) return 0.35;
+  if (pair.has("stop") && pair.has("nasal")) return 0.55;
+  if (pair.has("approximant") && pair.has("tap")) return 0.45;
+
+  return 1;
+}
+
+function consonantDistance(left: ConsonantFeatures, right: ConsonantFeatures) {
+  const place = placeDistance(left.place, right.place);
+  const manner = mannerDistance(left.manner, right.manner);
+  const voicing = left.voiced === right.voiced ? 0 : 1;
+  const sonorant = left.sonorant === right.sonorant ? 0 : 1;
+  const nasalOrLateral =
+    (left.nasal === right.nasal ? 0 : 0.5) +
+    (left.lateral === right.lateral ? 0 : 0.5);
+
+  return Math.min(
+    1,
+    0.3 * place +
+      0.35 * manner +
+      0.15 * voicing +
+      0.1 * sonorant +
+      0.1 * nasalOrLateral,
+  );
+}
+
+function vowelPointDistance(left: VowelPoint, right: VowelPoint) {
+  return Math.min(
+    1,
+    0.45 * Math.abs(left.height - right.height) +
+      0.35 * Math.abs(left.backness - right.backness) +
+      0.15 * (left.rounded === right.rounded ? 0 : 1) +
+      0.05 * (left.rhotic === right.rhotic ? 0 : 1),
+  );
+}
+
+function vowelDistance(left: VowelFeatures, right: VowelFeatures) {
+  const trajectory =
+    0.45 * vowelPointDistance(left.start, right.start) +
+    0.45 * vowelPointDistance(left.end, right.end);
+  const length = 0.1 * Math.abs(left.length - right.length);
+
+  return Math.min(1, trajectory + length);
+}
+
+/**
+ * A bounded articulatory prior inspired by feature-edit-distance work such as
+ * PanPhon. It is intentionally transparent and trainable later: these weights
+ * are hypotheses to validate against human labels, not pronunciation truth.
+ */
+export function phonologicalDistance(expected: string, observed: string) {
+  const normalizedExpected = normalizeEnglishPhone(expected);
+  const normalizedObserved = normalizeEnglishPhone(observed);
+
+  if (normalizedExpected === normalizedObserved) return 0;
+
+  const expectedFeatures = PHONE_FEATURES[normalizedExpected];
+  const observedFeatures = PHONE_FEATURES[normalizedObserved];
+
+  if (!expectedFeatures || !observedFeatures) return 1;
+  if (expectedFeatures.kind !== observedFeatures.kind) return 1;
+
+  return expectedFeatures.kind === "consonant"
+    ? consonantDistance(
+        expectedFeatures,
+        observedFeatures as ConsonantFeatures,
+      )
+    : vowelDistance(expectedFeatures, observedFeatures as VowelFeatures);
+}
+
+function averageVowelPoint(features: VowelFeatures) {
+  return {
+    height: (features.start.height + features.end.height) / 2,
+    backness: (features.start.backness + features.end.backness) / 2,
+    rounded: features.start.rounded || features.end.rounded,
+    rhotic: features.start.rhotic || features.end.rhotic,
+  };
+}
+
+export function articulatoryDeltaForPhones(
+  expected: string,
+  observed: string,
+): ArticulatoryDelta | null {
+  const normalizedExpected = normalizeEnglishPhone(expected);
+  const normalizedObserved = normalizeEnglishPhone(observed);
+  const expectedFeatures = PHONE_FEATURES[normalizedExpected];
+  const observedFeatures = PHONE_FEATURES[normalizedObserved];
+
+  if (!expectedFeatures || !observedFeatures) return null;
+
+  if (expectedFeatures.kind !== observedFeatures.kind) {
+    return {
+      majorClass: {
+        expected: expectedFeatures.kind,
+        observed: observedFeatures.kind,
+      },
+    };
+  }
+
+  if (expectedFeatures.kind === "consonant") {
+    const observedConsonant = observedFeatures as ConsonantFeatures;
+
+    return {
+      place:
+        expectedFeatures.place === observedConsonant.place
+          ? null
+          : {
+              expected: expectedFeatures.place,
+              observed: observedConsonant.place,
+            },
+      manner:
+        expectedFeatures.manner === observedConsonant.manner
+          ? null
+          : {
+              expected: expectedFeatures.manner,
+              observed: observedConsonant.manner,
+            },
+      voicing:
+        expectedFeatures.voiced === observedConsonant.voiced
+          ? null
+          : {
+              expected: expectedFeatures.voiced,
+              observed: observedConsonant.voiced,
+            },
+    };
+  }
+
+  const expectedVowel = expectedFeatures;
+  const observedVowel = observedFeatures as VowelFeatures;
+  const expectedPoint = averageVowelPoint(expectedVowel);
+  const observedPoint = averageVowelPoint(observedVowel);
+
+  return {
+    vowelHeight:
+      Math.abs(expectedPoint.height - observedPoint.height) < 0.05
+        ? null
+        : {
+            expected: expectedPoint.height,
+            observed: observedPoint.height,
+          },
+    vowelBackness:
+      Math.abs(expectedPoint.backness - observedPoint.backness) < 0.05
+        ? null
+        : {
+            expected: expectedPoint.backness,
+            observed: observedPoint.backness,
+          },
+    rounded:
+      expectedPoint.rounded === observedPoint.rounded
+        ? null
+        : {
+            expected: expectedPoint.rounded,
+            observed: observedPoint.rounded,
+          },
+    rhotic:
+      expectedPoint.rhotic === observedPoint.rhotic
+        ? null
+        : {
+            expected: expectedPoint.rhotic,
+            observed: observedPoint.rhotic,
+          },
+    length:
+      Math.abs(expectedVowel.length - observedVowel.length) < 0.05
+        ? null
+        : {
+            expected: expectedVowel.length,
+            observed: observedVowel.length,
+          },
+  };
+}
+
+export function isKnownEnglishPhone(phone: string) {
+  return Boolean(PHONE_FEATURES[normalizeEnglishPhone(phone)]);
+}

--- a/src/lib/pronunciation-engine/posterior.test.ts
+++ b/src/lib/pronunciation-engine/posterior.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  softmaxLogitMatrix,
+  summarizePhonePosteriorSequence,
+} from "./posterior";
+
+describe("pronunciation-engine posterior evidence", () => {
+  it("computes numerically stable softmax rows", () => {
+    const rows = softmaxLogitMatrix([1000, 999, -1000, -999], 2, 2);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.[0]).toBeGreaterThan(rows[0]?.[1] ?? 1);
+    expect(rows[1]?.[1]).toBeGreaterThan(rows[1]?.[0] ?? 1);
+    expect((rows[0]?.[0] ?? 0) + (rows[0]?.[1] ?? 0)).toBeCloseTo(1, 10);
+  });
+
+  it("preserves expected-phone posterior and competitor margin", () => {
+    const summary = summarizePhonePosteriorSequence(
+      {
+        phones: ["θ", "s", "t"],
+        frames: [
+          [0.8, 0.15, 0.05],
+          [0.7, 0.2, 0.1],
+          [0.6, 0.3, 0.1],
+        ],
+      },
+      "θ",
+    );
+
+    expect(summary.expected?.phone).toBe("θ");
+    expect(summary.expected?.meanPosterior).toBeCloseTo(0.7, 8);
+    expect(summary.expected?.top1Occupancy).toBe(1);
+    expect(summary.expected?.meanMarginToBestCompetitor).toBeCloseTo(0.5, 8);
+    expect(summary.meanTop2Margin).toBeCloseTo(0.5, 8);
+  });
+
+  it("reports uncertainty when a confusion dominates some frames", () => {
+    const summary = summarizePhonePosteriorSequence(
+      {
+        phones: ["θ", "s", "t"],
+        frames: [
+          [0.65, 0.3, 0.05],
+          [0.35, 0.6, 0.05],
+          [0.55, 0.4, 0.05],
+        ],
+      },
+      "θ",
+    );
+
+    expect(summary.expected?.top1Occupancy).toBeCloseTo(2 / 3, 8);
+    expect(summary.expected?.meanMarginToBestCompetitor).toBeLessThan(0.2);
+    expect(summary.meanTemporalVariation).toBeGreaterThan(0);
+  });
+
+  it("distinguishes sharp stable posteriors from diffuse posteriors", () => {
+    const sharp = summarizePhonePosteriorSequence({
+      phones: ["θ", "s", "t"],
+      frames: [
+        [0.98, 0.01, 0.01],
+        [0.98, 0.01, 0.01],
+      ],
+    });
+    const diffuse = summarizePhonePosteriorSequence({
+      phones: ["θ", "s", "t"],
+      frames: [
+        [0.34, 0.33, 0.33],
+        [0.34, 0.33, 0.33],
+      ],
+    });
+
+    expect(sharp.normalizedMeanEntropy).toBeLessThan(diffuse.normalizedMeanEntropy);
+    expect(sharp.meanTop2Margin).toBeGreaterThan(diffuse.meanTop2Margin);
+    expect(sharp.meanTemporalVariation).toBe(0);
+  });
+
+  it("rejects truncated or invalid probability rows", () => {
+    expect(() =>
+      summarizePhonePosteriorSequence({
+        phones: ["θ", "s"],
+        frames: [[0.5, 0.2]],
+      }),
+    ).toThrow("posterior_frame_must_sum_to_one");
+
+    expect(() => softmaxLogitMatrix([1, 2, 3], 2, 2)).toThrow(
+      "invalid_logit_matrix_shape",
+    );
+  });
+});

--- a/src/lib/pronunciation-engine/posterior.test.ts
+++ b/src/lib/pronunciation-engine/posterior.test.ts
@@ -27,12 +27,16 @@ describe("pronunciation-engine posterior evidence", () => {
       },
       "θ",
     );
+    const expectedMeanMargin = (0.65 + 0.5 + 0.3) / 3;
 
     expect(summary.expected?.phone).toBe("θ");
     expect(summary.expected?.meanPosterior).toBeCloseTo(0.7, 8);
     expect(summary.expected?.top1Occupancy).toBe(1);
-    expect(summary.expected?.meanMarginToBestCompetitor).toBeCloseTo(0.5, 8);
-    expect(summary.meanTop2Margin).toBeCloseTo(0.5, 8);
+    expect(summary.expected?.meanMarginToBestCompetitor).toBeCloseTo(
+      expectedMeanMargin,
+      8,
+    );
+    expect(summary.meanTop2Margin).toBeCloseTo(expectedMeanMargin, 8);
   });
 
   it("reports uncertainty when a confusion dominates some frames", () => {

--- a/src/lib/pronunciation-engine/posterior.ts
+++ b/src/lib/pronunciation-engine/posterior.ts
@@ -1,0 +1,277 @@
+export type PhonePosteriorSequence = {
+  phones: readonly string[];
+  frames: readonly (readonly number[])[];
+  frameDurationMs?: number | null;
+};
+
+export type PosteriorSequenceStatistics = {
+  frameCount: number;
+  vocabularySize: number;
+  meanEntropy: number;
+  normalizedMeanEntropy: number;
+  meanPeakPosterior: number;
+  p10PeakPosterior: number;
+  meanTop2Margin: number;
+  p10Top2Margin: number;
+  meanTemporalVariation: number;
+  maxTemporalVariation: number;
+  expected: {
+    phone: string;
+    meanPosterior: number;
+    p10Posterior: number;
+    medianPosterior: number;
+    p90Posterior: number;
+    top1Occupancy: number;
+    meanMarginToBestCompetitor: number;
+  } | null;
+};
+
+const POSTERIOR_SUM_TOLERANCE = 1e-3;
+
+function percentile(values: readonly number[], probability: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const bounded = Math.min(1, Math.max(0, probability));
+  const position = bounded * (sorted.length - 1);
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.ceil(position);
+  const lower = sorted[lowerIndex] ?? 0;
+  const upper = sorted[upperIndex] ?? lower;
+  return lower + (position - lowerIndex) * (upper - lower);
+}
+
+function validateVocabulary(phones: readonly string[]) {
+  if (phones.length < 2) throw new Error("posterior_vocabulary_too_small");
+
+  const normalized = phones.map((phone) => phone.trim());
+  if (normalized.some((phone) => !phone)) {
+    throw new Error("posterior_phone_label_required");
+  }
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error("posterior_phone_labels_must_be_unique");
+  }
+}
+
+function validateFrame(frame: readonly number[], vocabularySize: number) {
+  if (frame.length !== vocabularySize) {
+    throw new Error("posterior_frame_vocabulary_mismatch");
+  }
+
+  let sum = 0;
+  for (const probability of frame) {
+    if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+      throw new Error("posterior_probability_out_of_range");
+    }
+    sum += probability;
+  }
+
+  if (Math.abs(sum - 1) > POSTERIOR_SUM_TOLERANCE) {
+    throw new Error("posterior_frame_must_sum_to_one");
+  }
+}
+
+function entropy(frame: readonly number[]) {
+  let value = 0;
+  for (const probability of frame) {
+    if (probability > 0) value -= probability * Math.log(probability);
+  }
+  return value;
+}
+
+function topTwo(frame: readonly number[]) {
+  let first = -Infinity;
+  let second = -Infinity;
+  let firstIndex = -1;
+
+  for (let index = 0; index < frame.length; index += 1) {
+    const value = frame[index] ?? 0;
+    if (value > first) {
+      second = first;
+      first = value;
+      firstIndex = index;
+    } else if (value > second) {
+      second = value;
+    }
+  }
+
+  return {
+    first,
+    second: Number.isFinite(second) ? second : 0,
+    firstIndex,
+  };
+}
+
+function totalVariation(
+  left: readonly number[],
+  right: readonly number[],
+) {
+  let sum = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    sum += Math.abs((left[index] ?? 0) - (right[index] ?? 0));
+  }
+  return sum / 2;
+}
+
+/**
+ * Converts a dense frame x vocabulary logit matrix to complete posterior rows.
+ * This is deliberately separate from CTC decoding: pronunciation evidence needs
+ * the distribution that a greedy transcript would otherwise discard.
+ */
+export function softmaxLogitMatrix(
+  logits: ArrayLike<number>,
+  frameCount: number,
+  vocabularySize: number,
+) {
+  if (
+    !Number.isInteger(frameCount) ||
+    !Number.isInteger(vocabularySize) ||
+    frameCount <= 0 ||
+    vocabularySize < 2 ||
+    logits.length !== frameCount * vocabularySize
+  ) {
+    throw new Error("invalid_logit_matrix_shape");
+  }
+
+  const rows: number[][] = [];
+
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const offset = frameIndex * vocabularySize;
+    let maximum = -Infinity;
+
+    for (let phoneIndex = 0; phoneIndex < vocabularySize; phoneIndex += 1) {
+      const value = logits[offset + phoneIndex];
+      if (value === undefined || !Number.isFinite(value)) {
+        throw new Error("logits_must_be_finite");
+      }
+      maximum = Math.max(maximum, value);
+    }
+
+    const exponentials = Array<number>(vocabularySize);
+    let denominator = 0;
+
+    for (let phoneIndex = 0; phoneIndex < vocabularySize; phoneIndex += 1) {
+      const value = logits[offset + phoneIndex] as number;
+      const exponential = Math.exp(value - maximum);
+      exponentials[phoneIndex] = exponential;
+      denominator += exponential;
+    }
+
+    if (!Number.isFinite(denominator) || denominator <= 0) {
+      throw new Error("invalid_softmax_denominator");
+    }
+
+    rows.push(exponentials.map((value) => value / denominator));
+  }
+
+  return rows;
+}
+
+/**
+ * Extracts distribution-shape and temporal-stability evidence from complete
+ * phone posterior sequences. These are research features, not learner scores.
+ * They are intended to preserve information highlighted by logit/GOP research
+ * that is lost when a sensor returns only a top-1 phone string.
+ */
+export function summarizePhonePosteriorSequence(
+  sequence: PhonePosteriorSequence,
+  expectedPhone?: string | null,
+): PosteriorSequenceStatistics {
+  validateVocabulary(sequence.phones);
+  if (sequence.frames.length === 0) {
+    throw new Error("posterior_frames_required");
+  }
+
+  for (const frame of sequence.frames) {
+    validateFrame(frame, sequence.phones.length);
+  }
+
+  const entropies: number[] = [];
+  const peaks: number[] = [];
+  const top2Margins: number[] = [];
+  const top1Indices: number[] = [];
+  const temporalVariations: number[] = [];
+
+  for (let frameIndex = 0; frameIndex < sequence.frames.length; frameIndex += 1) {
+    const frame = sequence.frames[frameIndex] as readonly number[];
+    const { first, second, firstIndex } = topTwo(frame);
+    entropies.push(entropy(frame));
+    peaks.push(first);
+    top2Margins.push(first - second);
+    top1Indices.push(firstIndex);
+
+    if (frameIndex > 0) {
+      temporalVariations.push(
+        totalVariation(
+          sequence.frames[frameIndex - 1] as readonly number[],
+          frame,
+        ),
+      );
+    }
+  }
+
+  const expectedIndex = expectedPhone
+    ? sequence.phones.indexOf(expectedPhone)
+    : -1;
+
+  let expected: PosteriorSequenceStatistics["expected"] = null;
+  if (expectedPhone && expectedIndex >= 0) {
+    const expectedPosteriors: number[] = [];
+    const expectedMargins: number[] = [];
+    let top1Count = 0;
+
+    for (let frameIndex = 0; frameIndex < sequence.frames.length; frameIndex += 1) {
+      const frame = sequence.frames[frameIndex] as readonly number[];
+      const expectedPosterior = frame[expectedIndex] ?? 0;
+      let bestCompetitor = 0;
+
+      for (let phoneIndex = 0; phoneIndex < frame.length; phoneIndex += 1) {
+        if (phoneIndex === expectedIndex) continue;
+        bestCompetitor = Math.max(bestCompetitor, frame[phoneIndex] ?? 0);
+      }
+
+      expectedPosteriors.push(expectedPosterior);
+      expectedMargins.push(expectedPosterior - bestCompetitor);
+      if (top1Indices[frameIndex] === expectedIndex) top1Count += 1;
+    }
+
+    expected = {
+      phone: expectedPhone,
+      meanPosterior:
+        expectedPosteriors.reduce((sum, value) => sum + value, 0) /
+        expectedPosteriors.length,
+      p10Posterior: percentile(expectedPosteriors, 0.1),
+      medianPosterior: percentile(expectedPosteriors, 0.5),
+      p90Posterior: percentile(expectedPosteriors, 0.9),
+      top1Occupancy: top1Count / sequence.frames.length,
+      meanMarginToBestCompetitor:
+        expectedMargins.reduce((sum, value) => sum + value, 0) /
+        expectedMargins.length,
+    };
+  }
+
+  const meanEntropy =
+    entropies.reduce((sum, value) => sum + value, 0) / entropies.length;
+  const maxEntropy = Math.log(sequence.phones.length);
+
+  return {
+    frameCount: sequence.frames.length,
+    vocabularySize: sequence.phones.length,
+    meanEntropy,
+    normalizedMeanEntropy: maxEntropy > 0 ? meanEntropy / maxEntropy : 0,
+    meanPeakPosterior:
+      peaks.reduce((sum, value) => sum + value, 0) / peaks.length,
+    p10PeakPosterior: percentile(peaks, 0.1),
+    meanTop2Margin:
+      top2Margins.reduce((sum, value) => sum + value, 0) /
+      top2Margins.length,
+    p10Top2Margin: percentile(top2Margins, 0.1),
+    meanTemporalVariation:
+      temporalVariations.length === 0
+        ? 0
+        : temporalVariations.reduce((sum, value) => sum + value, 0) /
+          temporalVariations.length,
+    maxTemporalVariation:
+      temporalVariations.length === 0 ? 0 : Math.max(...temporalVariations),
+    expected,
+  };
+}

--- a/src/lib/pronunciation-engine/prosody.test.ts
+++ b/src/lib/pronunciation-engine/prosody.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeProsody } from "./prosody";
+
+function sineWave(
+  frequency: number,
+  durationSeconds: number,
+  sampleRate = 16_000,
+  amplitude = 0.2,
+) {
+  const samples = new Float32Array(Math.round(durationSeconds * sampleRate));
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] =
+      amplitude * Math.sin((2 * Math.PI * frequency * index) / sampleRate);
+  }
+  return samples;
+}
+
+function concatenate(...parts: Float32Array[]) {
+  const length = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Float32Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+describe("pronunciation-engine prosody", () => {
+  it("recovers the pitch of a clean synthetic voiced signal", () => {
+    const result = analyzeProsody(sineWave(200, 0.5), 16_000);
+
+    expect(result.pitch.medianHz).not.toBeNull();
+    expect(result.pitch.medianHz as number).toBeCloseTo(200, 0);
+    expect(result.pitch.meanConfidence).toBeGreaterThan(0.9);
+    expect(result.voicedFraction).toBeGreaterThan(0.9);
+    expect(result.pauseFraction).toBeLessThan(0.1);
+  });
+
+  it("does not hallucinate pitch for silence", () => {
+    const result = analyzeProsody(new Float32Array(8_000), 16_000);
+
+    expect(result.pitch.medianHz).toBeNull();
+    expect(result.pitch.rangeSemitones).toBeNull();
+    expect(result.voicedFraction).toBe(0);
+    expect(result.pauseFraction).toBe(1);
+  });
+
+  it("captures a wider pitch range when the signal changes frequency", () => {
+    const samples = concatenate(sineWave(120, 0.3), sineWave(240, 0.3));
+    const result = analyzeProsody(samples, 16_000);
+
+    expect(result.pitch.p10Hz).not.toBeNull();
+    expect(result.pitch.p90Hz).not.toBeNull();
+    expect(result.pitch.rangeSemitones).not.toBeNull();
+    expect(result.pitch.rangeSemitones as number).toBeGreaterThan(8);
+  });
+
+  it("captures pauses separately from voiced pitch", () => {
+    const samples = concatenate(
+      sineWave(180, 0.25),
+      new Float32Array(4_000),
+      sineWave(180, 0.25),
+    );
+    const result = analyzeProsody(samples, 16_000);
+
+    expect(result.pauseFraction).toBeGreaterThan(0.2);
+    expect(result.pauseFraction).toBeLessThan(0.7);
+    expect(result.pitch.medianHz as number).toBeCloseTo(180, 0);
+  });
+
+  it("reports energy dynamics without turning them into a prosody score", () => {
+    const samples = concatenate(
+      sineWave(200, 0.25, 16_000, 0.05),
+      sineWave(200, 0.25, 16_000, 0.3),
+    );
+    const result = analyzeProsody(samples, 16_000);
+
+    expect(result.energy.dynamicRangeDb).toBeGreaterThan(8);
+    expect(result.energy.p90Dbfs).toBeGreaterThan(result.energy.p10Dbfs);
+  });
+
+  it("rejects invalid audio inputs", () => {
+    expect(() => analyzeProsody(new Float32Array([0.1]), 0)).toThrow(
+      "invalid_prosody_sample_rate",
+    );
+    expect(() => analyzeProsody(new Float32Array(), 16_000)).toThrow(
+      "prosody_samples_required",
+    );
+  });
+});

--- a/src/lib/pronunciation-engine/prosody.ts
+++ b/src/lib/pronunciation-engine/prosody.ts
@@ -1,0 +1,274 @@
+export type ProsodyFrame = {
+  timeMs: number;
+  rms: number;
+  dbfs: number;
+  pitchHz: number | null;
+  pitchConfidence: number | null;
+  voiced: boolean;
+};
+
+export type ProsodySummary = {
+  durationSeconds: number;
+  frameCount: number;
+  voicedFraction: number;
+  pauseFraction: number;
+  pitch: {
+    medianHz: number | null;
+    p10Hz: number | null;
+    p90Hz: number | null;
+    rangeSemitones: number | null;
+    meanConfidence: number | null;
+  };
+  energy: {
+    medianDbfs: number;
+    p10Dbfs: number;
+    p90Dbfs: number;
+    dynamicRangeDb: number;
+  };
+  frames: ProsodyFrame[];
+};
+
+export type ProsodyOptions = {
+  frameDurationMs?: number;
+  hopDurationMs?: number;
+  minPitchHz?: number;
+  maxPitchHz?: number;
+  minVoicedRms?: number;
+  minPitchCorrelation?: number;
+};
+
+const DEFAULT_OPTIONS: Required<ProsodyOptions> = {
+  frameDurationMs: 40,
+  hopDurationMs: 20,
+  minPitchHz: 70,
+  maxPitchHz: 400,
+  minVoicedRms: 0.004,
+  minPitchCorrelation: 0.45,
+};
+
+function percentile(values: readonly number[], probability: number) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const bounded = Math.min(1, Math.max(0, probability));
+  const index = bounded * (sorted.length - 1);
+  const lowerIndex = Math.floor(index);
+  const upperIndex = Math.ceil(index);
+  const lower = sorted[lowerIndex] ?? 0;
+  const upper = sorted[upperIndex] ?? lower;
+  return lower + (index - lowerIndex) * (upper - lower);
+}
+
+function frameRms(samples: Float32Array, start: number, end: number) {
+  let squareSum = 0;
+  for (let index = start; index < end; index += 1) {
+    const value = samples[index] ?? 0;
+    squareSum += value * value;
+  }
+  return Math.sqrt(squareSum / Math.max(1, end - start));
+}
+
+function normalizedAutocorrelationAtLag(
+  frame: Float32Array,
+  mean: number,
+  lag: number,
+) {
+  let numerator = 0;
+  let leftEnergy = 0;
+  let rightEnergy = 0;
+  const length = frame.length - lag;
+
+  for (let index = 0; index < length; index += 1) {
+    const left = (frame[index] ?? 0) - mean;
+    const right = (frame[index + lag] ?? 0) - mean;
+    numerator += left * right;
+    leftEnergy += left * left;
+    rightEnergy += right * right;
+  }
+
+  const denominator = Math.sqrt(leftEnergy * rightEnergy);
+  return denominator <= 1e-12 ? 0 : numerator / denominator;
+}
+
+function estimatePitch(
+  frame: Float32Array,
+  sampleRate: number,
+  options: Required<ProsodyOptions>,
+) {
+  let mean = 0;
+  for (const value of frame) mean += value;
+  mean /= frame.length;
+
+  const minLag = Math.max(1, Math.floor(sampleRate / options.maxPitchHz));
+  const maxLag = Math.min(
+    frame.length - 2,
+    Math.ceil(sampleRate / options.minPitchHz),
+  );
+
+  if (maxLag <= minLag) return null;
+
+  const scores = new Map<number, number>();
+  let bestLag = minLag;
+  let bestScore = Number.NEGATIVE_INFINITY;
+
+  for (let lag = minLag; lag <= maxLag; lag += 1) {
+    const score = normalizedAutocorrelationAtLag(frame, mean, lag);
+    scores.set(lag, score);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestLag = lag;
+    }
+  }
+
+  if (!Number.isFinite(bestScore) || bestScore < options.minPitchCorrelation) {
+    return null;
+  }
+
+  const left = scores.get(bestLag - 1);
+  const center = scores.get(bestLag);
+  const right = scores.get(bestLag + 1);
+  let refinedLag = bestLag;
+
+  if (left !== undefined && center !== undefined && right !== undefined) {
+    const denominator = left - 2 * center + right;
+    if (Math.abs(denominator) > 1e-8) {
+      const adjustment = 0.5 * (left - right) / denominator;
+      refinedLag += Math.max(-0.5, Math.min(0.5, adjustment));
+    }
+  }
+
+  return {
+    pitchHz: sampleRate / refinedLag,
+    confidence: Math.max(0, Math.min(1, bestScore)),
+  };
+}
+
+function decibelsFromRms(rms: number) {
+  return 20 * Math.log10(Math.max(rms, 1e-8));
+}
+
+/**
+ * Extracts a transparent suprasegmental evidence stream from local PCM audio.
+ * It intentionally returns descriptive pitch/energy/pause features, not a
+ * learner-facing prosody or fluency score.
+ */
+export function analyzeProsody(
+  samples: Float32Array,
+  sampleRate: number,
+  options: ProsodyOptions = {},
+): ProsodySummary {
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error("invalid_prosody_sample_rate");
+  }
+  if (samples.length === 0) throw new Error("prosody_samples_required");
+  for (const value of samples) {
+    if (!Number.isFinite(value)) throw new Error("prosody_samples_must_be_finite");
+  }
+
+  const config = { ...DEFAULT_OPTIONS, ...options };
+  if (
+    config.minPitchHz <= 0 ||
+    config.maxPitchHz <= config.minPitchHz ||
+    config.frameDurationMs <= 0 ||
+    config.hopDurationMs <= 0
+  ) {
+    throw new Error("invalid_prosody_options");
+  }
+
+  const frameLength = Math.max(
+    4,
+    Math.round((sampleRate * config.frameDurationMs) / 1_000),
+  );
+  const hopLength = Math.max(
+    1,
+    Math.round((sampleRate * config.hopDurationMs) / 1_000),
+  );
+
+  const frameDescriptors: Array<{
+    start: number;
+    end: number;
+    rms: number;
+  }> = [];
+
+  for (let start = 0; start < samples.length; start += hopLength) {
+    const end = Math.min(samples.length, start + frameLength);
+    if (end - start < Math.min(frameLength, Math.round(sampleRate * 0.02))) break;
+    frameDescriptors.push({ start, end, rms: frameRms(samples, start, end) });
+    if (end === samples.length) break;
+  }
+
+  if (frameDescriptors.length === 0) throw new Error("prosody_audio_too_short");
+
+  const frameRmsList = frameDescriptors.map((frame) => frame.rms);
+  const lowEnergy = percentile(frameRmsList, 0.2) ?? 0;
+  const highEnergy = percentile(frameRmsList, 0.8) ?? 0;
+  const activeThreshold = Math.max(
+    config.minVoicedRms,
+    Math.min(
+      lowEnergy > 0 ? lowEnergy * 2 : config.minVoicedRms,
+      highEnergy > 0 ? highEnergy * 0.5 : config.minVoicedRms,
+    ),
+  );
+
+  const frames: ProsodyFrame[] = frameDescriptors.map((descriptor) => {
+    const active = descriptor.rms >= activeThreshold;
+    const frame = samples.slice(descriptor.start, descriptor.end);
+    const pitch = active ? estimatePitch(frame, sampleRate, config) : null;
+
+    return {
+      timeMs: ((descriptor.start + descriptor.end) / 2 / sampleRate) * 1_000,
+      rms: descriptor.rms,
+      dbfs: decibelsFromRms(descriptor.rms),
+      pitchHz: pitch?.pitchHz ?? null,
+      pitchConfidence: pitch?.confidence ?? null,
+      voiced: pitch !== null,
+    };
+  });
+
+  const voicedFrames = frames.filter((frame) => frame.voiced);
+  const pitchValues = voicedFrames
+    .map((frame) => frame.pitchHz)
+    .filter((value): value is number => value !== null);
+  const confidenceValues = voicedFrames
+    .map((frame) => frame.pitchConfidence)
+    .filter((value): value is number => value !== null);
+  const dbValues = frames.map((frame) => frame.dbfs);
+
+  const p10Pitch = percentile(pitchValues, 0.1);
+  const p90Pitch = percentile(pitchValues, 0.9);
+  const p10Db = percentile(dbValues, 0.1) ?? -160;
+  const p90Db = percentile(dbValues, 0.9) ?? -160;
+  const activeFrameCount = frameDescriptors.filter(
+    (frame) => frame.rms >= activeThreshold,
+  ).length;
+
+  return {
+    durationSeconds: samples.length / sampleRate,
+    frameCount: frames.length,
+    voicedFraction: voicedFrames.length / frames.length,
+    pauseFraction: 1 - activeFrameCount / frames.length,
+    pitch: {
+      medianHz: percentile(pitchValues, 0.5),
+      p10Hz: p10Pitch,
+      p90Hz: p90Pitch,
+      rangeSemitones:
+        p10Pitch !== null && p90Pitch !== null && p10Pitch > 0
+          ? 12 * Math.log2(p90Pitch / p10Pitch)
+          : null,
+      meanConfidence:
+        confidenceValues.length === 0
+          ? null
+          : confidenceValues.reduce((sum, value) => sum + value, 0) /
+            confidenceValues.length,
+    },
+    energy: {
+      medianDbfs: percentile(dbValues, 0.5) ?? -160,
+      p10Dbfs: p10Db,
+      p90Dbfs: p90Db,
+      dynamicRangeDb: p90Db - p10Db,
+    },
+    frames,
+  };
+}
+
+export const pronunciationProsodyDefaults = Object.freeze({ ...DEFAULT_OPTIONS });

--- a/src/lib/pronunciation-engine/prosody.ts
+++ b/src/lib/pronunciation-engine/prosody.ts
@@ -46,6 +46,8 @@ const DEFAULT_OPTIONS: Required<ProsodyOptions> = {
   minPitchCorrelation: 0.45,
 };
 
+const FUNDAMENTAL_PEAK_SCORE_TOLERANCE = 0.03;
+
 function percentile(values: readonly number[], probability: number) {
   if (values.length === 0) return null;
   const sorted = [...values].sort((left, right) => left - right);
@@ -89,6 +91,44 @@ function normalizedAutocorrelationAtLag(
   return denominator <= 1e-12 ? 0 : numerator / denominator;
 }
 
+function chooseFundamentalLag(
+  scores: ReadonlyMap<number, number>,
+  minLag: number,
+  maxLag: number,
+  bestLag: number,
+  bestScore: number,
+  minimumCorrelation: number,
+) {
+  // Periodic signals can have equally strong autocorrelation peaks at 2x/3x
+  // the true period. Taking the absolute maximum therefore creates false
+  // subharmonics. Prefer the earliest strong local maximum whose score is
+  // essentially tied with the global best; this is a transparent YIN-like
+  // fundamental prior without hiding the confidence value.
+  const qualifyingScore = Math.max(
+    minimumCorrelation,
+    bestScore - FUNDAMENTAL_PEAK_SCORE_TOLERANCE,
+  );
+
+  for (let lag = minLag + 1; lag < maxLag; lag += 1) {
+    const left = scores.get(lag - 1);
+    const center = scores.get(lag);
+    const right = scores.get(lag + 1);
+
+    if (
+      left !== undefined &&
+      center !== undefined &&
+      right !== undefined &&
+      center >= qualifyingScore &&
+      center >= left &&
+      center >= right
+    ) {
+      return lag;
+    }
+  }
+
+  return bestLag;
+}
+
 function estimatePitch(
   frame: Float32Array,
   sampleRate: number,
@@ -124,22 +164,31 @@ function estimatePitch(
     return null;
   }
 
-  const left = scores.get(bestLag - 1);
-  const center = scores.get(bestLag);
-  const right = scores.get(bestLag + 1);
-  let refinedLag = bestLag;
+  const selectedLag = chooseFundamentalLag(
+    scores,
+    minLag,
+    maxLag,
+    bestLag,
+    bestScore,
+    options.minPitchCorrelation,
+  );
+  const selectedScore = scores.get(selectedLag) ?? bestScore;
+  const left = scores.get(selectedLag - 1);
+  const center = scores.get(selectedLag);
+  const right = scores.get(selectedLag + 1);
+  let refinedLag = selectedLag;
 
   if (left !== undefined && center !== undefined && right !== undefined) {
     const denominator = left - 2 * center + right;
     if (Math.abs(denominator) > 1e-8) {
-      const adjustment = 0.5 * (left - right) / denominator;
+      const adjustment = (0.5 * (left - right)) / denominator;
       refinedLag += Math.max(-0.5, Math.min(0.5, adjustment));
     }
   }
 
   return {
     pitchHz: sampleRate / refinedLag,
-    confidence: Math.max(0, Math.min(1, bestScore)),
+    confidence: Math.max(0, Math.min(1, selectedScore)),
   };
 }
 

--- a/src/lib/pronunciation-engine/signal.test.ts
+++ b/src/lib/pronunciation-engine/signal.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeSignalQuality } from "./signal";
+
+function sineWave(
+  frequency: number,
+  durationSeconds: number,
+  sampleRate = 16_000,
+  amplitude = 0.2,
+) {
+  const samples = new Float32Array(Math.round(durationSeconds * sampleRate));
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] =
+      amplitude * Math.sin((2 * Math.PI * frequency * index) / sampleRate);
+  }
+  return samples;
+}
+
+describe("pronunciation-engine signal quality", () => {
+  it("accepts a clean non-clipping voiced signal as usable evidence", () => {
+    const result = analyzeSignalQuality(sineWave(200, 0.5), 16_000);
+
+    expect(result.durationSeconds).toBeCloseTo(0.5);
+    expect(result.peakAmplitude).toBeCloseTo(0.2, 2);
+    expect(result.rmsAmplitude).toBeGreaterThan(0.1);
+    expect(result.clippingFraction).toBe(0);
+    expect(result.activeSpeechFraction).toBeGreaterThan(0.9);
+    expect(result.warnings).toEqual([]);
+    expect(result.recommendAbstain).toBe(false);
+  });
+
+  it("abstains on near-silent input before pronunciation inference", () => {
+    const result = analyzeSignalQuality(new Float32Array(8_000), 16_000);
+
+    expect(result.warnings).toContain("too_quiet");
+    expect(result.warnings).toContain("insufficient_active_speech");
+    expect(result.recommendAbstain).toBe(true);
+  });
+
+  it("detects materially clipped recordings", () => {
+    const samples = sineWave(200, 0.5, 16_000, 1.2);
+    const result = analyzeSignalQuality(samples, 16_000);
+
+    expect(result.clippingFraction).toBeGreaterThan(0.002);
+    expect(result.warnings).toContain("clipping");
+  });
+
+  it("detects a recording that is too short", () => {
+    const result = analyzeSignalQuality(sineWave(200, 0.05), 16_000);
+    expect(result.warnings).toContain("too_short");
+  });
+
+  it("does not invent an SNR estimate when continuous speech has no noise-only frames", () => {
+    const result = analyzeSignalQuality(sineWave(200, 0.5), 16_000);
+    expect(result.snrProxyDb).toBeNull();
+  });
+
+  it("rejects invalid sample rates and non-finite samples", () => {
+    expect(() => analyzeSignalQuality(sineWave(200, 0.5), 0)).toThrow(
+      "invalid_signal_sample_rate",
+    );
+
+    const invalid = sineWave(200, 0.5);
+    invalid[10] = Number.NaN;
+    expect(() => analyzeSignalQuality(invalid, 16_000)).toThrow(
+      "signal_samples_must_be_finite",
+    );
+  });
+});

--- a/src/lib/pronunciation-engine/signal.ts
+++ b/src/lib/pronunciation-engine/signal.ts
@@ -42,13 +42,6 @@ const DEFAULT_OPTIONS: Required<SignalQualityOptions> = {
   frameDurationMs: 20,
 };
 
-function rms(values: readonly number[]) {
-  if (values.length === 0) return 0;
-  let squareSum = 0;
-  for (const value of values) squareSum += value * value;
-  return Math.sqrt(squareSum / values.length);
-}
-
 function percentile(sorted: readonly number[], probability: number) {
   if (sorted.length === 0) return 0;
   const bounded = Math.min(1, Math.max(0, probability));
@@ -134,18 +127,29 @@ export function analyzeSignalQuality(
   const activeRms = percentile(sortedFrames, 0.8);
   const activeThreshold = Math.max(
     config.minRms,
-    noiseFloorRms > 0 ? noiseFloorRms * 2 : config.minRms,
+    Math.min(
+      noiseFloorRms > 0 ? noiseFloorRms * 2 : config.minRms,
+      activeRms > 0 ? activeRms * 0.5 : config.minRms,
+    ),
   );
   const activeFrameCount = frames.filter((value) => value >= activeThreshold).length;
   const activeSpeechFraction =
     frames.length === 0 ? 0 : activeFrameCount / frames.length;
 
+  const activityContrast =
+    noiseFloorRms <= 1e-8 ? Number.POSITIVE_INFINITY : activeRms / noiseFloorRms;
+
+  // If virtually every frame has similar energy, the recording may simply be
+  // continuously voiced. In that case a percentile-based noise estimate is
+  // not identifiable, so return null rather than inventing a low SNR value.
   const snrProxyDb =
     noiseFloorRms <= 1e-8
       ? activeRms > config.minRms
         ? 60
         : null
-      : 20 * Math.log10(Math.max(activeRms, 1e-8) / noiseFloorRms);
+      : activityContrast < 1.25
+        ? null
+        : 20 * Math.log10(Math.max(activeRms, 1e-8) / noiseFloorRms);
 
   const warnings: SignalQualityWarning[] = [];
   if (durationSeconds < config.minDurationSeconds) warnings.push("too_short");

--- a/src/lib/pronunciation-engine/signal.ts
+++ b/src/lib/pronunciation-engine/signal.ts
@@ -1,0 +1,179 @@
+export type SignalQualityWarning =
+  | "too_short"
+  | "too_long"
+  | "too_quiet"
+  | "clipping"
+  | "low_snr"
+  | "insufficient_active_speech";
+
+export type SignalQualityEvidence = {
+  durationSeconds: number;
+  peakAmplitude: number;
+  rmsAmplitude: number;
+  dcOffset: number;
+  clippingFraction: number;
+  activeSpeechFraction: number;
+  noiseFloorRms: number;
+  activeRms: number;
+  snrProxyDb: number | null;
+  warnings: SignalQualityWarning[];
+  recommendAbstain: boolean;
+};
+
+export type SignalQualityOptions = {
+  minDurationSeconds?: number;
+  maxDurationSeconds?: number;
+  minRms?: number;
+  clippingAmplitude?: number;
+  maxClippingFraction?: number;
+  minSnrProxyDb?: number;
+  minActiveSpeechFraction?: number;
+  frameDurationMs?: number;
+};
+
+const DEFAULT_OPTIONS: Required<SignalQualityOptions> = {
+  minDurationSeconds: 0.2,
+  maxDurationSeconds: 15,
+  minRms: 0.004,
+  clippingAmplitude: 0.995,
+  maxClippingFraction: 0.002,
+  minSnrProxyDb: 6,
+  minActiveSpeechFraction: 0.05,
+  frameDurationMs: 20,
+};
+
+function rms(values: readonly number[]) {
+  if (values.length === 0) return 0;
+  let squareSum = 0;
+  for (const value of values) squareSum += value * value;
+  return Math.sqrt(squareSum / values.length);
+}
+
+function percentile(sorted: readonly number[], probability: number) {
+  if (sorted.length === 0) return 0;
+  const bounded = Math.min(1, Math.max(0, probability));
+  const index = bounded * (sorted.length - 1);
+  const lowerIndex = Math.floor(index);
+  const upperIndex = Math.ceil(index);
+  const lower = sorted[lowerIndex] ?? 0;
+  const upper = sorted[upperIndex] ?? lower;
+  const fraction = index - lowerIndex;
+  return lower + fraction * (upper - lower);
+}
+
+function frameRmsValues(
+  samples: Float32Array,
+  sampleRate: number,
+  frameDurationMs: number,
+) {
+  const frameLength = Math.max(
+    1,
+    Math.round((sampleRate * frameDurationMs) / 1_000),
+  );
+  const values: number[] = [];
+
+  for (let start = 0; start < samples.length; start += frameLength) {
+    const end = Math.min(samples.length, start + frameLength);
+    let squareSum = 0;
+
+    for (let index = start; index < end; index += 1) {
+      const value = samples[index] ?? 0;
+      squareSum += value * value;
+    }
+
+    values.push(Math.sqrt(squareSum / Math.max(1, end - start)));
+  }
+
+  return values;
+}
+
+function mergeOptions(options: SignalQualityOptions): Required<SignalQualityOptions> {
+  return { ...DEFAULT_OPTIONS, ...options };
+}
+
+/**
+ * Produces signal-quality evidence before any pronunciation inference.
+ * Thresholds are deliberately transparent research priors and must be tuned on
+ * recorded learner/device data. The quality gate may abstain; it never scores
+ * pronunciation itself.
+ */
+export function analyzeSignalQuality(
+  samples: Float32Array,
+  sampleRate: number,
+  options: SignalQualityOptions = {},
+): SignalQualityEvidence {
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error("invalid_signal_sample_rate");
+  }
+  if (samples.length === 0) throw new Error("signal_samples_required");
+
+  const config = mergeOptions(options);
+  const durationSeconds = samples.length / sampleRate;
+
+  let peakAmplitude = 0;
+  let squareSum = 0;
+  let sum = 0;
+  let clippingSamples = 0;
+
+  for (const value of samples) {
+    if (!Number.isFinite(value)) throw new Error("signal_samples_must_be_finite");
+    const absolute = Math.abs(value);
+    peakAmplitude = Math.max(peakAmplitude, absolute);
+    squareSum += value * value;
+    sum += value;
+    if (absolute >= config.clippingAmplitude) clippingSamples += 1;
+  }
+
+  const rmsAmplitude = Math.sqrt(squareSum / samples.length);
+  const dcOffset = sum / samples.length;
+  const clippingFraction = clippingSamples / samples.length;
+
+  const frames = frameRmsValues(samples, sampleRate, config.frameDurationMs);
+  const sortedFrames = [...frames].sort((left, right) => left - right);
+  const noiseFloorRms = percentile(sortedFrames, 0.2);
+  const activeRms = percentile(sortedFrames, 0.8);
+  const activeThreshold = Math.max(
+    config.minRms,
+    noiseFloorRms > 0 ? noiseFloorRms * 2 : config.minRms,
+  );
+  const activeFrameCount = frames.filter((value) => value >= activeThreshold).length;
+  const activeSpeechFraction =
+    frames.length === 0 ? 0 : activeFrameCount / frames.length;
+
+  const snrProxyDb =
+    noiseFloorRms <= 1e-8
+      ? activeRms > config.minRms
+        ? 60
+        : null
+      : 20 * Math.log10(Math.max(activeRms, 1e-8) / noiseFloorRms);
+
+  const warnings: SignalQualityWarning[] = [];
+  if (durationSeconds < config.minDurationSeconds) warnings.push("too_short");
+  if (durationSeconds > config.maxDurationSeconds) warnings.push("too_long");
+  if (rmsAmplitude < config.minRms) warnings.push("too_quiet");
+  if (clippingFraction > config.maxClippingFraction) warnings.push("clipping");
+  if (snrProxyDb !== null && snrProxyDb < config.minSnrProxyDb) {
+    warnings.push("low_snr");
+  }
+  if (activeSpeechFraction < config.minActiveSpeechFraction) {
+    warnings.push("insufficient_active_speech");
+  }
+
+  return {
+    durationSeconds,
+    peakAmplitude,
+    rmsAmplitude,
+    dcOffset,
+    clippingFraction,
+    activeSpeechFraction,
+    noiseFloorRms,
+    activeRms,
+    snrProxyDb,
+    warnings,
+    recommendAbstain: warnings.length > 0,
+  };
+}
+
+export const pronunciationSignalQualityDefaults = Object.freeze({
+  ...DEFAULT_OPTIONS,
+});

--- a/src/lib/pronunciation-engine/types.ts
+++ b/src/lib/pronunciation-engine/types.ts
@@ -77,7 +77,10 @@ export type UncalibratedSegmentalEvidence = {
   rawAccuracySignal: number;
   /** Research-only completeness signal based on canonical phone retention. */
   rawCompletenessSignal: number;
+  /** Mean confidence margin is useful globally but can hide one weak phone. */
   meanPosteriorMargin: number | null;
+  /** Weakest available phone margin; used by conservative abstention gates. */
+  minimumPosteriorMargin: number | null;
   deletionCount: number;
   insertionCount: number;
   substitutionCount: number;

--- a/src/lib/pronunciation-engine/types.ts
+++ b/src/lib/pronunciation-engine/types.ts
@@ -1,0 +1,85 @@
+export type PronunciationCalibrationState =
+  | "unvalidated"
+  | "calibrating"
+  | "validated";
+
+export type PronunciationDecision = "evidence" | "feedback" | "abstain";
+
+export type PhoneCandidate = {
+  phone: string;
+  /**
+   * Calibrated probability when a sensor exposes one. Null means the sensor
+   * supplied only a rank/order and the engine must not pretend it is a
+   * probability.
+   */
+  probability: number | null;
+};
+
+export type ObservedPhone = {
+  candidates: readonly PhoneCandidate[];
+  startMs?: number | null;
+  endMs?: number | null;
+  source?: string | null;
+};
+
+export type CanonicalPronunciation = {
+  id: string;
+  phones: readonly string[];
+  /** Optional lexical stress pattern, e.g. [1, 0] for a two-syllable word. */
+  stress?: readonly number[] | null;
+};
+
+export type PhoneAlignmentKind =
+  | "match"
+  | "substitution"
+  | "deletion"
+  | "insertion";
+
+export type ArticulatoryDelta = {
+  majorClass?: {
+    expected: "consonant" | "vowel";
+    observed: "consonant" | "vowel";
+  } | null;
+  place?: { expected: string; observed: string } | null;
+  manner?: { expected: string; observed: string } | null;
+  voicing?: { expected: boolean; observed: boolean } | null;
+  vowelHeight?: { expected: number; observed: number } | null;
+  vowelBackness?: { expected: number; observed: number } | null;
+  rounded?: { expected: boolean; observed: boolean } | null;
+  rhotic?: { expected: boolean; observed: boolean } | null;
+  length?: { expected: number; observed: number } | null;
+};
+
+export type PhoneAlignmentEvidence = {
+  kind: PhoneAlignmentKind;
+  expected: string | null;
+  observed: string | null;
+  /** 0 = acoustically/phonologically identical, 1 = maximally different. */
+  cost: number;
+  /** Probability assigned to the selected observed phone, if truly available. */
+  observedProbability: number | null;
+  /** Top-1 minus top-2 posterior margin, if probabilities are available. */
+  posteriorMargin: number | null;
+  articulatoryDelta: ArticulatoryDelta | null;
+};
+
+export type PronunciationAlignmentResult = {
+  pronunciationId: string;
+  totalCost: number;
+  normalizedCost: number;
+  alignment: PhoneAlignmentEvidence[];
+};
+
+export type UncalibratedSegmentalEvidence = {
+  calibration: "unvalidated";
+  selectedPronunciationId: string;
+  /** Research-only signal. Never display as a learner-facing score. */
+  rawAccuracySignal: number;
+  /** Research-only completeness signal based on canonical phone retention. */
+  rawCompletenessSignal: number;
+  meanPosteriorMargin: number | null;
+  deletionCount: number;
+  insertionCount: number;
+  substitutionCount: number;
+  alignment: PhoneAlignmentEvidence[];
+};


### PR DESCRIPTION
## Goal
Build the first model-independent research kernel for an original AtoEnglish pronunciation-assessment engine. The target is not to copy a vendor score but to preserve acoustic uncertainty, align multiple valid pronunciations, diagnose phone errors articulatorily, and calibrate any future numeric score against human ratings.

## Exception / current blocker
This work is intentionally isolated from the active pilot queue under the `DO_NOT_BUILD.md` exception rule. The blocker occurred in the real development flow twice: (1) the paid/provider pronunciation path failed in practice, and (2) the free browser top-1 phoneme path discarded the posterior evidence needed to distinguish learner errors reliably. Existing simpler solutions are insufficient for the requested free pronunciation-scoring direction because top-1 ASR output cannot expose hidden canonical-phone support or calibrated uncertainty.

The implementation remains reversible and bounded: one draft R&D branch/PR, no merge/deploy, no database/auth/analytics/XP/FSRS/curriculum changes, no raw-audio persistence, and no learner-facing score until human calibration exists. Rollback is closing this draft PR and deleting the branch.

## What is implemented
- frontier research program and license boundaries
- explicit sensor observation / diagnosis / calibration contracts
- English articulatory phone representation and transparent phonological distance prior
- posterior-aware dynamic-programming alignment
- explicit substitution/deletion/insertion evidence
- multiple canonical-pronunciation selection
- rank-only candidate handling without fabricating probabilities
- uncalibrated segmental evidence derivation
- monotonic isotonic calibration (PAVA)
- split-conformal residual intervals
- research metrics: Pearson, Spearman, MAE, RMSE, F1, MCC, FAR/FRR, Brier, ECE, ROC AUC
- raw CTC logits/posterior extraction in the local browser worker
- greedy CTC segment bridge with original posterior mass preserved
- posterior uncertainty and temporal-stability statistics
- local signal-quality and prosody evidence
- deterministic sensor benchmark utilities
- canonical CTC forward-lattice likelihood in log space
- repeated-label blank enforcement and impossible-target validation
- exact path-sum regression test plus blank-dominant canonical-evidence tests

## Scientific boundary
This is **not** a validated pronunciation scorer. No learner-facing 0–100 score is produced. Raw accuracy/completeness signals remain research-only and `calibration: "unvalidated"` until speaker-disjoint human-rated data supports calibration.

The engine explicitly separates:

`observation != diagnosis != calibrated score != learning decision`

## License boundary
- commercially compatible foundations can include SpeechOcean762 (CC BY 4.0), GOPT concepts/code where appropriate (BSD-3-Clause), Kaldi GOP concepts (Apache-2.0 project), and individually reviewed commercial-safe acoustic checkpoints.
- L2-ARCTIC is treated as research-only for AtoEnglish because it is CC BY-NC 4.0.
- IF-MDD and HierTFR are research references only here; their public repositories did not expose a usable repository license during review, so their source is not copied into AtoEnglish.

## Out of scope
- no database or migration changes
- no auth/RLS changes
- no analytics changes
- no XP/FSRS/mastery changes
- no lesson/curriculum changes
- no paid API
- no model training in this PR
- no production deployment
- no merge by agent

## Verification on current head
Head: `d3fe450e58eca3724d1f89fd2378db9dfc2e1492`.

[GitHub Verify run 33948085867](https://github.com/Thunderkill016/AtoEnglish/actions/runs/33948085867) passed on this head:
- lint, type-check, unit tests, and content standards
- fresh migrations, database lint, and pgTAP/RLS tests

Local checks rerun after committing this head:
- focused CTC lattice suite: 16 tests passed
- `npx tsc --noEmit` and `npm run lint`: passed
- `npm run test`: 63 files / 486 tests passed
- `npm run test:content-standard`: 50 tests passed
- `npm run build -- --webpack`: passed (90 pages generated; existing Sentry configuration warnings)

## Completed bounded task: canonical CTC forward lattice
The engine now computes `log P(canonical target | acoustic frames)` by summing all valid CTC paths rather than relying on greedy top-1 output. It preserves evidence for a target phone even when blank wins every frame, enforces the CTC repeated-label blank rule, and rejects impossible/invalid target paths.

## Completed bounded task: CTC forward-backward state posterior V1
`canonicalCtcForwardBackward()` now returns canonical sequence log-likelihood, the extended target, minimum frame count, the complete state posterior matrix, and a state-to-canonical-position/blank mapping. Each canonical position also receives expected occupied frames, expected duration, peak-support frame, and peak posterior. Repeated tokens retain distinct positions.

The backward recurrence uses suffix probabilities excluding the current emission and exactly reverses the forward transition rules. Gamma comes directly from alpha, beta, and sequence likelihood without post-hoc normalization. The existing forward-only API retains rolling-row memory; only the new API retains the lattice.

Tests cover manually enumerated path posteriors, frame mass conservation, blank/competitor dominance, repeated labels, forward likelihood equivalence, duration, nonzero blank IDs, single-frame targets, long-sequence underflow, and explicit invalid/zero-mass failures.

Occupancy is conditional on the supplied target and is not evidence that the pronunciation is correct. All outputs remain research-only; calibration remains unvalidated. This task changes only `ctc-lattice.ts` and `ctc-lattice.test.ts`. The existing barrel export already exposes the new API.

## Next empirical gate
After forward-backward state evidence is verified, benchmark deliberate `θ / s / t` contrasts on identical learner audio. A sensor is discarded if it cannot separate those large contrasts or if it produces high false-alarm rates.
