### PR TITLE
feat(native-pilot): begin N2 synthetic evidence plumbing

### DIFF
--- a/.github/workflows/native-evidence-n2.yml
+++ b/.github/workflows/native-evidence-n2.yml
@@ -71,3 +71,14 @@ jobs:
 
       - name: Run predictor contract tests
         run: python -m unittest discover -v -s benchmarks/native-evidence-v1/tests -p 'test_*.py'
+
+      - name: Emit synthetic pyBKT diagnostic report
+        run: python benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py --output "$RUNNER_TEMP/native-bkt-diagnostics.json"
+
+      - name: Upload synthetic pyBKT diagnostic report
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-bkt-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/native-bkt-diagnostics.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/native-evidence-n2.yml
+++ b/.github/workflows/native-evidence-n2.yml
@@ -45,7 +45,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Run focused N2 tests
-        run: npx vitest run benchmarks/native-evidence-v1/native-evidence-v1.test.ts
+        run: npx vitest run 'benchmarks/native-evidence-v1/*.test.ts'
 
   predictor-plumbing:
     name: Frozen predictor and metric checks

--- a/.github/workflows/native-evidence-n2.yml
+++ b/.github/workflows/native-evidence-n2.yml
@@ -1,0 +1,48 @@
+name: Native Evidence N2
+
+on:
+  push:
+    branches:
+      - "frontier/native-evidence-n2-v1"
+  workflow_dispatch:
+
+concurrency:
+  group: native-evidence-n2-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  synthetic-harness:
+    name: Synthetic contract and leakage checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: true
+      HUSKY: 0
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline
+
+      - name: Verify documentation governance
+        run: npm run check:source-of-truth
+
+      - name: Lint native harness
+        run: npx eslint benchmarks/native-evidence-v1
+
+      - name: Type-check repository
+        run: npx tsc --noEmit
+
+      - name: Run focused N2 tests
+        run: npx vitest run benchmarks/native-evidence-v1/native-evidence-v1.test.ts

--- a/.github/workflows/native-evidence-n2.yml
+++ b/.github/workflows/native-evidence-n2.yml
@@ -45,7 +45,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Run focused N2 tests
-        run: npx vitest run 'benchmarks/native-evidence-v1/*.test.ts'
+        run: npx vitest run benchmarks/native-evidence-v1/*.test.ts
 
   predictor-plumbing:
     name: Frozen predictor and metric checks

--- a/.github/workflows/native-evidence-n2.yml
+++ b/.github/workflows/native-evidence-n2.yml
@@ -46,3 +46,28 @@ jobs:
 
       - name: Run focused N2 tests
         run: npx vitest run benchmarks/native-evidence-v1/native-evidence-v1.test.ts
+
+  predictor-plumbing:
+    name: Frozen predictor and metric checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: benchmarks/native-evidence-v1/requirements.lock
+
+      - name: Install isolated research dependencies
+        run: python -m pip install --disable-pip-version-check -r benchmarks/native-evidence-v1/requirements.lock
+
+      - name: Compile predictor scripts
+        run: python -m compileall -q benchmarks/native-evidence-v1/scripts benchmarks/native-evidence-v1/tests
+
+      - name: Run predictor contract tests
+        run: python -m unittest discover -v -s benchmarks/native-evidence-v1/tests -p 'test_*.py'

--- a/benchmarks/native-evidence-v1/accepted-history.test.ts
+++ b/benchmarks/native-evidence-v1/accepted-history.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { selectCausalAcceptedHistory } from "./features";
+import { buildPredictionFeatureRow, selectCausalAcceptedHistory } from "./features";
+import { buildPilotTaskDefinition } from "./task-matrix";
 import { issueSyntheticPilotEvent } from "./synthetic";
 
 describe("native pilot accepted-history parity", () => {
@@ -51,5 +52,96 @@ describe("native pilot accepted-history parity", () => {
       "p-history-parity:baseline",
       "p-history-parity:transfer",
     ]);
+  });
+
+  it("rebinds duplicate event IDs one-to-one instead of double-counting a core rejection", () => {
+    const duplicateSuccess = issueSyntheticPilotEvent({
+      participantId: "p-duplicate-parity",
+      family: "free-recall",
+      eventId: "p-duplicate-parity:e01",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:01.000Z",
+      success: true,
+    });
+    const duplicateFailure = issueSyntheticPilotEvent({
+      participantId: "p-duplicate-parity",
+      family: "free-recall",
+      eventId: "p-duplicate-parity:e01",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:02.000Z",
+      success: false,
+    });
+
+    const history = [duplicateSuccess, duplicateFailure];
+    const accepted = selectCausalAcceptedHistory(
+      "p-duplicate-parity",
+      history,
+      "2026-09-01T09:00:00.000Z",
+    );
+    const row = buildPredictionFeatureRow({
+      participantId: "p-duplicate-parity",
+      targetEventId: "p-duplicate-parity:target",
+      predictionTimestamp: "2026-09-01T09:00:00.000Z",
+      currentTask: buildPilotTaskDefinition("free-recall"),
+      history,
+    });
+
+    expect(accepted).toHaveLength(1);
+    expect(row.acceptedHistoryEventIds).toEqual(["p-duplicate-parity:e01"]);
+    expect(row.b2.prior_eligible_attempt_count).toBe(1);
+    expect(row.b3.nep_total_event_count).toBe(1);
+  });
+
+  it("preserves the core occurredAt/eventId order instead of ordering by label availability", () => {
+    const eventB = issueSyntheticPilotEvent({
+      participantId: "p-order-parity",
+      family: "recognition-independent",
+      eventId: "p-order-parity:b",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:01.000Z",
+      success: false,
+    });
+    const eventA = issueSyntheticPilotEvent({
+      participantId: "p-order-parity",
+      family: "recognition-independent",
+      eventId: "p-order-parity:a",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:02.000Z",
+      success: true,
+    });
+
+    const accepted = selectCausalAcceptedHistory(
+      "p-order-parity",
+      [eventB, eventA],
+      "2026-09-01T09:00:00.000Z",
+    );
+
+    expect(accepted.map((event) => event.evidence.eventId)).toEqual([
+      "p-order-parity:a",
+      "p-order-parity:b",
+    ]);
+  });
+
+  it("fails closed when wrapper task metadata diverges from the validated evidence", () => {
+    const event = issueSyntheticPilotEvent({
+      participantId: "p-wrapper-mismatch",
+      family: "free-recall",
+      eventId: "p-wrapper-mismatch:e01",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:01.000Z",
+      success: true,
+    });
+    const forged = Object.freeze({
+      ...event,
+      taskDefinition: buildPilotTaskDefinition("recognition-independent"),
+    });
+
+    expect(() =>
+      selectCausalAcceptedHistory(
+        "p-wrapper-mismatch",
+        [forged],
+        "2026-09-01T09:00:00.000Z",
+      ),
+    ).toThrow(/wrapper does not match validated evidence/);
   });
 });

--- a/benchmarks/native-evidence-v1/accepted-history.test.ts
+++ b/benchmarks/native-evidence-v1/accepted-history.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { selectCausalAcceptedHistory } from "./features";
+import { issueSyntheticPilotEvent } from "./synthetic";
+
+describe("native pilot accepted-history parity", () => {
+  it("excludes causally available evidence that the core projector rejects", () => {
+    const firstTransfer = issueSyntheticPilotEvent({
+      participantId: "p-history-parity",
+      family: "near-transfer",
+      eventId: "p-history-parity:transfer-first",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:01.000Z",
+      success: true,
+    });
+
+    const accepted = selectCausalAcceptedHistory(
+      "p-history-parity",
+      [firstTransfer],
+      "2026-09-01T09:00:00.000Z",
+    );
+
+    expect(accepted).toEqual([]);
+  });
+
+  it("uses the same accepted ledger after a valid baseline makes transfer lawful", () => {
+    const baseline = issueSyntheticPilotEvent({
+      participantId: "p-history-parity",
+      family: "free-recall",
+      eventId: "p-history-parity:baseline",
+      occurredAt: "2026-09-01T08:00:00.000Z",
+      availableAt: "2026-09-01T08:00:01.000Z",
+      success: true,
+    });
+    const transfer = issueSyntheticPilotEvent({
+      participantId: "p-history-parity",
+      family: "near-transfer",
+      eventId: "p-history-parity:transfer",
+      occurredAt: "2026-09-01T08:10:00.000Z",
+      availableAt: "2026-09-01T08:10:01.000Z",
+      success: true,
+    });
+
+    const accepted = selectCausalAcceptedHistory(
+      "p-history-parity",
+      [baseline, transfer],
+      "2026-09-01T09:00:00.000Z",
+    );
+
+    expect(accepted.map((event) => event.evidence.eventId)).toEqual([
+      "p-history-parity:baseline",
+      "p-history-parity:transfer",
+    ]);
+  });
+});

--- a/benchmarks/native-evidence-v1/artifact-lineage.test.ts
+++ b/benchmarks/native-evidence-v1/artifact-lineage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { SyntheticPilotStore } from "./store";
+
+
+describe("native pilot synthetic artifact lineage", () => {
+  it("propagates participant lineage through feature -> model -> prediction -> result dependencies", () => {
+    const store = new SyntheticPilotStore();
+
+    const feature = store.registerArtifact("feature:p-a", "feature", ["p-a"]);
+    const model = store.registerArtifact("model:shared", "model", ["p-b"], [feature.artifactId]);
+    const prediction = store.registerArtifact(
+      "prediction:p-b",
+      "prediction",
+      ["p-b"],
+      [model.artifactId],
+    );
+    const result = store.registerArtifact("result:aggregate", "result", [], [prediction.artifactId]);
+
+    expect(model.participantIds).toEqual(["p-a", "p-b"]);
+    expect(prediction.participantIds).toEqual(["p-a", "p-b"]);
+    expect(result.participantIds).toEqual(["p-a", "p-b"]);
+    expect(result.dependsOnArtifactIds).toEqual(["prediction:p-b"]);
+
+    const deletion = store.deleteParticipant("p-a");
+    expect(deletion.invalidatedArtifactIds).toEqual([
+      "feature:p-a",
+      "model:shared",
+      "prediction:p-b",
+      "result:aggregate",
+    ]);
+    expect(store.listValidArtifacts()).toEqual([]);
+  });
+
+  it("fails closed on missing or already-invalidated dependencies", () => {
+    const store = new SyntheticPilotStore();
+
+    expect(() =>
+      store.registerArtifact("prediction:orphan", "prediction", [], ["model:missing"]),
+    ).toThrow("Synthetic artifact dependency is missing: model:missing");
+
+    store.registerArtifact("feature:p-a", "feature", ["p-a"]);
+    store.registerArtifact("model:p-a", "model", [], ["feature:p-a"]);
+    store.deleteParticipant("p-a");
+
+    expect(() =>
+      store.registerArtifact("result:stale", "result", [], ["model:p-a"]),
+    ).toThrow("Synthetic artifact dependency is invalidated: model:p-a");
+  });
+});

--- a/benchmarks/native-evidence-v1/features.ts
+++ b/benchmarks/native-evidence-v1/features.ts
@@ -65,16 +65,25 @@ export function selectCausalAcceptedHistory(
   predictionTimestamp: string,
 ): readonly SyntheticPilotEvent[] {
   const cutoffMs = parseTimestamp(predictionTimestamp, "predictionTimestamp");
-  return Object.freeze(
-    history
-      .filter((event) => {
-        if (event.participantId !== participantId) return false;
-        const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
-        const availableMs = parseTimestamp(event.availableAt, "availableAt");
-        return occurredMs < cutoffMs && availableMs < cutoffMs;
-      })
-      .sort(sortHistory),
+  const causallyAvailable = history
+    .filter((event) => {
+      if (event.participantId !== participantId) return false;
+      const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
+      const availableMs = parseTimestamp(event.availableAt, "availableAt");
+      return occurredMs < cutoffMs && availableMs < cutoffMs;
+    })
+    .sort(sortHistory);
+
+  if (causallyAvailable.length === 0) return Object.freeze([]);
+
+  const projected = projectLearnerState(
+    ontology,
+    causallyAvailable.map((event) => event.evidence),
+    { evaluationTimestamp: predictionTimestamp },
   );
+  const acceptedIds = new Set(projected.acceptedEvents.map((event) => event.eventId));
+
+  return Object.freeze(causallyAvailable.filter((event) => acceptedIds.has(event.evidence.eventId)));
 }
 
 function buildB2(

--- a/benchmarks/native-evidence-v1/features.ts
+++ b/benchmarks/native-evidence-v1/features.ts
@@ -2,6 +2,7 @@ import {
   createEmptyConstructProjection,
   evaluateOutcomeSuccess,
   projectLearnerState,
+  type AcceptedEventAudit,
   type ConstructProjection,
 } from "@/lib/core/learner-state";
 import { buildEnglishOntologyV1 } from "@/lib/core/ontology-seed";
@@ -9,6 +10,7 @@ import { buildEnglishOntologyV1 } from "@/lib/core/ontology-seed";
 import {
   PILOT_TASK_FAMILIES,
   NATIVE_PILOT_TARGET_ID,
+  NATIVE_PILOT_CONTRACT_ID,
   type FeatureVector,
   type PilotTaskDefinition,
   type PredictionFeatureRow,
@@ -51,12 +53,102 @@ function secondsBetween(later: string, earlier: string): number {
   return Math.max(0, (parseTimestamp(later, "later") - parseTimestamp(earlier, "earlier")) / 1000);
 }
 
-function sortHistory(left: SyntheticPilotEvent, right: SyntheticPilotEvent): number {
-  const occurred = left.evidence.occurredAt.localeCompare(right.evidence.occurredAt);
-  if (occurred !== 0) return occurred;
-  const available = left.availableAt.localeCompare(right.availableAt);
-  if (available !== 0) return available;
-  return left.evidence.eventId.localeCompare(right.evidence.eventId);
+function normalizeContextId(value: string | null): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function assertSyntheticEventBinding(event: SyntheticPilotEvent): void {
+  const taskDefinition = event.taskDefinition;
+  const task = taskDefinition.task;
+  const evidence = event.evidence;
+  const problems: string[] = [];
+
+  if (taskDefinition.pilotContractId !== NATIVE_PILOT_CONTRACT_ID) {
+    problems.push("pilot-contract-id");
+  }
+  if (!task.id.startsWith(`native-pilot-v1:${taskDefinition.family}:`)) {
+    problems.push("task-family");
+  }
+  if (task.id !== evidence.taskId) problems.push("task-id");
+  if (evidence.targetId !== NATIVE_PILOT_TARGET_ID || !task.targetIds.includes(evidence.targetId)) {
+    problems.push("target-id");
+  }
+  if (task.activity !== evidence.activity) problems.push("activity");
+  if (
+    task.responseModality !== evidence.responseModality ||
+    task.responseModality !== evidence.attempt.responseModality
+  ) {
+    problems.push("response-modality");
+  }
+  if (task.allowedEvidenceRoles.length !== 1 || task.allowedEvidenceRoles[0] !== evidence.role) {
+    problems.push("evidence-role");
+  }
+  if (task.support.level !== evidence.attempt.supportLevel) problems.push("support-level");
+  if (task.transferDistance !== evidence.transferDistance) problems.push("transfer-distance");
+  if (normalizeContextId(taskDefinition.contextId) !== normalizeContextId(evidence.attempt.contextId)) {
+    problems.push("context-id");
+  }
+  if (taskDefinition.scoringContractId !== task.scoringContractId) {
+    problems.push("scoring-contract-id");
+  }
+  if (JSON.stringify([...task.contextTags].sort()) !== JSON.stringify([...evidence.contextTags].sort())) {
+    problems.push("context-tags");
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Synthetic event wrapper does not match validated evidence ${evidence.eventId}: ${problems.join(",")}`,
+    );
+  }
+}
+
+function acceptanceKeyFromEvent(event: SyntheticPilotEvent): string {
+  const evidence = event.evidence;
+  return JSON.stringify({
+    eventId: evidence.eventId,
+    targetId: evidence.targetId,
+    taskId: evidence.taskId,
+    observationId: evidence.observationId,
+    occurredAt: evidence.occurredAt,
+    role: evidence.role,
+    activity: evidence.activity,
+    responseModality: evidence.responseModality,
+    transferDistance: evidence.transferDistance,
+    contextId: normalizeContextId(evidence.attempt.contextId),
+    contextTags: [...evidence.contextTags].sort(),
+    authorityScope: evidence.authorityScope,
+    outcome: evidence.outcome,
+    supportLevel: evidence.attempt.supportLevel,
+    revealUsed: evidence.attempt.revealUsed,
+    modelFingerprint: evidence.modelFingerprint,
+    calibrationBenchmarkId: evidence.calibrationBenchmarkId,
+    grantId: evidence.grantId,
+  });
+}
+
+function acceptanceKeyFromAudit(audit: AcceptedEventAudit): string {
+  return JSON.stringify({
+    eventId: audit.eventId,
+    targetId: audit.targetId,
+    taskId: audit.taskId,
+    observationId: audit.observationId,
+    occurredAt: audit.occurredAt,
+    role: audit.role,
+    activity: audit.activity,
+    responseModality: audit.responseModality,
+    transferDistance: audit.transferDistance,
+    contextId: normalizeContextId(audit.contextId),
+    contextTags: [...audit.contextTags].sort(),
+    authorityScope: audit.authorityScope,
+    outcome: audit.outcome,
+    supportLevel: audit.supportLevel,
+    revealUsed: audit.revealUsed,
+    modelFingerprint: audit.modelFingerprint,
+    calibrationBenchmarkId: audit.calibrationBenchmarkId,
+    grantId: audit.grantId,
+  });
 }
 
 export function selectCausalAcceptedHistory(
@@ -65,25 +157,44 @@ export function selectCausalAcceptedHistory(
   predictionTimestamp: string,
 ): readonly SyntheticPilotEvent[] {
   const cutoffMs = parseTimestamp(predictionTimestamp, "predictionTimestamp");
-  const causallyAvailable = history
-    .filter((event) => {
-      if (event.participantId !== participantId) return false;
-      const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
-      const availableMs = parseTimestamp(event.availableAt, "availableAt");
-      return occurredMs < cutoffMs && availableMs < cutoffMs;
-    })
-    .sort(sortHistory);
+  const causallyAvailable = history.filter((event) => {
+    if (event.participantId !== participantId) return false;
+    const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
+    const availableMs = parseTimestamp(event.availableAt, "availableAt");
+    return occurredMs < cutoffMs && availableMs < cutoffMs;
+  });
 
   if (causallyAvailable.length === 0) return Object.freeze([]);
+  for (const event of causallyAvailable) assertSyntheticEventBinding(event);
 
   const projected = projectLearnerState(
     ontology,
     causallyAvailable.map((event) => event.evidence),
     { evaluationTimestamp: predictionTimestamp },
   );
-  const acceptedIds = new Set(projected.acceptedEvents.map((event) => event.eventId));
 
-  return Object.freeze(causallyAvailable.filter((event) => acceptedIds.has(event.evidence.eventId)));
+  const wrappersByAcceptedKey = new Map<string, SyntheticPilotEvent[]>();
+  for (const event of causallyAvailable) {
+    const key = acceptanceKeyFromEvent(event);
+    const wrappers = wrappersByAcceptedKey.get(key) ?? [];
+    wrappers.push(event);
+    wrappersByAcceptedKey.set(key, wrappers);
+  }
+
+  const acceptedHistory: SyntheticPilotEvent[] = [];
+  for (const accepted of projected.acceptedEvents) {
+    const key = acceptanceKeyFromAudit(accepted);
+    const wrappers = wrappersByAcceptedKey.get(key);
+    const wrapper = wrappers?.shift();
+    if (!wrapper) {
+      throw new Error(
+        `Accepted core evidence could not be rebound to exactly one synthetic event wrapper: ${accepted.eventId}`,
+      );
+    }
+    acceptedHistory.push(wrapper);
+  }
+
+  return Object.freeze(acceptedHistory);
 }
 
 function buildB2(
@@ -218,7 +329,9 @@ function buildB2(
   return Object.freeze(features);
 }
 
-function deriveBasisProjection(b2: FeatureVector): Pick<ConstructProjection, "status" | "uncertainty" | "provisionalRoutingScore"> {
+function deriveBasisProjection(
+  b2: FeatureVector,
+): Pick<ConstructProjection, "status" | "uncertainty" | "provisionalRoutingScore"> {
   const total = Number(b2.prior_eligible_attempt_count ?? 0);
   const positive = Number(b2.prior_positive_count ?? 0);
   const negative = Number(b2.prior_negative_count ?? 0);
@@ -274,7 +387,9 @@ function buildB3(
     causalHistory.map((event) => event.evidence),
     { evaluationTimestamp: predictionTimestamp, populateAllOntologyNodes: true },
   );
-  const projection = state.constructs[NATIVE_PILOT_TARGET_ID] ?? createEmptyConstructProjection(NATIVE_PILOT_TARGET_ID);
+  const projection =
+    state.constructs[NATIVE_PILOT_TARGET_ID] ??
+    createEmptyConstructProjection(NATIVE_PILOT_TARGET_ID);
   const stats = projection.statistics;
   const first = stats.firstObservedAt;
   const last = stats.lastObservedAt;

--- a/benchmarks/native-evidence-v1/features.ts
+++ b/benchmarks/native-evidence-v1/features.ts
@@ -1,0 +1,325 @@
+import {
+  createEmptyConstructProjection,
+  evaluateOutcomeSuccess,
+  projectLearnerState,
+  type ConstructProjection,
+} from "@/lib/core/learner-state";
+import { buildEnglishOntologyV1 } from "@/lib/core/ontology-seed";
+
+import {
+  PILOT_TASK_FAMILIES,
+  NATIVE_PILOT_TARGET_ID,
+  type FeatureVector,
+  type PilotTaskDefinition,
+  type PredictionFeatureRow,
+  type SyntheticPilotEvent,
+} from "./types";
+
+const ontologyResult = buildEnglishOntologyV1();
+if (!ontologyResult.ok) {
+  throw new Error(`Native pilot ontology failed to build: ${JSON.stringify(ontologyResult.problems)}`);
+}
+const ontology = ontologyResult.graph;
+
+const PILOT_ROLES = ["meaning-recognition", "free-recall", "near-transfer"] as const;
+const SUPPORT_BUCKETS = ["level0", "level1", "level2plus"] as const;
+
+type SupportBucket = (typeof SUPPORT_BUCKETS)[number];
+
+export type BuildPredictionRowInput = {
+  readonly participantId: string;
+  readonly targetEventId: string;
+  readonly predictionTimestamp: string;
+  readonly currentTask: PilotTaskDefinition;
+  readonly history: readonly SyntheticPilotEvent[];
+  readonly label?: 0 | 1 | null;
+};
+
+function parseTimestamp(value: string, field: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${field} must be a valid ISO timestamp: ${value}`);
+  return parsed;
+}
+
+function supportBucket(level: number): SupportBucket {
+  if (level === 0) return "level0";
+  if (level === 1) return "level1";
+  return "level2plus";
+}
+
+function secondsBetween(later: string, earlier: string): number {
+  return Math.max(0, (parseTimestamp(later, "later") - parseTimestamp(earlier, "earlier")) / 1000);
+}
+
+function sortHistory(left: SyntheticPilotEvent, right: SyntheticPilotEvent): number {
+  const occurred = left.evidence.occurredAt.localeCompare(right.evidence.occurredAt);
+  if (occurred !== 0) return occurred;
+  const available = left.availableAt.localeCompare(right.availableAt);
+  if (available !== 0) return available;
+  return left.evidence.eventId.localeCompare(right.evidence.eventId);
+}
+
+export function selectCausalAcceptedHistory(
+  participantId: string,
+  history: readonly SyntheticPilotEvent[],
+  predictionTimestamp: string,
+): readonly SyntheticPilotEvent[] {
+  const cutoffMs = parseTimestamp(predictionTimestamp, "predictionTimestamp");
+  return Object.freeze(
+    history
+      .filter((event) => {
+        if (event.participantId !== participantId) return false;
+        const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
+        const availableMs = parseTimestamp(event.availableAt, "availableAt");
+        return occurredMs < cutoffMs && availableMs < cutoffMs;
+      })
+      .sort(sortHistory),
+  );
+}
+
+function buildB2(
+  causalHistory: readonly SyntheticPilotEvent[],
+  currentTask: PilotTaskDefinition,
+  predictionTimestamp: string,
+): FeatureVector {
+  let positive = 0;
+  let negative = 0;
+  let revealUsed = 0;
+  let sameContextSuccess = 0;
+  let sameContextFailure = 0;
+  let nearTransferSuccess = 0;
+  let nearTransferFailure = 0;
+
+  const familyCount = Object.fromEntries(PILOT_TASK_FAMILIES.map((family) => [family, 0])) as Record<
+    (typeof PILOT_TASK_FAMILIES)[number],
+    number
+  >;
+  const familyPositive = Object.fromEntries(
+    PILOT_TASK_FAMILIES.map((family) => [family, 0]),
+  ) as Record<(typeof PILOT_TASK_FAMILIES)[number], number>;
+  const familyNegative = Object.fromEntries(
+    PILOT_TASK_FAMILIES.map((family) => [family, 0]),
+  ) as Record<(typeof PILOT_TASK_FAMILIES)[number], number>;
+  const rolePositive = Object.fromEntries(PILOT_ROLES.map((role) => [role, 0])) as Record<
+    (typeof PILOT_ROLES)[number],
+    number
+  >;
+  const roleNegative = Object.fromEntries(PILOT_ROLES.map((role) => [role, 0])) as Record<
+    (typeof PILOT_ROLES)[number],
+    number
+  >;
+  const supportCount = Object.fromEntries(SUPPORT_BUCKETS.map((bucket) => [bucket, 0])) as Record<
+    SupportBucket,
+    number
+  >;
+  const supportPositive = Object.fromEntries(SUPPORT_BUCKETS.map((bucket) => [bucket, 0])) as Record<
+    SupportBucket,
+    number
+  >;
+  const supportNegative = Object.fromEntries(SUPPORT_BUCKETS.map((bucket) => [bucket, 0])) as Record<
+    SupportBucket,
+    number
+  >;
+  const contexts = new Set<string>();
+
+  for (const event of causalHistory) {
+    const success = evaluateOutcomeSuccess(event.evidence.outcome);
+    if (success) positive += 1;
+    else negative += 1;
+
+    familyCount[event.taskDefinition.family] += 1;
+    if (success) familyPositive[event.taskDefinition.family] += 1;
+    else familyNegative[event.taskDefinition.family] += 1;
+
+    const role = event.evidence.role;
+    if (role === "meaning-recognition" || role === "free-recall" || role === "near-transfer") {
+      if (success) rolePositive[role] += 1;
+      else roleNegative[role] += 1;
+    }
+
+    const bucket = supportBucket(event.evidence.attempt.supportLevel);
+    supportCount[bucket] += 1;
+    if (success) supportPositive[bucket] += 1;
+    else supportNegative[bucket] += 1;
+
+    if (event.evidence.attempt.revealUsed) revealUsed += 1;
+    if (event.evidence.attempt.contextId) contexts.add(event.evidence.attempt.contextId);
+
+    if (event.evidence.transferDistance === "same-context") {
+      if (success) sameContextSuccess += 1;
+      else sameContextFailure += 1;
+    } else if (event.evidence.transferDistance === "near-transfer") {
+      if (success) nearTransferSuccess += 1;
+      else nearTransferFailure += 1;
+    }
+  }
+
+  const previous = causalHistory.at(-1) ?? null;
+  const first = causalHistory.at(0) ?? null;
+  const total = causalHistory.length;
+  const successRate = total === 0 ? null : positive / total;
+
+  const features: Record<string, number | string | null> = {
+    prior_eligible_attempt_count: total,
+    prior_positive_count: positive,
+    prior_negative_count: negative,
+    prior_success_rate: successRate,
+    previous_outcome: previous
+      ? evaluateOutcomeSuccess(previous.evidence.outcome)
+        ? "success"
+        : "failure"
+      : "missing",
+    seconds_since_previous_attempt: previous
+      ? secondsBetween(predictionTimestamp, previous.evidence.occurredAt)
+      : null,
+    prior_support_level0_count: supportCount.level0,
+    prior_support_level1_count: supportCount.level1,
+    prior_support_level2plus_count: supportCount.level2plus,
+    prior_reveal_used_count: revealUsed,
+    prior_distinct_context_count: contexts.size,
+    same_context_success_count: sameContextSuccess,
+    same_context_failure_count: sameContextFailure,
+    near_transfer_success_count: nearTransferSuccess,
+    near_transfer_failure_count: nearTransferFailure,
+    seconds_since_first_accepted_evidence: first
+      ? secondsBetween(predictionTimestamp, first.evidence.occurredAt)
+      : null,
+    current_task_family: currentTask.family,
+    current_planned_support_level: currentTask.task.support.level,
+    current_reveal_allowed: currentTask.task.support.revealAllowed ? 1 : 0,
+    current_transfer_distance: currentTask.task.transferDistance,
+    current_context_id: currentTask.contextId,
+    current_stimulus_form_group: currentTask.stimulusFormGroup,
+  };
+
+  for (const family of PILOT_TASK_FAMILIES) {
+    features[`prior_family_${family}_count`] = familyCount[family];
+    features[`prior_family_${family}_positive`] = familyPositive[family];
+    features[`prior_family_${family}_negative`] = familyNegative[family];
+  }
+  for (const role of PILOT_ROLES) {
+    features[`prior_role_${role}_positive`] = rolePositive[role];
+    features[`prior_role_${role}_negative`] = roleNegative[role];
+  }
+  for (const bucket of SUPPORT_BUCKETS) {
+    features[`prior_support_${bucket}_positive`] = supportPositive[bucket];
+    features[`prior_support_${bucket}_negative`] = supportNegative[bucket];
+  }
+
+  return Object.freeze(features);
+}
+
+function deriveBasisProjection(b2: FeatureVector): Pick<ConstructProjection, "status" | "uncertainty" | "provisionalRoutingScore"> {
+  const total = Number(b2.prior_eligible_attempt_count ?? 0);
+  const positive = Number(b2.prior_positive_count ?? 0);
+  const negative = Number(b2.prior_negative_count ?? 0);
+
+  if (total === 0) {
+    return { status: "unknown", uncertainty: "maximal", provisionalRoutingScore: null };
+  }
+  if (total < 2) {
+    return { status: "insufficient-support", uncertainty: "high", provisionalRoutingScore: null };
+  }
+  if (positive >= 2 && negative === 0) {
+    return {
+      status: "provisional-support",
+      uncertainty: total >= 5 ? "low" : "moderate",
+      provisionalRoutingScore: positive / total,
+    };
+  }
+  if (negative >= 2 && positive === 0) {
+    return {
+      status: "provisional-weakness",
+      uncertainty: total >= 5 ? "low" : "moderate",
+      provisionalRoutingScore: 0,
+    };
+  }
+  if (positive >= 1 && negative >= 1) {
+    return { status: "conflicted-support", uncertainty: "high", provisionalRoutingScore: null };
+  }
+  return { status: "insufficient-support", uncertainty: "high", provisionalRoutingScore: null };
+}
+
+function buildB2Basis(b2: FeatureVector): FeatureVector {
+  const basis = deriveBasisProjection(b2);
+  return Object.freeze({
+    ...b2,
+    basis_status: basis.status,
+    basis_uncertainty: basis.uncertainty,
+    basis_provisional_routing_score: basis.provisionalRoutingScore,
+    basis_routing_score_missing: basis.provisionalRoutingScore === null ? 1 : 0,
+    basis_conflicted_count: Math.min(
+      Number(b2.prior_positive_count ?? 0),
+      Number(b2.prior_negative_count ?? 0),
+    ),
+  });
+}
+
+function buildB3(
+  b2: FeatureVector,
+  causalHistory: readonly SyntheticPilotEvent[],
+  predictionTimestamp: string,
+): FeatureVector {
+  const state = projectLearnerState(
+    ontology,
+    causalHistory.map((event) => event.evidence),
+    { evaluationTimestamp: predictionTimestamp, populateAllOntologyNodes: true },
+  );
+  const projection = state.constructs[NATIVE_PILOT_TARGET_ID] ?? createEmptyConstructProjection(NATIVE_PILOT_TARGET_ID);
+  const stats = projection.statistics;
+  const first = stats.firstObservedAt;
+  const last = stats.lastObservedAt;
+
+  return Object.freeze({
+    ...b2,
+    nep_status: projection.status,
+    nep_uncertainty: projection.uncertainty,
+    nep_provisional_routing_score: projection.provisionalRoutingScore,
+    nep_routing_score_missing: projection.provisionalRoutingScore === null ? 1 : 0,
+    nep_total_event_count: stats.totalEvents,
+    nep_positive_count: stats.positiveCount,
+    nep_negative_count: stats.negativeCount,
+    nep_conflicted_count: stats.conflictedCount,
+    nep_distinct_context_count: stats.distinctContextCount,
+    nep_role_meaning_recognition_positive: stats.byRole["meaning-recognition"].positive,
+    nep_role_meaning_recognition_negative: stats.byRole["meaning-recognition"].negative,
+    nep_role_free_recall_positive: stats.byRole["free-recall"].positive,
+    nep_role_free_recall_negative: stats.byRole["free-recall"].negative,
+    nep_role_near_transfer_positive: stats.byRole["near-transfer"].positive,
+    nep_role_near_transfer_negative: stats.byRole["near-transfer"].negative,
+    nep_support_level0_count: stats.supportDistribution.level0,
+    nep_support_level1_count: stats.supportDistribution.level1,
+    nep_support_level2plus_count: stats.supportDistribution.level2Plus,
+    nep_reveal_used_count: stats.revealUsedCount,
+    nep_same_context_success_count: b2.same_context_success_count,
+    nep_same_context_failure_count: b2.same_context_failure_count,
+    nep_near_transfer_success_count: b2.near_transfer_success_count,
+    nep_near_transfer_failure_count: b2.near_transfer_failure_count,
+    nep_seconds_since_first_accepted_evidence: first
+      ? secondsBetween(predictionTimestamp, first)
+      : null,
+    nep_seconds_since_last_accepted_evidence: last ? secondsBetween(predictionTimestamp, last) : null,
+  });
+}
+
+export function buildPredictionFeatureRow(input: BuildPredictionRowInput): PredictionFeatureRow {
+  const causalHistory = selectCausalAcceptedHistory(
+    input.participantId,
+    input.history,
+    input.predictionTimestamp,
+  );
+  const b2 = buildB2(causalHistory, input.currentTask, input.predictionTimestamp);
+  const b2Basis = buildB2Basis(b2);
+  const b3 = buildB3(b2, causalHistory, input.predictionTimestamp);
+
+  return Object.freeze({
+    participantId: input.participantId,
+    targetEventId: input.targetEventId,
+    predictionTimestamp: input.predictionTimestamp,
+    label: input.label ?? null,
+    acceptedHistoryEventIds: Object.freeze(causalHistory.map((event) => event.evidence.eventId)),
+    b2,
+    b2Basis,
+    b3,
+  });
+}

--- a/benchmarks/native-evidence-v1/manifest.ts
+++ b/benchmarks/native-evidence-v1/manifest.ts
@@ -1,18 +1,11 @@
 import crypto from "node:crypto";
 
-import type { FrozenNativeSplitProtocol } from "./protocol";
-import type {
-  PilotTaskDefinition,
-  PredictionFeatureRow,
-  SyntheticArtifactRecord,
-} from "./types";
+import type { PilotTaskDefinition, PredictionFeatureRow } from "./types";
 import {
   NATIVE_PILOT_CONTRACT_ID,
   NATIVE_PREDICTOR_CONTRACT_ID,
   SYNTHETIC_ONLY_STATUS,
 } from "./types";
-
-export const NATIVE_DECISION_RULE_ID = "nep.native-decision.v1" as const;
 
 export const NATIVE_PREDICTOR_SETTINGS = Object.freeze({
   implementation: "scikit-learn",
@@ -39,186 +32,18 @@ export const NATIVE_METRIC_SETTINGS = Object.freeze({
   aucOneClassPolicy: "null-with-reason",
 });
 
-export const NATIVE_FEATURE_POLICY = Object.freeze({
-  sharedHistorySource: "accepted-reference-evidence-only",
-  b2: Object.freeze({
-    role: "strong-causal-history",
-    currentOutcomeForbidden: true,
-    currentRevealUseForbidden: true,
-    currentLatencyForbidden: true,
-  }),
-  b2Basis: Object.freeze({
-    role: "deterministic-projector-basis-control",
-    source: "b2-counts-only",
-  }),
-  b3: Object.freeze({
-    role: "learner-state-representation-test",
-    source: "projectLearnerState-over-same-accepted-history",
-  }),
-  pruning: Object.freeze({
-    trainConstantColumns: "drop",
-    exactDuplicateColumns: "drop-stable-name-order-b2-preferred",
-    fitScope: "TRAIN-only",
-  }),
-});
-
-export const NATIVE_SOURCE_BINDINGS = Object.freeze([
-  Object.freeze({
-    id: "core-frontier",
-    revision: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
-    role: "canonical-core-contract-donor",
-    rights: "repository-owned",
-  }),
-  Object.freeze({
-    id: "native-spec-amendment",
-    revision: "34013121cb9ab6850d15fa09a06ed3a46da44486",
-    role: "reviewed-experiment-contract",
-    rights: "repository-owned",
-  }),
-  Object.freeze({
-    id: "slam-benchmark-donor",
-    revision: "490fbcd0fcfbf161a475a17463445410ef67e99e",
-    role: "manifest-statistics-pattern-donor-only",
-    rights: "repository-owned-derived-code",
-  }),
-  Object.freeze({
-    id: "scikit-learn",
-    revision: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
-    role: "common-logistic-estimator",
-    rights: "BSD-3-Clause",
-  }),
-  Object.freeze({
-    id: "pyBKT",
-    revision: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
-    role: "conditional-classical-comparator",
-    rights: "MIT",
-  }),
-] as const);
-
-export type SyntheticPredictorLane =
-  | "b0-native"
-  | "b2-native"
-  | "b2-basis-native"
-  | "b3-native"
-  | "bkt-native";
-
-export type SyntheticPredictorArtifactBinding = {
-  readonly lane: SyntheticPredictorLane;
-  readonly availability: "available" | "not-estimable" | "not-run";
-  readonly specFingerprint: `sha256:${string}` | null;
-  readonly transformFingerprint: `sha256:${string}` | null;
-  readonly fittedModelFingerprint: `sha256:${string}` | null;
-  readonly predictionFingerprint: `sha256:${string}` | null;
-  readonly nonEstimabilityReason: string | null;
-};
-
-export type SyntheticCoverageSummary = {
-  readonly eligibleOpportunityCount: number;
-  readonly observedOutcomeCount: number;
-  readonly emittedPredictionCount: number;
-  readonly acceptedHistoryEventCount: number;
-  readonly rejectedHistoryEventCount: number;
-  readonly learnerCount: number;
-  readonly attemptCount: number;
-};
-
-export type SyntheticBktManifestBinding = {
-  readonly diagnosticsArtifactDigest: `sha256:${string}` | null;
-  readonly diagnosticsUnavailableReason: string | null;
-  readonly convergenceAssurance: "convergence-observed" | "convergence-unverified" | "not-run";
-  readonly stabilityAssurance:
-    | "unresolved-pending-reviewed-train-only-tolerances"
-    | "reviewed"
-    | "not-run";
-};
-
-export type BuildSyntheticNativePilotManifestInput = {
-  readonly tasks: readonly PilotTaskDefinition[];
-  readonly rows: readonly PredictionFeatureRow[];
-  readonly protocol: FrozenNativeSplitProtocol;
-  readonly artifacts: readonly SyntheticArtifactRecord[];
-  readonly predictorArtifacts: readonly SyntheticPredictorArtifactBinding[];
-  readonly coverage: SyntheticCoverageSummary;
-  readonly bkt: SyntheticBktManifestBinding;
-};
-
 function digestJson(value: unknown): `sha256:${string}` {
   return `sha256:${crypto.createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex")}`;
 }
 
-function assertNonnegativeInteger(value: number, field: string): void {
-  if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`${field} must be a nonnegative integer`);
-  }
-}
-
-function validateCoverage(coverage: SyntheticCoverageSummary): void {
-  for (const [field, value] of Object.entries(coverage)) {
-    assertNonnegativeInteger(value, `coverage.${field}`);
-  }
-  if (coverage.observedOutcomeCount > coverage.eligibleOpportunityCount) {
-    throw new Error("coverage.observedOutcomeCount cannot exceed eligibleOpportunityCount");
-  }
-  if (coverage.emittedPredictionCount > coverage.eligibleOpportunityCount) {
-    throw new Error("coverage.emittedPredictionCount cannot exceed eligibleOpportunityCount");
-  }
-}
-
-function validatePredictorArtifacts(
-  artifacts: readonly SyntheticPredictorArtifactBinding[],
-): readonly SyntheticPredictorArtifactBinding[] {
-  const expected: readonly SyntheticPredictorLane[] = [
-    "b0-native",
-    "b2-native",
-    "b2-basis-native",
-    "b3-native",
-    "bkt-native",
-  ];
-  const byLane = new Map(artifacts.map((artifact) => [artifact.lane, artifact]));
-  if (byLane.size !== artifacts.length) {
-    throw new Error("predictorArtifacts must contain unique lanes");
-  }
-  for (const lane of expected) {
-    if (!byLane.has(lane)) throw new Error(`predictorArtifacts missing lane: ${lane}`);
-  }
-  for (const artifact of artifacts) {
-    if (artifact.availability === "not-estimable" && !artifact.nonEstimabilityReason) {
-      throw new Error(`not-estimable lane must record a reason: ${artifact.lane}`);
-    }
-    if (artifact.availability !== "not-estimable" && artifact.nonEstimabilityReason) {
-      throw new Error(`only not-estimable lanes may record nonEstimabilityReason: ${artifact.lane}`);
-    }
-  }
-  return Object.freeze(
-    [...artifacts].sort((left, right) => left.lane.localeCompare(right.lane)),
-  );
-}
-
-function validateBktBinding(binding: SyntheticBktManifestBinding): void {
-  if (binding.diagnosticsArtifactDigest === null && !binding.diagnosticsUnavailableReason) {
-    throw new Error("missing BKT diagnostics digest requires diagnosticsUnavailableReason");
-  }
-  if (binding.diagnosticsArtifactDigest !== null && binding.diagnosticsUnavailableReason !== null) {
-    throw new Error("BKT diagnostics reason must be null when a digest is present");
-  }
-}
-
 export type SyntheticNativePilotManifest = {
   readonly status: typeof SYNTHETIC_ONLY_STATUS;
-  readonly manifestDigest: `sha256:${string}`;
+  readonly purpose: "fixture-feature-summary";
   readonly pilotContractId: typeof NATIVE_PILOT_CONTRACT_ID;
   readonly predictorContractId: typeof NATIVE_PREDICTOR_CONTRACT_ID;
-  readonly decisionRuleId: typeof NATIVE_DECISION_RULE_ID;
-  readonly dataPolicy: {
-    readonly source: "synthetic-only";
-    readonly humanDataIncluded: false;
-    readonly externalCorpusRowsIncluded: false;
-    readonly redistributionDecision: "not-applicable";
-  };
-  readonly sourceBindings: typeof NATIVE_SOURCE_BINDINGS;
+  readonly sourcePins: Readonly<Record<string, string>>;
   readonly predictor: typeof NATIVE_PREDICTOR_SETTINGS;
   readonly metrics: typeof NATIVE_METRIC_SETTINGS;
-  readonly featurePolicy: typeof NATIVE_FEATURE_POLICY;
   readonly causalPolicy: {
     readonly currentOutcomeForbidden: true;
     readonly futureOutcomeForbidden: true;
@@ -226,24 +51,12 @@ export type SyntheticNativePilotManifest = {
     readonly strictAvailableBeforePrediction: true;
     readonly equalTimestampExcluded: true;
     readonly trainOnlyTransforms: true;
-    readonly blindBlockFeedbackForbidden: true;
   };
   readonly utilityGate: {
     readonly status: "unresolved";
     readonly deltaHistory: null;
     readonly deltaBasis: null;
     readonly predictiveKeepSimplifyEnabled: false;
-  };
-  readonly split: {
-    readonly protocolId: string;
-    readonly frozenAt: string;
-    readonly fitCutoff: string;
-    readonly fitCompletedAt: string;
-    readonly trainingParticipantIds: readonly string[];
-    readonly heldOutParticipantIds: readonly string[];
-    readonly trainPrefixEventIdsByParticipant: Readonly<Record<string, readonly string[]>>;
-    readonly blindTargetEventIds: readonly string[];
-    readonly digest: `sha256:${string}`;
   };
   readonly taskDefinitions: readonly {
     readonly family: string;
@@ -258,34 +71,16 @@ export type SyntheticNativePilotManifest = {
     readonly targetEventId: string;
     readonly predictionTimestamp: string;
     readonly acceptedHistoryEventIds: readonly string[];
-    readonly featureDigest: `sha256:${string}`;
-    readonly predictionBindingDigest: `sha256:${string}`;
+    readonly featureDigest: string;
   }[];
-  readonly predictorArtifacts: readonly SyntheticPredictorArtifactBinding[];
-  readonly artifacts: readonly SyntheticArtifactRecord[];
-  readonly coverage: SyntheticCoverageSummary;
-  readonly contrasts: {
-    readonly b3MinusB2: null;
-    readonly b3MinusB2Basis: null;
-    readonly reason: "synthetic-data-cannot-rank-models";
-  };
-  readonly attribution: "unresolved-synthetic-only";
-  readonly bkt: SyntheticBktManifestBinding;
-  readonly decision: {
-    readonly status: "disabled-synthetic-only";
-    readonly reason: "no-human-outcomes-and-utility-margins-unresolved";
-  };
   readonly forbiddenClaims: readonly string[];
 };
 
 export function buildSyntheticNativePilotManifest(
-  input: BuildSyntheticNativePilotManifestInput,
+  tasks: readonly PilotTaskDefinition[],
+  rows: readonly PredictionFeatureRow[],
 ): SyntheticNativePilotManifest {
-  validateCoverage(input.coverage);
-  validateBktBinding(input.bkt);
-  const predictorArtifacts = validatePredictorArtifacts(input.predictorArtifacts);
-
-  const taskDefinitions = input.tasks
+  const taskDefinitions = tasks
     .map((definition) => ({
       family: definition.family,
       taskId: definition.task.id,
@@ -296,105 +91,46 @@ export function buildSyntheticNativePilotManifest(
     }))
     .sort((left, right) => left.taskId.localeCompare(right.taskId));
 
-  const featureRows = input.rows
-    .map((row) => {
-      const featureDigest = digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 });
-      return {
-        participantId: row.participantId,
-        targetEventId: row.targetEventId,
-        predictionTimestamp: row.predictionTimestamp,
-        acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
-        featureDigest,
-        predictionBindingDigest: digestJson({
-          participantId: row.participantId,
-          targetEventId: row.targetEventId,
-          predictionTimestamp: row.predictionTimestamp,
-          acceptedHistoryEventIds: row.acceptedHistoryEventIds,
-          featureDigest,
-        }),
-      };
-    })
+  const featureRows = rows
+    .map((row) => ({
+      participantId: row.participantId,
+      targetEventId: row.targetEventId,
+      predictionTimestamp: row.predictionTimestamp,
+      acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
+      featureDigest: digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 }),
+    }))
     .sort((left, right) => left.targetEventId.localeCompare(right.targetEventId));
 
-  const trainPrefixEventIdsByParticipant = Object.fromEntries(
-    Object.entries(input.protocol.trainPrefixEventIdsByParticipant)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([participantId, eventIds]) => [participantId, Object.freeze([...eventIds].sort())]),
-  );
-  const splitWithoutDigest = {
-    protocolId: input.protocol.protocolId,
-    frozenAt: input.protocol.frozenAt,
-    fitCutoff: input.protocol.fitCutoff,
-    fitCompletedAt: input.protocol.fitCompletedAt,
-    trainingParticipantIds: Object.freeze([...input.protocol.trainingParticipantIds].sort()),
-    heldOutParticipantIds: Object.freeze([...input.protocol.heldOutParticipantIds].sort()),
-    trainPrefixEventIdsByParticipant: Object.freeze(trainPrefixEventIdsByParticipant),
-    blindTargetEventIds: Object.freeze([...input.protocol.blindTargetEventIds].sort()),
-  };
-  const split = Object.freeze({
-    ...splitWithoutDigest,
-    digest: digestJson(splitWithoutDigest),
-  });
-
-  const artifacts = Object.freeze(
-    [...input.artifacts]
-      .map((artifact) =>
-        Object.freeze({
-          ...artifact,
-          participantIds: Object.freeze([...artifact.participantIds].sort()),
-          dependsOnArtifactIds: Object.freeze([...artifact.dependsOnArtifactIds].sort()),
-        }),
-      )
-      .sort((left, right) => left.artifactId.localeCompare(right.artifactId)),
-  );
-
-  const manifestWithoutDigest = Object.freeze({
+  return Object.freeze({
     status: SYNTHETIC_ONLY_STATUS,
+    purpose: "fixture-feature-summary",
     pilotContractId: NATIVE_PILOT_CONTRACT_ID,
     predictorContractId: NATIVE_PREDICTOR_CONTRACT_ID,
-    decisionRuleId: NATIVE_DECISION_RULE_ID,
-    dataPolicy: Object.freeze({
-      source: "synthetic-only" as const,
-      humanDataIncluded: false as const,
-      externalCorpusRowsIncluded: false as const,
-      redistributionDecision: "not-applicable" as const,
+    sourcePins: Object.freeze({
+      coreFrontier: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
+      nativeSpecAmendment: "34013121cb9ab6850d15fa09a06ed3a46da44486",
+      slamDonor: "490fbcd0fcfbf161a475a17463445410ef67e99e",
+      scikitLearn: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
+      pyBKT: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
     }),
-    sourceBindings: NATIVE_SOURCE_BINDINGS,
     predictor: NATIVE_PREDICTOR_SETTINGS,
     metrics: NATIVE_METRIC_SETTINGS,
-    featurePolicy: NATIVE_FEATURE_POLICY,
     causalPolicy: Object.freeze({
-      currentOutcomeForbidden: true as const,
-      futureOutcomeForbidden: true as const,
-      strictOccurredBeforePrediction: true as const,
-      strictAvailableBeforePrediction: true as const,
-      equalTimestampExcluded: true as const,
-      trainOnlyTransforms: true as const,
-      blindBlockFeedbackForbidden: true as const,
+      currentOutcomeForbidden: true,
+      futureOutcomeForbidden: true,
+      strictOccurredBeforePrediction: true,
+      strictAvailableBeforePrediction: true,
+      equalTimestampExcluded: true,
+      trainOnlyTransforms: true,
     }),
     utilityGate: Object.freeze({
-      status: "unresolved" as const,
+      status: "unresolved",
       deltaHistory: null,
       deltaBasis: null,
-      predictiveKeepSimplifyEnabled: false as const,
+      predictiveKeepSimplifyEnabled: false,
     }),
-    split,
     taskDefinitions: Object.freeze(taskDefinitions),
     featureRows: Object.freeze(featureRows),
-    predictorArtifacts,
-    artifacts,
-    coverage: Object.freeze({ ...input.coverage }),
-    contrasts: Object.freeze({
-      b3MinusB2: null,
-      b3MinusB2Basis: null,
-      reason: "synthetic-data-cannot-rank-models" as const,
-    }),
-    attribution: "unresolved-synthetic-only" as const,
-    bkt: Object.freeze({ ...input.bkt }),
-    decision: Object.freeze({
-      status: "disabled-synthetic-only" as const,
-      reason: "no-human-outcomes-and-utility-margins-unresolved" as const,
-    }),
     forbiddenClaims: Object.freeze([
       "learner-model-validity",
       "predictive-superiority",
@@ -406,10 +142,5 @@ export function buildSyntheticNativePilotManifest(
       "calibrated",
       "production-authority",
     ]),
-  });
-
-  return Object.freeze({
-    ...manifestWithoutDigest,
-    manifestDigest: digestJson(manifestWithoutDigest),
   });
 }

--- a/benchmarks/native-evidence-v1/manifest.ts
+++ b/benchmarks/native-evidence-v1/manifest.ts
@@ -1,0 +1,144 @@
+import crypto from "node:crypto";
+
+import type { PilotTaskDefinition, PredictionFeatureRow } from "./types";
+import {
+  NATIVE_PILOT_CONTRACT_ID,
+  NATIVE_PREDICTOR_CONTRACT_ID,
+  SYNTHETIC_ONLY_STATUS,
+} from "./types";
+
+export const NATIVE_PREDICTOR_SETTINGS = Object.freeze({
+  implementation: "scikit-learn",
+  version: "1.6.1",
+  estimator: "LogisticRegression",
+  parameters: Object.freeze({
+    penalty: "l2",
+    C: 1,
+    solver: "lbfgs",
+    fit_intercept: true,
+    class_weight: null,
+    max_iter: 1000,
+    tol: 1e-8,
+  }),
+});
+
+export const NATIVE_METRIC_SETTINGS = Object.freeze({
+  positiveClass: "error=1",
+  primary: "mean-per-learner-natural-log-loss",
+  secondary: "mean-per-learner-brier-loss",
+  logLossClipEpsilon: 1e-15,
+  calibrationBins: 5,
+  bootstrap: Object.freeze({ unit: "learner", draws: 2000, seed: 143 }),
+  aucOneClassPolicy: "null-with-reason",
+});
+
+function digestJson(value: unknown): `sha256:${string}` {
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex")}`;
+}
+
+export type SyntheticNativePilotManifest = {
+  readonly status: typeof SYNTHETIC_ONLY_STATUS;
+  readonly pilotContractId: typeof NATIVE_PILOT_CONTRACT_ID;
+  readonly predictorContractId: typeof NATIVE_PREDICTOR_CONTRACT_ID;
+  readonly sourcePins: Readonly<Record<string, string>>;
+  readonly predictor: typeof NATIVE_PREDICTOR_SETTINGS;
+  readonly metrics: typeof NATIVE_METRIC_SETTINGS;
+  readonly causalPolicy: {
+    readonly currentOutcomeForbidden: true;
+    readonly futureOutcomeForbidden: true;
+    readonly strictOccurredBeforePrediction: true;
+    readonly strictAvailableBeforePrediction: true;
+    readonly equalTimestampExcluded: true;
+    readonly trainOnlyTransforms: true;
+  };
+  readonly utilityGate: {
+    readonly status: "unresolved";
+    readonly deltaHistory: null;
+    readonly deltaBasis: null;
+    readonly predictiveKeepSimplifyEnabled: false;
+  };
+  readonly taskDefinitions: readonly {
+    readonly family: string;
+    readonly taskId: string;
+    readonly taskVersion: number;
+    readonly contentFingerprint: string;
+    readonly contextId: string;
+    readonly stimulusFormGroup: string;
+  }[];
+  readonly featureRows: readonly {
+    readonly participantId: string;
+    readonly targetEventId: string;
+    readonly predictionTimestamp: string;
+    readonly acceptedHistoryEventIds: readonly string[];
+    readonly featureDigest: string;
+  }[];
+  readonly forbiddenClaims: readonly string[];
+};
+
+export function buildSyntheticNativePilotManifest(
+  tasks: readonly PilotTaskDefinition[],
+  rows: readonly PredictionFeatureRow[],
+): SyntheticNativePilotManifest {
+  const taskDefinitions = tasks
+    .map((definition) => ({
+      family: definition.family,
+      taskId: definition.task.id,
+      taskVersion: definition.task.version,
+      contentFingerprint: definition.contentFingerprint,
+      contextId: definition.contextId,
+      stimulusFormGroup: definition.stimulusFormGroup,
+    }))
+    .sort((left, right) => left.taskId.localeCompare(right.taskId));
+
+  const featureRows = rows
+    .map((row) => ({
+      participantId: row.participantId,
+      targetEventId: row.targetEventId,
+      predictionTimestamp: row.predictionTimestamp,
+      acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
+      featureDigest: digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 }),
+    }))
+    .sort((left, right) => left.targetEventId.localeCompare(right.targetEventId));
+
+  return Object.freeze({
+    status: SYNTHETIC_ONLY_STATUS,
+    pilotContractId: NATIVE_PILOT_CONTRACT_ID,
+    predictorContractId: NATIVE_PREDICTOR_CONTRACT_ID,
+    sourcePins: Object.freeze({
+      coreFrontier: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
+      nativeSpecAmendment: "34013121cb9ab6850d15fa09a06ed3a46da44486",
+      slamDonor: "490fbcd0fcfbf161a475a17463445410ef67e99e",
+      scikitLearn: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
+      pyBKT: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
+    }),
+    predictor: NATIVE_PREDICTOR_SETTINGS,
+    metrics: NATIVE_METRIC_SETTINGS,
+    causalPolicy: Object.freeze({
+      currentOutcomeForbidden: true,
+      futureOutcomeForbidden: true,
+      strictOccurredBeforePrediction: true,
+      strictAvailableBeforePrediction: true,
+      equalTimestampExcluded: true,
+      trainOnlyTransforms: true,
+    }),
+    utilityGate: Object.freeze({
+      status: "unresolved",
+      deltaHistory: null,
+      deltaBasis: null,
+      predictiveKeepSimplifyEnabled: false,
+    }),
+    taskDefinitions: Object.freeze(taskDefinitions),
+    featureRows: Object.freeze(featureRows),
+    forbiddenClaims: Object.freeze([
+      "learner-model-validity",
+      "predictive-superiority",
+      "learning-efficacy",
+      "retention-validity",
+      "transfer-validity",
+      "mastery",
+      "CEFR",
+      "calibrated",
+      "production-authority",
+    ]),
+  });
+}

--- a/benchmarks/native-evidence-v1/manifest.ts
+++ b/benchmarks/native-evidence-v1/manifest.ts
@@ -1,11 +1,18 @@
 import crypto from "node:crypto";
 
-import type { PilotTaskDefinition, PredictionFeatureRow } from "./types";
+import type { FrozenNativeSplitProtocol } from "./protocol";
+import type {
+  PilotTaskDefinition,
+  PredictionFeatureRow,
+  SyntheticArtifactRecord,
+} from "./types";
 import {
   NATIVE_PILOT_CONTRACT_ID,
   NATIVE_PREDICTOR_CONTRACT_ID,
   SYNTHETIC_ONLY_STATUS,
 } from "./types";
+
+export const NATIVE_DECISION_RULE_ID = "nep.native-decision.v1" as const;
 
 export const NATIVE_PREDICTOR_SETTINGS = Object.freeze({
   implementation: "scikit-learn",
@@ -32,17 +39,186 @@ export const NATIVE_METRIC_SETTINGS = Object.freeze({
   aucOneClassPolicy: "null-with-reason",
 });
 
+export const NATIVE_FEATURE_POLICY = Object.freeze({
+  sharedHistorySource: "accepted-reference-evidence-only",
+  b2: Object.freeze({
+    role: "strong-causal-history",
+    currentOutcomeForbidden: true,
+    currentRevealUseForbidden: true,
+    currentLatencyForbidden: true,
+  }),
+  b2Basis: Object.freeze({
+    role: "deterministic-projector-basis-control",
+    source: "b2-counts-only",
+  }),
+  b3: Object.freeze({
+    role: "learner-state-representation-test",
+    source: "projectLearnerState-over-same-accepted-history",
+  }),
+  pruning: Object.freeze({
+    trainConstantColumns: "drop",
+    exactDuplicateColumns: "drop-stable-name-order-b2-preferred",
+    fitScope: "TRAIN-only",
+  }),
+});
+
+export const NATIVE_SOURCE_BINDINGS = Object.freeze([
+  Object.freeze({
+    id: "core-frontier",
+    revision: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
+    role: "canonical-core-contract-donor",
+    rights: "repository-owned",
+  }),
+  Object.freeze({
+    id: "native-spec-amendment",
+    revision: "34013121cb9ab6850d15fa09a06ed3a46da44486",
+    role: "reviewed-experiment-contract",
+    rights: "repository-owned",
+  }),
+  Object.freeze({
+    id: "slam-benchmark-donor",
+    revision: "490fbcd0fcfbf161a475a17463445410ef67e99e",
+    role: "manifest-statistics-pattern-donor-only",
+    rights: "repository-owned-derived-code",
+  }),
+  Object.freeze({
+    id: "scikit-learn",
+    revision: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
+    role: "common-logistic-estimator",
+    rights: "BSD-3-Clause",
+  }),
+  Object.freeze({
+    id: "pyBKT",
+    revision: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
+    role: "conditional-classical-comparator",
+    rights: "MIT",
+  }),
+] as const);
+
+export type SyntheticPredictorLane =
+  | "b0-native"
+  | "b2-native"
+  | "b2-basis-native"
+  | "b3-native"
+  | "bkt-native";
+
+export type SyntheticPredictorArtifactBinding = {
+  readonly lane: SyntheticPredictorLane;
+  readonly availability: "available" | "not-estimable" | "not-run";
+  readonly specFingerprint: `sha256:${string}` | null;
+  readonly transformFingerprint: `sha256:${string}` | null;
+  readonly fittedModelFingerprint: `sha256:${string}` | null;
+  readonly predictionFingerprint: `sha256:${string}` | null;
+  readonly nonEstimabilityReason: string | null;
+};
+
+export type SyntheticCoverageSummary = {
+  readonly eligibleOpportunityCount: number;
+  readonly observedOutcomeCount: number;
+  readonly emittedPredictionCount: number;
+  readonly acceptedHistoryEventCount: number;
+  readonly rejectedHistoryEventCount: number;
+  readonly learnerCount: number;
+  readonly attemptCount: number;
+};
+
+export type SyntheticBktManifestBinding = {
+  readonly diagnosticsArtifactDigest: `sha256:${string}` | null;
+  readonly diagnosticsUnavailableReason: string | null;
+  readonly convergenceAssurance: "convergence-observed" | "convergence-unverified" | "not-run";
+  readonly stabilityAssurance:
+    | "unresolved-pending-reviewed-train-only-tolerances"
+    | "reviewed"
+    | "not-run";
+};
+
+export type BuildSyntheticNativePilotManifestInput = {
+  readonly tasks: readonly PilotTaskDefinition[];
+  readonly rows: readonly PredictionFeatureRow[];
+  readonly protocol: FrozenNativeSplitProtocol;
+  readonly artifacts: readonly SyntheticArtifactRecord[];
+  readonly predictorArtifacts: readonly SyntheticPredictorArtifactBinding[];
+  readonly coverage: SyntheticCoverageSummary;
+  readonly bkt: SyntheticBktManifestBinding;
+};
+
 function digestJson(value: unknown): `sha256:${string}` {
   return `sha256:${crypto.createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex")}`;
 }
 
+function assertNonnegativeInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a nonnegative integer`);
+  }
+}
+
+function validateCoverage(coverage: SyntheticCoverageSummary): void {
+  for (const [field, value] of Object.entries(coverage)) {
+    assertNonnegativeInteger(value, `coverage.${field}`);
+  }
+  if (coverage.observedOutcomeCount > coverage.eligibleOpportunityCount) {
+    throw new Error("coverage.observedOutcomeCount cannot exceed eligibleOpportunityCount");
+  }
+  if (coverage.emittedPredictionCount > coverage.eligibleOpportunityCount) {
+    throw new Error("coverage.emittedPredictionCount cannot exceed eligibleOpportunityCount");
+  }
+}
+
+function validatePredictorArtifacts(
+  artifacts: readonly SyntheticPredictorArtifactBinding[],
+): readonly SyntheticPredictorArtifactBinding[] {
+  const expected: readonly SyntheticPredictorLane[] = [
+    "b0-native",
+    "b2-native",
+    "b2-basis-native",
+    "b3-native",
+    "bkt-native",
+  ];
+  const byLane = new Map(artifacts.map((artifact) => [artifact.lane, artifact]));
+  if (byLane.size !== artifacts.length) {
+    throw new Error("predictorArtifacts must contain unique lanes");
+  }
+  for (const lane of expected) {
+    if (!byLane.has(lane)) throw new Error(`predictorArtifacts missing lane: ${lane}`);
+  }
+  for (const artifact of artifacts) {
+    if (artifact.availability === "not-estimable" && !artifact.nonEstimabilityReason) {
+      throw new Error(`not-estimable lane must record a reason: ${artifact.lane}`);
+    }
+    if (artifact.availability !== "not-estimable" && artifact.nonEstimabilityReason) {
+      throw new Error(`only not-estimable lanes may record nonEstimabilityReason: ${artifact.lane}`);
+    }
+  }
+  return Object.freeze(
+    [...artifacts].sort((left, right) => left.lane.localeCompare(right.lane)),
+  );
+}
+
+function validateBktBinding(binding: SyntheticBktManifestBinding): void {
+  if (binding.diagnosticsArtifactDigest === null && !binding.diagnosticsUnavailableReason) {
+    throw new Error("missing BKT diagnostics digest requires diagnosticsUnavailableReason");
+  }
+  if (binding.diagnosticsArtifactDigest !== null && binding.diagnosticsUnavailableReason !== null) {
+    throw new Error("BKT diagnostics reason must be null when a digest is present");
+  }
+}
+
 export type SyntheticNativePilotManifest = {
   readonly status: typeof SYNTHETIC_ONLY_STATUS;
+  readonly manifestDigest: `sha256:${string}`;
   readonly pilotContractId: typeof NATIVE_PILOT_CONTRACT_ID;
   readonly predictorContractId: typeof NATIVE_PREDICTOR_CONTRACT_ID;
-  readonly sourcePins: Readonly<Record<string, string>>;
+  readonly decisionRuleId: typeof NATIVE_DECISION_RULE_ID;
+  readonly dataPolicy: {
+    readonly source: "synthetic-only";
+    readonly humanDataIncluded: false;
+    readonly externalCorpusRowsIncluded: false;
+    readonly redistributionDecision: "not-applicable";
+  };
+  readonly sourceBindings: typeof NATIVE_SOURCE_BINDINGS;
   readonly predictor: typeof NATIVE_PREDICTOR_SETTINGS;
   readonly metrics: typeof NATIVE_METRIC_SETTINGS;
+  readonly featurePolicy: typeof NATIVE_FEATURE_POLICY;
   readonly causalPolicy: {
     readonly currentOutcomeForbidden: true;
     readonly futureOutcomeForbidden: true;
@@ -50,12 +226,24 @@ export type SyntheticNativePilotManifest = {
     readonly strictAvailableBeforePrediction: true;
     readonly equalTimestampExcluded: true;
     readonly trainOnlyTransforms: true;
+    readonly blindBlockFeedbackForbidden: true;
   };
   readonly utilityGate: {
     readonly status: "unresolved";
     readonly deltaHistory: null;
     readonly deltaBasis: null;
     readonly predictiveKeepSimplifyEnabled: false;
+  };
+  readonly split: {
+    readonly protocolId: string;
+    readonly frozenAt: string;
+    readonly fitCutoff: string;
+    readonly fitCompletedAt: string;
+    readonly trainingParticipantIds: readonly string[];
+    readonly heldOutParticipantIds: readonly string[];
+    readonly trainPrefixEventIdsByParticipant: Readonly<Record<string, readonly string[]>>;
+    readonly blindTargetEventIds: readonly string[];
+    readonly digest: `sha256:${string}`;
   };
   readonly taskDefinitions: readonly {
     readonly family: string;
@@ -70,16 +258,34 @@ export type SyntheticNativePilotManifest = {
     readonly targetEventId: string;
     readonly predictionTimestamp: string;
     readonly acceptedHistoryEventIds: readonly string[];
-    readonly featureDigest: string;
+    readonly featureDigest: `sha256:${string}`;
+    readonly predictionBindingDigest: `sha256:${string}`;
   }[];
+  readonly predictorArtifacts: readonly SyntheticPredictorArtifactBinding[];
+  readonly artifacts: readonly SyntheticArtifactRecord[];
+  readonly coverage: SyntheticCoverageSummary;
+  readonly contrasts: {
+    readonly b3MinusB2: null;
+    readonly b3MinusB2Basis: null;
+    readonly reason: "synthetic-data-cannot-rank-models";
+  };
+  readonly attribution: "unresolved-synthetic-only";
+  readonly bkt: SyntheticBktManifestBinding;
+  readonly decision: {
+    readonly status: "disabled-synthetic-only";
+    readonly reason: "no-human-outcomes-and-utility-margins-unresolved";
+  };
   readonly forbiddenClaims: readonly string[];
 };
 
 export function buildSyntheticNativePilotManifest(
-  tasks: readonly PilotTaskDefinition[],
-  rows: readonly PredictionFeatureRow[],
+  input: BuildSyntheticNativePilotManifestInput,
 ): SyntheticNativePilotManifest {
-  const taskDefinitions = tasks
+  validateCoverage(input.coverage);
+  validateBktBinding(input.bkt);
+  const predictorArtifacts = validatePredictorArtifacts(input.predictorArtifacts);
+
+  const taskDefinitions = input.tasks
     .map((definition) => ({
       family: definition.family,
       taskId: definition.task.id,
@@ -90,45 +296,105 @@ export function buildSyntheticNativePilotManifest(
     }))
     .sort((left, right) => left.taskId.localeCompare(right.taskId));
 
-  const featureRows = rows
-    .map((row) => ({
-      participantId: row.participantId,
-      targetEventId: row.targetEventId,
-      predictionTimestamp: row.predictionTimestamp,
-      acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
-      featureDigest: digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 }),
-    }))
+  const featureRows = input.rows
+    .map((row) => {
+      const featureDigest = digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 });
+      return {
+        participantId: row.participantId,
+        targetEventId: row.targetEventId,
+        predictionTimestamp: row.predictionTimestamp,
+        acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
+        featureDigest,
+        predictionBindingDigest: digestJson({
+          participantId: row.participantId,
+          targetEventId: row.targetEventId,
+          predictionTimestamp: row.predictionTimestamp,
+          acceptedHistoryEventIds: row.acceptedHistoryEventIds,
+          featureDigest,
+        }),
+      };
+    })
     .sort((left, right) => left.targetEventId.localeCompare(right.targetEventId));
 
-  return Object.freeze({
+  const trainPrefixEventIdsByParticipant = Object.fromEntries(
+    Object.entries(input.protocol.trainPrefixEventIdsByParticipant)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([participantId, eventIds]) => [participantId, Object.freeze([...eventIds].sort())]),
+  );
+  const splitWithoutDigest = {
+    protocolId: input.protocol.protocolId,
+    frozenAt: input.protocol.frozenAt,
+    fitCutoff: input.protocol.fitCutoff,
+    fitCompletedAt: input.protocol.fitCompletedAt,
+    trainingParticipantIds: Object.freeze([...input.protocol.trainingParticipantIds].sort()),
+    heldOutParticipantIds: Object.freeze([...input.protocol.heldOutParticipantIds].sort()),
+    trainPrefixEventIdsByParticipant: Object.freeze(trainPrefixEventIdsByParticipant),
+    blindTargetEventIds: Object.freeze([...input.protocol.blindTargetEventIds].sort()),
+  };
+  const split = Object.freeze({
+    ...splitWithoutDigest,
+    digest: digestJson(splitWithoutDigest),
+  });
+
+  const artifacts = Object.freeze(
+    [...input.artifacts]
+      .map((artifact) =>
+        Object.freeze({
+          ...artifact,
+          participantIds: Object.freeze([...artifact.participantIds].sort()),
+          dependsOnArtifactIds: Object.freeze([...artifact.dependsOnArtifactIds].sort()),
+        }),
+      )
+      .sort((left, right) => left.artifactId.localeCompare(right.artifactId)),
+  );
+
+  const manifestWithoutDigest = Object.freeze({
     status: SYNTHETIC_ONLY_STATUS,
     pilotContractId: NATIVE_PILOT_CONTRACT_ID,
     predictorContractId: NATIVE_PREDICTOR_CONTRACT_ID,
-    sourcePins: Object.freeze({
-      coreFrontier: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
-      nativeSpecAmendment: "34013121cb9ab6850d15fa09a06ed3a46da44486",
-      slamDonor: "490fbcd0fcfbf161a475a17463445410ef67e99e",
-      scikitLearn: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
-      pyBKT: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
+    decisionRuleId: NATIVE_DECISION_RULE_ID,
+    dataPolicy: Object.freeze({
+      source: "synthetic-only" as const,
+      humanDataIncluded: false as const,
+      externalCorpusRowsIncluded: false as const,
+      redistributionDecision: "not-applicable" as const,
     }),
+    sourceBindings: NATIVE_SOURCE_BINDINGS,
     predictor: NATIVE_PREDICTOR_SETTINGS,
     metrics: NATIVE_METRIC_SETTINGS,
+    featurePolicy: NATIVE_FEATURE_POLICY,
     causalPolicy: Object.freeze({
-      currentOutcomeForbidden: true,
-      futureOutcomeForbidden: true,
-      strictOccurredBeforePrediction: true,
-      strictAvailableBeforePrediction: true,
-      equalTimestampExcluded: true,
-      trainOnlyTransforms: true,
+      currentOutcomeForbidden: true as const,
+      futureOutcomeForbidden: true as const,
+      strictOccurredBeforePrediction: true as const,
+      strictAvailableBeforePrediction: true as const,
+      equalTimestampExcluded: true as const,
+      trainOnlyTransforms: true as const,
+      blindBlockFeedbackForbidden: true as const,
     }),
     utilityGate: Object.freeze({
-      status: "unresolved",
+      status: "unresolved" as const,
       deltaHistory: null,
       deltaBasis: null,
-      predictiveKeepSimplifyEnabled: false,
+      predictiveKeepSimplifyEnabled: false as const,
     }),
+    split,
     taskDefinitions: Object.freeze(taskDefinitions),
     featureRows: Object.freeze(featureRows),
+    predictorArtifacts,
+    artifacts,
+    coverage: Object.freeze({ ...input.coverage }),
+    contrasts: Object.freeze({
+      b3MinusB2: null,
+      b3MinusB2Basis: null,
+      reason: "synthetic-data-cannot-rank-models" as const,
+    }),
+    attribution: "unresolved-synthetic-only" as const,
+    bkt: Object.freeze({ ...input.bkt }),
+    decision: Object.freeze({
+      status: "disabled-synthetic-only" as const,
+      reason: "no-human-outcomes-and-utility-margins-unresolved" as const,
+    }),
     forbiddenClaims: Object.freeze([
       "learner-model-validity",
       "predictive-superiority",
@@ -140,5 +406,10 @@ export function buildSyntheticNativePilotManifest(
       "calibrated",
       "production-authority",
     ]),
+  });
+
+  return Object.freeze({
+    ...manifestWithoutDigest,
+    manifestDigest: digestJson(manifestWithoutDigest),
   });
 }

--- a/benchmarks/native-evidence-v1/native-evidence-v1.test.ts
+++ b/benchmarks/native-evidence-v1/native-evidence-v1.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+
+import { projectLearnerState, createEmptyLearnerStateProjection, reduceLearnerState } from "@/lib/core/learner-state";
+import { buildEnglishOntologyV1 } from "@/lib/core/ontology-seed";
+import { validateCoreTask } from "@/lib/core/task";
+
+import { buildPredictionFeatureRow, selectCausalAcceptedHistory } from "./features";
+import { buildSyntheticNativePilotManifest } from "./manifest";
+import { SyntheticPilotStore } from "./store";
+import { buildFrozenPilotTaskMatrix, buildPilotTaskDefinition } from "./task-matrix";
+import {
+  buildSyntheticTrace,
+  createSyntheticEvidenceFixture,
+  issueSyntheticPilotEvent,
+} from "./synthetic";
+import { NATIVE_PILOT_TARGET_ID, SYNTHETIC_ONLY_STATUS } from "./types";
+
+const ontologyResult = buildEnglishOntologyV1();
+if (!ontologyResult.ok) throw new Error(JSON.stringify(ontologyResult.problems));
+const ontology = ontologyResult.graph;
+
+function predictionPayload(row: ReturnType<typeof buildPredictionFeatureRow>) {
+  return JSON.stringify({
+    acceptedHistoryEventIds: row.acceptedHistoryEventIds,
+    b2: row.b2,
+    b2Basis: row.b2Basis,
+    b3: row.b3,
+  });
+}
+
+describe("Nếp native evidence N2 synthetic plumbing", () => {
+  it("freezes the five prospective task families with valid core semantics", () => {
+    const matrix = buildFrozenPilotTaskMatrix();
+    expect(matrix.map((definition) => definition.family)).toEqual([
+      "recognition-independent",
+      "recognition-supported",
+      "free-recall",
+      "delayed-free-recall",
+      "near-transfer",
+    ]);
+
+    for (const definition of matrix) {
+      expect(definition.task.targetIds).toEqual([NATIVE_PILOT_TARGET_ID]);
+      expect(definition.contentFingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(definition.task.scoringContractId).toBe("nep.native-pilot.binary-v1");
+      expect(validateCoreTask(definition.task)).toEqual([]);
+    }
+
+    const supported = matrix.find((definition) => definition.family === "recognition-supported");
+    expect(supported?.task.support).toEqual({ level: 1, revealAllowed: true });
+
+    const transfer = matrix.find((definition) => definition.family === "near-transfer");
+    expect(transfer?.task.transferDistance).toBe("near-transfer");
+    expect(transfer?.task.allowedEvidenceRoles).toEqual(["near-transfer"]);
+  });
+
+  it("issues only unvalidated repository-reference evidence and keeps supported reveal explicit", () => {
+    const unused = issueSyntheticPilotEvent({
+      participantId: "p-support",
+      family: "recognition-supported",
+      eventId: "p-support:e1",
+      occurredAt: "2026-09-01T09:00:00.000Z",
+      availableAt: "2026-09-01T09:00:01.000Z",
+      success: false,
+      revealUsed: false,
+    });
+    const used = issueSyntheticPilotEvent({
+      participantId: "p-support",
+      family: "recognition-supported",
+      eventId: "p-support:e2",
+      occurredAt: "2026-09-01T09:01:00.000Z",
+      availableAt: "2026-09-01T09:01:01.000Z",
+      success: true,
+      revealUsed: true,
+    });
+
+    expect(unused.evidence.authorityScope).toBe("repository-reference");
+    expect(unused.evidence.calibrationBenchmarkId).toBeNull();
+    expect(unused.evidence.grantId).toBeNull();
+    expect(unused.evidence.attempt.revealUsed).toBe(false);
+    expect(used.evidence.attempt.revealUsed).toBe(true);
+
+    const invalidIndependent = createSyntheticEvidenceFixture({
+      participantId: "p-support",
+      family: "free-recall",
+      eventId: "p-support:invalid-independent",
+      occurredAt: "2026-09-01T09:02:00.000Z",
+      availableAt: "2026-09-01T09:02:01.000Z",
+      success: true,
+      revealUsed: true,
+    });
+    expect(invalidIndependent.validation.ok).toBe(false);
+    if (!invalidIndependent.validation.ok) {
+      expect(invalidIndependent.validation.problems).toContainEqual({ type: "reveal-not-allowed" });
+      expect(invalidIndependent.validation.problems).toContainEqual({
+        type: "support-invalidates-strong-evidence",
+        role: "free-recall",
+      });
+    }
+  });
+
+  it("rejects first-event transfer but accepts prospective changed-context transfer after baseline", () => {
+    const firstTransfer = issueSyntheticPilotEvent({
+      participantId: "p-transfer",
+      family: "near-transfer",
+      eventId: "p-transfer:e1",
+      occurredAt: "2026-09-01T10:00:00.000Z",
+      availableAt: "2026-09-01T10:00:01.000Z",
+      success: true,
+    });
+    const firstState = projectLearnerState(ontology, [firstTransfer.evidence]);
+    expect(firstState.acceptedEvents).toHaveLength(0);
+    expect(firstState.rejectedEvents[0]?.code).toBe("invalid-transfer-distance");
+
+    const baseline = issueSyntheticPilotEvent({
+      participantId: "p-transfer",
+      family: "free-recall",
+      eventId: "p-transfer:e0",
+      occurredAt: "2026-09-01T09:55:00.000Z",
+      availableAt: "2026-09-01T09:55:01.000Z",
+      success: true,
+    });
+    const validState = projectLearnerState(ontology, [baseline.evidence, firstTransfer.evidence]);
+    expect(validState.acceptedEvents).toHaveLength(2);
+    expect(validState.rejectedEvents).toHaveLength(0);
+    expect(validState.constructs[NATIVE_PILOT_TARGET_ID]?.statistics.transfer.nearTransferCount).toBe(1);
+  });
+
+  it("rejects duplicate and late out-of-order events in the append-only reducer", () => {
+    const trace = buildSyntheticTrace("p-order");
+    const early = trace[0];
+    const late = trace[3];
+    if (!early || !late) throw new Error("Synthetic trace fixture incomplete");
+
+    let state = createEmptyLearnerStateProjection(ontology);
+    state = reduceLearnerState(state, early.evidence, ontology);
+    state = reduceLearnerState(state, early.evidence, ontology);
+    expect(state.acceptedEvents).toHaveLength(1);
+    expect(state.rejectedEvents.at(-1)?.code).toBe("duplicate-event-id");
+
+    let lateFirst = createEmptyLearnerStateProjection(ontology);
+    lateFirst = reduceLearnerState(lateFirst, late.evidence, ontology);
+    lateFirst = reduceLearnerState(lateFirst, early.evidence, ontology);
+    expect(lateFirst.acceptedEvents).toHaveLength(1);
+    expect(lateFirst.rejectedEvents.at(-1)?.code).toBe("out-of-order-event");
+  });
+
+  it("rejects a detached cloned evidence object even when its fields are unchanged", () => {
+    const event = buildSyntheticTrace("p-clone")[0];
+    if (!event) throw new Error("Synthetic trace fixture incomplete");
+    const detached: unknown = JSON.parse(JSON.stringify(event.evidence));
+    const state = projectLearnerState(ontology, [detached]);
+    expect(state.acceptedEvents).toHaveLength(0);
+    expect(state.rejectedEvents).toHaveLength(1);
+    expect(state.rejectedEvents[0]?.code).toBe("unvalidated-evidence-rejected");
+  });
+
+  it("keeps cold-start unknown distinct from observed zero", () => {
+    const currentTask = buildPilotTaskDefinition("free-recall");
+    const row = buildPredictionFeatureRow({
+      participantId: "p-cold",
+      targetEventId: "p-cold:target",
+      predictionTimestamp: "2026-09-01T09:00:00.000Z",
+      currentTask,
+      history: [],
+    });
+
+    expect(row.b2.prior_eligible_attempt_count).toBe(0);
+    expect(row.b2.prior_positive_count).toBe(0);
+    expect(row.b2.prior_success_rate).toBeNull();
+    expect(row.b2.previous_outcome).toBe("missing");
+    expect(row.b2.seconds_since_previous_attempt).toBeNull();
+    expect(row.b3.nep_status).toBe("unknown");
+    expect(row.b3.nep_uncertainty).toBe("maximal");
+    expect(row.b3.nep_provisional_routing_score).toBeNull();
+    expect(row.b3.nep_routing_score_missing).toBe(1);
+  });
+
+  it("requires strict occurredAt and availableAt precedence, excluding equal-time labels", () => {
+    const event = issueSyntheticPilotEvent({
+      participantId: "p-late-label",
+      family: "recognition-independent",
+      eventId: "p-late-label:e1",
+      occurredAt: "2026-09-01T08:59:00.000Z",
+      availableAt: "2026-09-01T09:00:00.000Z",
+      success: true,
+    });
+
+    const excluded = selectCausalAcceptedHistory(
+      "p-late-label",
+      [event],
+      "2026-09-01T09:00:00.000Z",
+    );
+    expect(excluded).toEqual([]);
+
+    const included = selectCausalAcceptedHistory(
+      "p-late-label",
+      [event],
+      "2026-09-01T09:00:00.001Z",
+    );
+    expect(included.map((item) => item.evidence.eventId)).toEqual(["p-late-label:e1"]);
+  });
+
+  it("keeps pre-attempt features byte-identical when current/future outcomes or attached label change", () => {
+    const participantId = "p-leakage";
+    const baseTrace = buildSyntheticTrace(participantId);
+    const currentTask = buildPilotTaskDefinition("free-recall");
+    const predictionTimestamp = "2026-09-01T09:20:00.000Z";
+
+    const mutatedFuture = [
+      ...baseTrace.slice(0, 3),
+      issueSyntheticPilotEvent({
+        participantId,
+        family: "free-recall",
+        eventId: `${participantId}:e04-mutated`,
+        occurredAt: "2026-09-01T09:20:00.000Z",
+        availableAt: "2026-09-01T09:20:01.000Z",
+        success: true,
+      }),
+      issueSyntheticPilotEvent({
+        participantId,
+        family: "delayed-free-recall",
+        eventId: `${participantId}:e05-mutated`,
+        occurredAt: "2026-09-02T09:00:00.000Z",
+        availableAt: "2026-09-02T09:00:01.000Z",
+        success: false,
+      }),
+      issueSyntheticPilotEvent({
+        participantId,
+        family: "near-transfer",
+        eventId: `${participantId}:e06-mutated`,
+        occurredAt: "2026-09-02T09:10:00.000Z",
+        availableAt: "2026-09-02T09:10:01.000Z",
+        success: false,
+      }),
+    ];
+
+    const rowA = buildPredictionFeatureRow({
+      participantId,
+      targetEventId: `${participantId}:target`,
+      predictionTimestamp,
+      currentTask,
+      history: baseTrace,
+      label: 0,
+    });
+    const rowB = buildPredictionFeatureRow({
+      participantId,
+      targetEventId: `${participantId}:target`,
+      predictionTimestamp,
+      currentTask,
+      history: mutatedFuture,
+      label: 1,
+    });
+
+    expect(rowA.acceptedHistoryEventIds).toEqual([
+      `${participantId}:e01`,
+      `${participantId}:e02`,
+      `${participantId}:e03`,
+    ]);
+    expect(predictionPayload(rowA)).toBe(predictionPayload(rowB));
+  });
+
+  it("reconstructs the projector count-derived status, uncertainty and routing control from B2 history", () => {
+    const participantId = "p-basis";
+    const trace = buildSyntheticTrace(participantId);
+    const row = buildPredictionFeatureRow({
+      participantId,
+      targetEventId: `${participantId}:target`,
+      predictionTimestamp: "2026-09-01T09:20:00.000Z",
+      currentTask: buildPilotTaskDefinition("free-recall"),
+      history: trace,
+    });
+
+    expect(row.b2Basis.basis_status).toBe(row.b3.nep_status);
+    expect(row.b2Basis.basis_uncertainty).toBe(row.b3.nep_uncertainty);
+    expect(row.b2Basis.basis_provisional_routing_score).toBe(row.b3.nep_provisional_routing_score);
+    expect(row.b2Basis.basis_conflicted_count).toBe(row.b3.nep_conflicted_count);
+  });
+
+  it("exports only synthetic metadata and deletion invalidates participant-dependent artifacts", () => {
+    const participantId = "p-delete";
+    const store = new SyntheticPilotStore();
+    store.addEvents(buildSyntheticTrace(participantId));
+    store.addEvents(buildSyntheticTrace("p-other"));
+
+    for (const kind of ["feature", "model", "prediction", "result"] as const) {
+      store.registerArtifact(`${kind}:dependent`, kind, [participantId, "p-other"]);
+    }
+    store.registerArtifact("result:other-only", "result", ["p-other"]);
+
+    const exported = store.exportParticipant(participantId);
+    expect(exported.status).toBe(SYNTHETIC_ONLY_STATUS);
+    expect(exported.events).toHaveLength(6);
+    expect(exported.events[0]?.evidenceDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+    const deletion = store.deleteParticipant(participantId);
+    expect(deletion.removedEventCount).toBe(6);
+    expect(store.getEvents(participantId)).toEqual([]);
+    expect(deletion.invalidatedArtifactIds).toEqual([
+      "feature:dependent",
+      "model:dependent",
+      "prediction:dependent",
+      "result:dependent",
+    ]);
+    expect(store.getArtifact("model:dependent")?.valid).toBe(false);
+    expect(store.getArtifact("result:other-only")?.valid).toBe(true);
+  });
+
+  it("emits a machine-readable manifest that cannot be mistaken for learner validity evidence", () => {
+    const tasks = buildFrozenPilotTaskMatrix();
+    const row = buildPredictionFeatureRow({
+      participantId: "p-manifest",
+      targetEventId: "p-manifest:target",
+      predictionTimestamp: "2026-09-01T09:20:00.000Z",
+      currentTask: buildPilotTaskDefinition("free-recall"),
+      history: buildSyntheticTrace("p-manifest"),
+    });
+    const manifest = buildSyntheticNativePilotManifest(tasks, [row]);
+
+    expect(manifest.status).toBe("synthetic-plumbing-only");
+    expect(manifest.predictor.version).toBe("1.6.1");
+    expect(manifest.utilityGate.deltaHistory).toBeNull();
+    expect(manifest.utilityGate.deltaBasis).toBeNull();
+    expect(manifest.utilityGate.predictiveKeepSimplifyEnabled).toBe(false);
+    expect(manifest.forbiddenClaims).toContain("predictive-superiority");
+    expect(manifest.forbiddenClaims).toContain("learner-model-validity");
+  });
+});

--- a/benchmarks/native-evidence-v1/protocol.test.ts
+++ b/benchmarks/native-evidence-v1/protocol.test.ts
@@ -17,9 +17,16 @@ function targetBinding(
   return {
     participantId,
     predictionTimestamp,
+    family: definition.family,
     taskId: definition.task.id,
     taskVersion: definition.task.version,
     contentFingerprint: definition.contentFingerprint,
+    supportLevel: definition.task.support.level,
+    revealAllowed: definition.task.support.revealAllowed,
+    transferDistance: definition.task.transferDistance,
+    contextId: definition.contextId,
+    stimulusFormGroup: definition.stimulusFormGroup,
+    scoringContractId: definition.scoringContractId,
   } as const;
 }
 

--- a/benchmarks/native-evidence-v1/protocol.test.ts
+++ b/benchmarks/native-evidence-v1/protocol.test.ts
@@ -64,6 +64,35 @@ describe("native pilot frozen split and blind block", () => {
     );
   });
 
+  it("rejects duplicate frozen TRAIN-prefix evidence instead of last-write-wins", () => {
+    const protocol = makeProtocol();
+    const trace = buildSyntheticTrace("p-train");
+    const duplicate = issueSyntheticPilotEvent({
+      participantId: "p-train",
+      family: "recognition-supported",
+      eventId: "p-train:e02",
+      occurredAt: "2026-09-01T09:05:00.000Z",
+      availableAt: "2026-09-01T09:05:02.000Z",
+      success: true,
+      responseLatencyMs: 900,
+    });
+
+    expect(() => selectAuthorizedTrainPrefixEvents(protocol, [...trace, duplicate])).toThrow(
+      /ambiguous due to duplicate eventId: p-train:e02/,
+    );
+
+    expect(() =>
+      buildBlindPredictionFeatureRow({
+        protocol,
+        participantId: "p-train",
+        targetEventId: "p-train:e05",
+        predictionTimestamp: "2026-09-02T09:00:00.000Z",
+        currentTask: buildPilotTaskDefinition("delayed-free-recall"),
+        history: [...trace, duplicate],
+      }),
+    ).toThrow(/duplicate prefix eventId: p-train:e02/);
+  });
+
   it("never feeds an earlier blind-block outcome into a later blind-block prediction", () => {
     const protocol = makeProtocol();
     const original = buildSyntheticTrace("p-train");

--- a/benchmarks/native-evidence-v1/protocol.test.ts
+++ b/benchmarks/native-evidence-v1/protocol.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBlindPredictionFeatureRow,
+  buildFrozenNativeSplitProtocol,
+  selectAuthorizedTrainPrefixEvents,
+} from "./protocol";
+import { buildPilotTaskDefinition } from "./task-matrix";
+import { buildSyntheticTrace, issueSyntheticPilotEvent } from "./synthetic";
+
+function makeProtocol() {
+  return buildFrozenNativeSplitProtocol({
+    frozenAt: "2026-09-01T08:00:00.000Z",
+    fitCutoff: "2026-09-01T09:15:00.000Z",
+    fitCompletedAt: "2026-09-01T09:16:00.000Z",
+    trainingParticipantIds: ["p-train"],
+    heldOutParticipantIds: ["p-heldout"],
+    trainPrefixEventIdsByParticipant: {
+      "p-train": ["p-train:e01", "p-train:e02", "p-train:e03"],
+      "p-heldout": [],
+    },
+    blindTargetEventIds: [
+      "p-train:e04",
+      "p-train:e05",
+      "p-heldout:cold-target",
+    ],
+  });
+}
+
+function rowPayload(row: ReturnType<typeof buildBlindPredictionFeatureRow>): string {
+  return JSON.stringify({
+    acceptedHistoryEventIds: row.acceptedHistoryEventIds,
+    b2: row.b2,
+    b2Basis: row.b2Basis,
+    b3: row.b3,
+  });
+}
+
+describe("native pilot frozen split and blind block", () => {
+  it("selects only frozen TRAIN-prefix labels available before the global fit cutoff", () => {
+    const protocol = makeProtocol();
+    const trace = buildSyntheticTrace("p-train");
+    const selected = selectAuthorizedTrainPrefixEvents(protocol, trace);
+
+    expect(selected.map((event) => event.evidence.eventId)).toEqual([
+      "p-train:e01",
+      "p-train:e02",
+      "p-train:e03",
+    ]);
+
+    const latePrefix = issueSyntheticPilotEvent({
+      participantId: "p-train",
+      family: "recognition-independent",
+      eventId: "p-train:e03",
+      occurredAt: "2026-09-01T09:10:00.000Z",
+      availableAt: "2026-09-01T09:15:00.000Z",
+      success: true,
+    });
+    const replaced = [trace[0], trace[1], latePrefix, ...trace.slice(3)].filter(
+      (event): event is NonNullable<typeof event> => event !== undefined,
+    );
+    expect(() => selectAuthorizedTrainPrefixEvents(protocol, replaced)).toThrow(
+      /not causally available by fitCutoff/,
+    );
+  });
+
+  it("never feeds an earlier blind-block outcome into a later blind-block prediction", () => {
+    const protocol = makeProtocol();
+    const original = buildSyntheticTrace("p-train");
+    const currentTask = buildPilotTaskDefinition("delayed-free-recall");
+
+    const rowA = buildBlindPredictionFeatureRow({
+      protocol,
+      participantId: "p-train",
+      targetEventId: "p-train:e05",
+      predictionTimestamp: "2026-09-02T09:00:00.000Z",
+      currentTask,
+      history: original,
+    });
+
+    const mutatedEarlierBlindOutcome = [
+      ...original.slice(0, 3),
+      issueSyntheticPilotEvent({
+        participantId: "p-train",
+        family: "free-recall",
+        eventId: "p-train:e04",
+        occurredAt: "2026-09-01T09:20:00.000Z",
+        availableAt: "2026-09-01T09:20:01.000Z",
+        success: true,
+      }),
+      ...original.slice(4),
+    ];
+    const rowB = buildBlindPredictionFeatureRow({
+      protocol,
+      participantId: "p-train",
+      targetEventId: "p-train:e05",
+      predictionTimestamp: "2026-09-02T09:00:00.000Z",
+      currentTask,
+      history: mutatedEarlierBlindOutcome,
+    });
+
+    expect(rowA.acceptedHistoryEventIds).toEqual([
+      "p-train:e01",
+      "p-train:e02",
+      "p-train:e03",
+    ]);
+    expect(rowPayload(rowA)).toBe(rowPayload(rowB));
+  });
+
+  it("keeps a held-out participant at cold start even when their labeled history is supplied", () => {
+    const protocol = makeProtocol();
+    const row = buildBlindPredictionFeatureRow({
+      protocol,
+      participantId: "p-heldout",
+      targetEventId: "p-heldout:cold-target",
+      predictionTimestamp: "2026-09-02T10:00:00.000Z",
+      currentTask: buildPilotTaskDefinition("free-recall"),
+      history: buildSyntheticTrace("p-heldout"),
+    });
+
+    expect(row.acceptedHistoryEventIds).toEqual([]);
+    expect(row.b2.prior_eligible_attempt_count).toBe(0);
+    expect(row.b2.prior_success_rate).toBeNull();
+    expect(row.b3.nep_status).toBe("unknown");
+    expect(row.b3.nep_uncertainty).toBe("maximal");
+  });
+
+  it("rejects held-out TRAIN contribution and fitting that completes at prediction time", () => {
+    expect(() =>
+      buildFrozenNativeSplitProtocol({
+        frozenAt: "2026-09-01T08:00:00.000Z",
+        fitCutoff: "2026-09-01T09:15:00.000Z",
+        fitCompletedAt: "2026-09-01T09:16:00.000Z",
+        trainingParticipantIds: ["p-train"],
+        heldOutParticipantIds: ["p-heldout"],
+        trainPrefixEventIdsByParticipant: {
+          "p-train": [],
+          "p-heldout": ["p-heldout:e01"],
+        },
+        blindTargetEventIds: ["target"],
+      }),
+    ).toThrow(/held-out participant cannot contribute TRAIN prefix events/);
+
+    const protocol = buildFrozenNativeSplitProtocol({
+      frozenAt: "2026-09-01T08:00:00.000Z",
+      fitCutoff: "2026-09-01T09:15:00.000Z",
+      fitCompletedAt: "2026-09-01T09:20:00.000Z",
+      trainingParticipantIds: ["p-train"],
+      heldOutParticipantIds: [],
+      trainPrefixEventIdsByParticipant: { "p-train": [] },
+      blindTargetEventIds: ["target"],
+    });
+
+    expect(() =>
+      buildBlindPredictionFeatureRow({
+        protocol,
+        participantId: "p-train",
+        targetEventId: "target",
+        predictionTimestamp: "2026-09-01T09:20:00.000Z",
+        currentTask: buildPilotTaskDefinition("free-recall"),
+        history: [],
+      }),
+    ).toThrow(/fitCompletedAt must strictly precede predictionTimestamp/);
+  });
+});

--- a/benchmarks/native-evidence-v1/protocol.test.ts
+++ b/benchmarks/native-evidence-v1/protocol.test.ts
@@ -8,6 +8,21 @@ import {
 import { buildPilotTaskDefinition } from "./task-matrix";
 import { buildSyntheticTrace, issueSyntheticPilotEvent } from "./synthetic";
 
+function targetBinding(
+  participantId: string,
+  predictionTimestamp: string,
+  family: Parameters<typeof buildPilotTaskDefinition>[0],
+) {
+  const definition = buildPilotTaskDefinition(family);
+  return {
+    participantId,
+    predictionTimestamp,
+    taskId: definition.task.id,
+    taskVersion: definition.task.version,
+    contentFingerprint: definition.contentFingerprint,
+  } as const;
+}
+
 function makeProtocol() {
   return buildFrozenNativeSplitProtocol({
     frozenAt: "2026-09-01T08:00:00.000Z",
@@ -24,10 +39,22 @@ function makeProtocol() {
       "p-train:e05",
       "p-heldout:cold-target",
     ],
-    blindTargetParticipantIdByEventId: {
-      "p-train:e04": "p-train",
-      "p-train:e05": "p-train",
-      "p-heldout:cold-target": "p-heldout",
+    blindTargetBindings: {
+      "p-train:e04": targetBinding(
+        "p-train",
+        "2026-09-01T09:20:00.000Z",
+        "free-recall",
+      ),
+      "p-train:e05": targetBinding(
+        "p-train",
+        "2026-09-02T09:00:00.000Z",
+        "delayed-free-recall",
+      ),
+      "p-heldout:cold-target": targetBinding(
+        "p-heldout",
+        "2026-09-02T10:00:00.000Z",
+        "free-recall",
+      ),
     },
   });
 }
@@ -98,7 +125,7 @@ describe("native pilot frozen split and blind block", () => {
     ).toThrow(/duplicate prefix eventId: p-train:e02/);
   });
 
-  it("binds every blind target to the prospectively frozen participant", () => {
+  it("binds every blind target to its participant, timestamp and frozen task identity", () => {
     const protocol = makeProtocol();
 
     expect(() =>
@@ -113,6 +140,30 @@ describe("native pilot frozen split and blind block", () => {
     ).toThrow(/frozen to participant p-heldout: p-heldout:cold-target/);
 
     expect(() =>
+      buildBlindPredictionFeatureRow({
+        protocol,
+        participantId: "p-train",
+        targetEventId: "p-train:e05",
+        predictionTimestamp: "2026-09-02T09:00:00.001Z",
+        currentTask: buildPilotTaskDefinition("delayed-free-recall"),
+        history: buildSyntheticTrace("p-train"),
+      }),
+    ).toThrow(/predictionTimestamp differs from frozen blind target: p-train:e05/);
+
+    expect(() =>
+      buildBlindPredictionFeatureRow({
+        protocol,
+        participantId: "p-train",
+        targetEventId: "p-train:e05",
+        predictionTimestamp: "2026-09-02T09:00:00.000Z",
+        currentTask: buildPilotTaskDefinition("free-recall"),
+        history: buildSyntheticTrace("p-train"),
+      }),
+    ).toThrow(/currentTask differs from frozen blind target: p-train:e05/);
+  });
+
+  it("fails closed on missing, extra or unallocated blind-target bindings", () => {
+    expect(() =>
       buildFrozenNativeSplitProtocol({
         frozenAt: "2026-09-01T08:00:00.000Z",
         fitCutoff: "2026-09-01T09:15:00.000Z",
@@ -121,9 +172,9 @@ describe("native pilot frozen split and blind block", () => {
         heldOutParticipantIds: ["p-heldout"],
         trainPrefixEventIdsByParticipant: { "p-train": [], "p-heldout": [] },
         blindTargetEventIds: ["target-a"],
-        blindTargetParticipantIdByEventId: {},
+        blindTargetBindings: {},
       }),
-    ).toThrow(/missing frozen participant binding: target-a/);
+    ).toThrow(/missing frozen binding: target-a/);
 
     expect(() =>
       buildFrozenNativeSplitProtocol({
@@ -134,12 +185,16 @@ describe("native pilot frozen split and blind block", () => {
         heldOutParticipantIds: [],
         trainPrefixEventIdsByParticipant: { "p-train": [] },
         blindTargetEventIds: ["target-a"],
-        blindTargetParticipantIdByEventId: {
-          "target-a": "p-train",
-          "target-extra": "p-train",
+        blindTargetBindings: {
+          "target-a": targetBinding("p-train", "2026-09-01T09:20:00.000Z", "free-recall"),
+          "target-extra": targetBinding(
+            "p-train",
+            "2026-09-01T09:21:00.000Z",
+            "free-recall",
+          ),
         },
       }),
-    ).toThrow(/participant binding references unknown target: target-extra/);
+    ).toThrow(/blind target binding references unknown target: target-extra/);
 
     expect(() =>
       buildFrozenNativeSplitProtocol({
@@ -150,7 +205,13 @@ describe("native pilot frozen split and blind block", () => {
         heldOutParticipantIds: [],
         trainPrefixEventIdsByParticipant: { "p-train": [] },
         blindTargetEventIds: ["target-a"],
-        blindTargetParticipantIdByEventId: { "target-a": "not-allocated" },
+        blindTargetBindings: {
+          "target-a": targetBinding(
+            "not-allocated",
+            "2026-09-01T09:20:00.000Z",
+            "free-recall",
+          ),
+        },
       }),
     ).toThrow(/blind target references unallocated participant: target-a:not-allocated/);
   });
@@ -216,7 +277,7 @@ describe("native pilot frozen split and blind block", () => {
     expect(row.b3.nep_uncertainty).toBe("maximal");
   });
 
-  it("rejects held-out TRAIN contribution and fitting that completes at prediction time", () => {
+  it("rejects held-out TRAIN contribution and noncausal frozen prediction timing", () => {
     expect(() =>
       buildFrozenNativeSplitProtocol({
         frozenAt: "2026-09-01T08:00:00.000Z",
@@ -229,30 +290,25 @@ describe("native pilot frozen split and blind block", () => {
           "p-heldout": ["p-heldout:e01"],
         },
         blindTargetEventIds: ["target"],
-        blindTargetParticipantIdByEventId: { target: "p-train" },
+        blindTargetBindings: {
+          target: targetBinding("p-train", "2026-09-01T09:20:00.000Z", "free-recall"),
+        },
       }),
     ).toThrow(/held-out participant cannot contribute TRAIN prefix events/);
 
-    const protocol = buildFrozenNativeSplitProtocol({
-      frozenAt: "2026-09-01T08:00:00.000Z",
-      fitCutoff: "2026-09-01T09:15:00.000Z",
-      fitCompletedAt: "2026-09-01T09:20:00.000Z",
-      trainingParticipantIds: ["p-train"],
-      heldOutParticipantIds: [],
-      trainPrefixEventIdsByParticipant: { "p-train": [] },
-      blindTargetEventIds: ["target"],
-      blindTargetParticipantIdByEventId: { target: "p-train" },
-    });
-
     expect(() =>
-      buildBlindPredictionFeatureRow({
-        protocol,
-        participantId: "p-train",
-        targetEventId: "target",
-        predictionTimestamp: "2026-09-01T09:20:00.000Z",
-        currentTask: buildPilotTaskDefinition("free-recall"),
-        history: [],
+      buildFrozenNativeSplitProtocol({
+        frozenAt: "2026-09-01T08:00:00.000Z",
+        fitCutoff: "2026-09-01T09:15:00.000Z",
+        fitCompletedAt: "2026-09-01T09:20:00.000Z",
+        trainingParticipantIds: ["p-train"],
+        heldOutParticipantIds: [],
+        trainPrefixEventIdsByParticipant: { "p-train": [] },
+        blindTargetEventIds: ["target"],
+        blindTargetBindings: {
+          target: targetBinding("p-train", "2026-09-01T09:20:00.000Z", "free-recall"),
+        },
       }),
-    ).toThrow(/fitCompletedAt must strictly precede predictionTimestamp/);
+    ).toThrow(/blind target prediction must occur after fitCompletedAt: target/);
   });
 });

--- a/benchmarks/native-evidence-v1/protocol.test.ts
+++ b/benchmarks/native-evidence-v1/protocol.test.ts
@@ -24,6 +24,11 @@ function makeProtocol() {
       "p-train:e05",
       "p-heldout:cold-target",
     ],
+    blindTargetParticipantIdByEventId: {
+      "p-train:e04": "p-train",
+      "p-train:e05": "p-train",
+      "p-heldout:cold-target": "p-heldout",
+    },
   });
 }
 
@@ -91,6 +96,63 @@ describe("native pilot frozen split and blind block", () => {
         history: [...trace, duplicate],
       }),
     ).toThrow(/duplicate prefix eventId: p-train:e02/);
+  });
+
+  it("binds every blind target to the prospectively frozen participant", () => {
+    const protocol = makeProtocol();
+
+    expect(() =>
+      buildBlindPredictionFeatureRow({
+        protocol,
+        participantId: "p-train",
+        targetEventId: "p-heldout:cold-target",
+        predictionTimestamp: "2026-09-02T10:00:00.000Z",
+        currentTask: buildPilotTaskDefinition("free-recall"),
+        history: buildSyntheticTrace("p-train"),
+      }),
+    ).toThrow(/frozen to participant p-heldout: p-heldout:cold-target/);
+
+    expect(() =>
+      buildFrozenNativeSplitProtocol({
+        frozenAt: "2026-09-01T08:00:00.000Z",
+        fitCutoff: "2026-09-01T09:15:00.000Z",
+        fitCompletedAt: "2026-09-01T09:16:00.000Z",
+        trainingParticipantIds: ["p-train"],
+        heldOutParticipantIds: ["p-heldout"],
+        trainPrefixEventIdsByParticipant: { "p-train": [], "p-heldout": [] },
+        blindTargetEventIds: ["target-a"],
+        blindTargetParticipantIdByEventId: {},
+      }),
+    ).toThrow(/missing frozen participant binding: target-a/);
+
+    expect(() =>
+      buildFrozenNativeSplitProtocol({
+        frozenAt: "2026-09-01T08:00:00.000Z",
+        fitCutoff: "2026-09-01T09:15:00.000Z",
+        fitCompletedAt: "2026-09-01T09:16:00.000Z",
+        trainingParticipantIds: ["p-train"],
+        heldOutParticipantIds: [],
+        trainPrefixEventIdsByParticipant: { "p-train": [] },
+        blindTargetEventIds: ["target-a"],
+        blindTargetParticipantIdByEventId: {
+          "target-a": "p-train",
+          "target-extra": "p-train",
+        },
+      }),
+    ).toThrow(/participant binding references unknown target: target-extra/);
+
+    expect(() =>
+      buildFrozenNativeSplitProtocol({
+        frozenAt: "2026-09-01T08:00:00.000Z",
+        fitCutoff: "2026-09-01T09:15:00.000Z",
+        fitCompletedAt: "2026-09-01T09:16:00.000Z",
+        trainingParticipantIds: ["p-train"],
+        heldOutParticipantIds: [],
+        trainPrefixEventIdsByParticipant: { "p-train": [] },
+        blindTargetEventIds: ["target-a"],
+        blindTargetParticipantIdByEventId: { "target-a": "not-allocated" },
+      }),
+    ).toThrow(/blind target references unallocated participant: target-a:not-allocated/);
   });
 
   it("never feeds an earlier blind-block outcome into a later blind-block prediction", () => {
@@ -167,6 +229,7 @@ describe("native pilot frozen split and blind block", () => {
           "p-heldout": ["p-heldout:e01"],
         },
         blindTargetEventIds: ["target"],
+        blindTargetParticipantIdByEventId: { target: "p-train" },
       }),
     ).toThrow(/held-out participant cannot contribute TRAIN prefix events/);
 
@@ -178,6 +241,7 @@ describe("native pilot frozen split and blind block", () => {
       heldOutParticipantIds: [],
       trainPrefixEventIdsByParticipant: { "p-train": [] },
       blindTargetEventIds: ["target"],
+      blindTargetParticipantIdByEventId: { target: "p-train" },
     });
 
     expect(() =>

--- a/benchmarks/native-evidence-v1/protocol.ts
+++ b/benchmarks/native-evidence-v1/protocol.ts
@@ -16,6 +16,7 @@ export type FrozenNativeSplitProtocol = {
   readonly heldOutParticipantIds: readonly string[];
   readonly trainPrefixEventIdsByParticipant: Readonly<Record<string, readonly string[]>>;
   readonly blindTargetEventIds: readonly string[];
+  readonly blindTargetParticipantIdByEventId: Readonly<Record<string, string>>;
 };
 
 export type BuildFrozenNativeSplitProtocolInput = Omit<FrozenNativeSplitProtocol, "protocolId">;
@@ -94,6 +95,26 @@ export function buildFrozenNativeSplitProtocol(
     }
   }
 
+  const frozenBlindTargetIds = new Set(input.blindTargetEventIds);
+  const targetBindingEntries = Object.entries(input.blindTargetParticipantIdByEventId);
+  for (const [targetEventId, participantId] of targetBindingEntries) {
+    if (!frozenBlindTargetIds.has(targetEventId)) {
+      throw new Error(`blind target participant binding references unknown target: ${targetEventId}`);
+    }
+    if (!knownParticipants.has(participantId)) {
+      throw new Error(`blind target references unallocated participant: ${targetEventId}:${participantId}`);
+    }
+  }
+
+  const blindTargetParticipantIdByEventId: Record<string, string> = {};
+  for (const targetEventId of [...input.blindTargetEventIds].sort()) {
+    const participantId = input.blindTargetParticipantIdByEventId[targetEventId];
+    if (!participantId) {
+      throw new Error(`blind target is missing frozen participant binding: ${targetEventId}`);
+    }
+    blindTargetParticipantIdByEventId[targetEventId] = participantId;
+  }
+
   const sortedPrefix: Record<string, readonly string[]> = {};
   for (const participantId of [...knownParticipants].sort()) {
     sortedPrefix[participantId] = Object.freeze([
@@ -110,6 +131,7 @@ export function buildFrozenNativeSplitProtocol(
     heldOutParticipantIds: Object.freeze([...input.heldOutParticipantIds].sort()),
     trainPrefixEventIdsByParticipant: Object.freeze(sortedPrefix),
     blindTargetEventIds: Object.freeze([...input.blindTargetEventIds].sort()),
+    blindTargetParticipantIdByEventId: Object.freeze(blindTargetParticipantIdByEventId),
   });
 }
 
@@ -192,6 +214,16 @@ export function buildBlindPredictionFeatureRow(
 ): PredictionFeatureRow {
   if (!input.protocol.blindTargetEventIds.includes(input.targetEventId)) {
     throw new Error(`targetEventId is not in frozen blind block: ${input.targetEventId}`);
+  }
+  const frozenParticipantId =
+    input.protocol.blindTargetParticipantIdByEventId[input.targetEventId];
+  if (!frozenParticipantId) {
+    throw new Error(`blind target is missing frozen participant binding: ${input.targetEventId}`);
+  }
+  if (frozenParticipantId !== input.participantId) {
+    throw new Error(
+      `blind target is frozen to participant ${frozenParticipantId}: ${input.targetEventId}`,
+    );
   }
 
   const predictionMs = parseTimestamp(input.predictionTimestamp, "predictionTimestamp");

--- a/benchmarks/native-evidence-v1/protocol.ts
+++ b/benchmarks/native-evidence-v1/protocol.ts
@@ -1,0 +1,205 @@
+import { buildPredictionFeatureRow } from "./features";
+import type {
+  PilotTaskDefinition,
+  PredictionFeatureRow,
+  SyntheticPilotEvent,
+} from "./types";
+
+export const NATIVE_SPLIT_PROTOCOL_ID = "nep.native-split.v1" as const;
+
+export type FrozenNativeSplitProtocol = {
+  readonly protocolId: typeof NATIVE_SPLIT_PROTOCOL_ID;
+  readonly frozenAt: string;
+  readonly fitCutoff: string;
+  readonly fitCompletedAt: string;
+  readonly trainingParticipantIds: readonly string[];
+  readonly heldOutParticipantIds: readonly string[];
+  readonly trainPrefixEventIdsByParticipant: Readonly<Record<string, readonly string[]>>;
+  readonly blindTargetEventIds: readonly string[];
+};
+
+export type BuildFrozenNativeSplitProtocolInput = Omit<FrozenNativeSplitProtocol, "protocolId">;
+
+export type BuildBlindPredictionRowInput = {
+  readonly protocol: FrozenNativeSplitProtocol;
+  readonly participantId: string;
+  readonly targetEventId: string;
+  readonly predictionTimestamp: string;
+  readonly currentTask: PilotTaskDefinition;
+  readonly history: readonly SyntheticPilotEvent[];
+  readonly label?: 0 | 1 | null;
+};
+
+function parseTimestamp(value: string, field: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${field} must be a valid ISO timestamp: ${value}`);
+  return parsed;
+}
+
+function assertUnique(values: readonly string[], field: string): void {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`${field} must contain unique values`);
+  }
+}
+
+export function buildFrozenNativeSplitProtocol(
+  input: BuildFrozenNativeSplitProtocolInput,
+): FrozenNativeSplitProtocol {
+  const frozenAtMs = parseTimestamp(input.frozenAt, "frozenAt");
+  const fitCutoffMs = parseTimestamp(input.fitCutoff, "fitCutoff");
+  const fitCompletedAtMs = parseTimestamp(input.fitCompletedAt, "fitCompletedAt");
+  if (frozenAtMs > fitCutoffMs) {
+    throw new Error("split protocol must be frozen no later than fitCutoff");
+  }
+  if (fitCompletedAtMs < fitCutoffMs) {
+    throw new Error("fitCompletedAt cannot precede the global fitCutoff");
+  }
+
+  assertUnique(input.trainingParticipantIds, "trainingParticipantIds");
+  assertUnique(input.heldOutParticipantIds, "heldOutParticipantIds");
+  assertUnique(input.blindTargetEventIds, "blindTargetEventIds");
+
+  const training = new Set(input.trainingParticipantIds);
+  for (const heldOut of input.heldOutParticipantIds) {
+    if (training.has(heldOut)) {
+      throw new Error(`participant cannot be both TRAIN and held out: ${heldOut}`);
+    }
+  }
+
+  const knownParticipants = new Set([
+    ...input.trainingParticipantIds,
+    ...input.heldOutParticipantIds,
+  ]);
+  const prefixEntries = Object.entries(input.trainPrefixEventIdsByParticipant);
+  const seenPrefixEvents = new Set<string>();
+  for (const [participantId, eventIds] of prefixEntries) {
+    if (!knownParticipants.has(participantId)) {
+      throw new Error(`train prefix references unallocated participant: ${participantId}`);
+    }
+    if (input.heldOutParticipantIds.includes(participantId) && eventIds.length > 0) {
+      throw new Error(`held-out participant cannot contribute TRAIN prefix events: ${participantId}`);
+    }
+    assertUnique(eventIds, `trainPrefixEventIdsByParticipant.${participantId}`);
+    for (const eventId of eventIds) {
+      if (seenPrefixEvents.has(eventId)) {
+        throw new Error(`train prefix eventId must be globally unique: ${eventId}`);
+      }
+      seenPrefixEvents.add(eventId);
+    }
+  }
+
+  for (const targetEventId of input.blindTargetEventIds) {
+    if (seenPrefixEvents.has(targetEventId)) {
+      throw new Error(`blind target cannot also be a TRAIN prefix event: ${targetEventId}`);
+    }
+  }
+
+  const sortedPrefix: Record<string, readonly string[]> = {};
+  for (const participantId of [...knownParticipants].sort()) {
+    sortedPrefix[participantId] = Object.freeze([
+      ...(input.trainPrefixEventIdsByParticipant[participantId] ?? []),
+    ].sort());
+  }
+
+  return Object.freeze({
+    protocolId: NATIVE_SPLIT_PROTOCOL_ID,
+    frozenAt: input.frozenAt,
+    fitCutoff: input.fitCutoff,
+    fitCompletedAt: input.fitCompletedAt,
+    trainingParticipantIds: Object.freeze([...input.trainingParticipantIds].sort()),
+    heldOutParticipantIds: Object.freeze([...input.heldOutParticipantIds].sort()),
+    trainPrefixEventIdsByParticipant: Object.freeze(sortedPrefix),
+    blindTargetEventIds: Object.freeze([...input.blindTargetEventIds].sort()),
+  });
+}
+
+export function selectAuthorizedTrainPrefixEvents(
+  protocol: FrozenNativeSplitProtocol,
+  events: readonly SyntheticPilotEvent[],
+): readonly SyntheticPilotEvent[] {
+  const fitCutoffMs = parseTimestamp(protocol.fitCutoff, "fitCutoff");
+  const eventsById = new Map(events.map((event) => [event.evidence.eventId, event]));
+  const selected: SyntheticPilotEvent[] = [];
+
+  for (const participantId of protocol.trainingParticipantIds) {
+    const prefixIds = protocol.trainPrefixEventIdsByParticipant[participantId] ?? [];
+    for (const eventId of prefixIds) {
+      const event = eventsById.get(eventId);
+      if (!event) throw new Error(`frozen TRAIN prefix event is missing: ${eventId}`);
+      if (event.participantId !== participantId) {
+        throw new Error(`frozen TRAIN prefix event belongs to wrong participant: ${eventId}`);
+      }
+      const occurredMs = parseTimestamp(event.evidence.occurredAt, "occurredAt");
+      const availableMs = parseTimestamp(event.availableAt, "availableAt");
+      if (occurredMs >= fitCutoffMs || availableMs >= fitCutoffMs) {
+        throw new Error(`TRAIN prefix label is not causally available by fitCutoff: ${eventId}`);
+      }
+      selected.push(event);
+    }
+  }
+
+  return Object.freeze(
+    selected.sort((left, right) => {
+      const occurred = left.evidence.occurredAt.localeCompare(right.evidence.occurredAt);
+      if (occurred !== 0) return occurred;
+      return left.evidence.eventId.localeCompare(right.evidence.eventId);
+    }),
+  );
+}
+
+export function selectFrozenPredictionHistory(
+  protocol: FrozenNativeSplitProtocol,
+  participantId: string,
+  events: readonly SyntheticPilotEvent[],
+): readonly SyntheticPilotEvent[] {
+  if (protocol.heldOutParticipantIds.includes(participantId)) return Object.freeze([]);
+  if (!protocol.trainingParticipantIds.includes(participantId)) {
+    throw new Error(`participant is not allocated by frozen split protocol: ${participantId}`);
+  }
+
+  const allowedIds = new Set(protocol.trainPrefixEventIdsByParticipant[participantId] ?? []);
+  const selected = events.filter(
+    (event) => event.participantId === participantId && allowedIds.has(event.evidence.eventId),
+  );
+  if (selected.length !== allowedIds.size) {
+    const present = new Set(selected.map((event) => event.evidence.eventId));
+    const missing = [...allowedIds].filter((eventId) => !present.has(eventId));
+    throw new Error(`frozen prediction history is missing prefix events: ${missing.join(",")}`);
+  }
+  return Object.freeze([...selected]);
+}
+
+export function buildBlindPredictionFeatureRow(
+  input: BuildBlindPredictionRowInput,
+): PredictionFeatureRow {
+  if (!input.protocol.blindTargetEventIds.includes(input.targetEventId)) {
+    throw new Error(`targetEventId is not in frozen blind block: ${input.targetEventId}`);
+  }
+
+  const predictionMs = parseTimestamp(input.predictionTimestamp, "predictionTimestamp");
+  const fitCutoffMs = parseTimestamp(input.protocol.fitCutoff, "fitCutoff");
+  const fitCompletedAtMs = parseTimestamp(input.protocol.fitCompletedAt, "fitCompletedAt");
+  if (predictionMs <= fitCutoffMs) {
+    throw new Error("evaluated prediction must occur after the global fitCutoff");
+  }
+  if (predictionMs <= fitCompletedAtMs) {
+    throw new Error("fitCompletedAt must strictly precede predictionTimestamp");
+  }
+
+  // A blind-block row may replay only the prospectively frozen TRAIN prefix. Earlier TEST labels,
+  // even if already available in wall-clock time, are intentionally excluded from every later row.
+  const frozenHistory = selectFrozenPredictionHistory(
+    input.protocol,
+    input.participantId,
+    input.history,
+  );
+
+  return buildPredictionFeatureRow({
+    participantId: input.participantId,
+    targetEventId: input.targetEventId,
+    predictionTimestamp: input.predictionTimestamp,
+    currentTask: input.currentTask,
+    history: frozenHistory,
+    label: input.label,
+  });
+}

--- a/benchmarks/native-evidence-v1/protocol.ts
+++ b/benchmarks/native-evidence-v1/protocol.ts
@@ -7,6 +7,14 @@ import type {
 
 export const NATIVE_SPLIT_PROTOCOL_ID = "nep.native-split.v1" as const;
 
+export type FrozenBlindTargetBinding = {
+  readonly participantId: string;
+  readonly predictionTimestamp: string;
+  readonly taskId: string;
+  readonly taskVersion: number;
+  readonly contentFingerprint: `sha256:${string}`;
+};
+
 export type FrozenNativeSplitProtocol = {
   readonly protocolId: typeof NATIVE_SPLIT_PROTOCOL_ID;
   readonly frozenAt: string;
@@ -16,7 +24,7 @@ export type FrozenNativeSplitProtocol = {
   readonly heldOutParticipantIds: readonly string[];
   readonly trainPrefixEventIdsByParticipant: Readonly<Record<string, readonly string[]>>;
   readonly blindTargetEventIds: readonly string[];
-  readonly blindTargetParticipantIdByEventId: Readonly<Record<string, string>>;
+  readonly blindTargetBindings: Readonly<Record<string, FrozenBlindTargetBinding>>;
 };
 
 export type BuildFrozenNativeSplitProtocolInput = Omit<FrozenNativeSplitProtocol, "protocolId">;
@@ -41,6 +49,40 @@ function assertUnique(values: readonly string[], field: string): void {
   if (new Set(values).size !== values.length) {
     throw new Error(`${field} must contain unique values`);
   }
+}
+
+function freezeBlindTargetBinding(
+  targetEventId: string,
+  binding: FrozenBlindTargetBinding,
+  knownParticipants: ReadonlySet<string>,
+  fitCutoffMs: number,
+  fitCompletedAtMs: number,
+): FrozenBlindTargetBinding {
+  if (!knownParticipants.has(binding.participantId)) {
+    throw new Error(
+      `blind target references unallocated participant: ${targetEventId}:${binding.participantId}`,
+    );
+  }
+  const predictionMs = parseTimestamp(
+    binding.predictionTimestamp,
+    `blindTargetBindings.${targetEventId}.predictionTimestamp`,
+  );
+  if (predictionMs <= fitCutoffMs) {
+    throw new Error(`blind target prediction must occur after fitCutoff: ${targetEventId}`);
+  }
+  if (predictionMs <= fitCompletedAtMs) {
+    throw new Error(`blind target prediction must occur after fitCompletedAt: ${targetEventId}`);
+  }
+  if (!binding.taskId) {
+    throw new Error(`blind target taskId must be non-empty: ${targetEventId}`);
+  }
+  if (!Number.isInteger(binding.taskVersion) || binding.taskVersion <= 0) {
+    throw new Error(`blind target taskVersion must be a positive integer: ${targetEventId}`);
+  }
+  if (!/^sha256:[0-9a-f]{64}$/.test(binding.contentFingerprint)) {
+    throw new Error(`blind target contentFingerprint must be sha256: ${targetEventId}`);
+  }
+  return Object.freeze({ ...binding });
 }
 
 export function buildFrozenNativeSplitProtocol(
@@ -96,23 +138,25 @@ export function buildFrozenNativeSplitProtocol(
   }
 
   const frozenBlindTargetIds = new Set(input.blindTargetEventIds);
-  const targetBindingEntries = Object.entries(input.blindTargetParticipantIdByEventId);
-  for (const [targetEventId, participantId] of targetBindingEntries) {
+  for (const targetEventId of Object.keys(input.blindTargetBindings)) {
     if (!frozenBlindTargetIds.has(targetEventId)) {
-      throw new Error(`blind target participant binding references unknown target: ${targetEventId}`);
-    }
-    if (!knownParticipants.has(participantId)) {
-      throw new Error(`blind target references unallocated participant: ${targetEventId}:${participantId}`);
+      throw new Error(`blind target binding references unknown target: ${targetEventId}`);
     }
   }
 
-  const blindTargetParticipantIdByEventId: Record<string, string> = {};
+  const blindTargetBindings: Record<string, FrozenBlindTargetBinding> = {};
   for (const targetEventId of [...input.blindTargetEventIds].sort()) {
-    const participantId = input.blindTargetParticipantIdByEventId[targetEventId];
-    if (!participantId) {
-      throw new Error(`blind target is missing frozen participant binding: ${targetEventId}`);
+    const binding = input.blindTargetBindings[targetEventId];
+    if (!binding) {
+      throw new Error(`blind target is missing frozen binding: ${targetEventId}`);
     }
-    blindTargetParticipantIdByEventId[targetEventId] = participantId;
+    blindTargetBindings[targetEventId] = freezeBlindTargetBinding(
+      targetEventId,
+      binding,
+      knownParticipants,
+      fitCutoffMs,
+      fitCompletedAtMs,
+    );
   }
 
   const sortedPrefix: Record<string, readonly string[]> = {};
@@ -131,7 +175,7 @@ export function buildFrozenNativeSplitProtocol(
     heldOutParticipantIds: Object.freeze([...input.heldOutParticipantIds].sort()),
     trainPrefixEventIdsByParticipant: Object.freeze(sortedPrefix),
     blindTargetEventIds: Object.freeze([...input.blindTargetEventIds].sort()),
-    blindTargetParticipantIdByEventId: Object.freeze(blindTargetParticipantIdByEventId),
+    blindTargetBindings: Object.freeze(blindTargetBindings),
   });
 }
 
@@ -215,15 +259,24 @@ export function buildBlindPredictionFeatureRow(
   if (!input.protocol.blindTargetEventIds.includes(input.targetEventId)) {
     throw new Error(`targetEventId is not in frozen blind block: ${input.targetEventId}`);
   }
-  const frozenParticipantId =
-    input.protocol.blindTargetParticipantIdByEventId[input.targetEventId];
-  if (!frozenParticipantId) {
-    throw new Error(`blind target is missing frozen participant binding: ${input.targetEventId}`);
+  const targetBinding = input.protocol.blindTargetBindings[input.targetEventId];
+  if (!targetBinding) {
+    throw new Error(`blind target is missing frozen binding: ${input.targetEventId}`);
   }
-  if (frozenParticipantId !== input.participantId) {
+  if (targetBinding.participantId !== input.participantId) {
     throw new Error(
-      `blind target is frozen to participant ${frozenParticipantId}: ${input.targetEventId}`,
+      `blind target is frozen to participant ${targetBinding.participantId}: ${input.targetEventId}`,
     );
+  }
+  if (targetBinding.predictionTimestamp !== input.predictionTimestamp) {
+    throw new Error(`predictionTimestamp differs from frozen blind target: ${input.targetEventId}`);
+  }
+  if (
+    targetBinding.taskId !== input.currentTask.task.id ||
+    targetBinding.taskVersion !== input.currentTask.task.version ||
+    targetBinding.contentFingerprint !== input.currentTask.contentFingerprint
+  ) {
+    throw new Error(`currentTask differs from frozen blind target: ${input.targetEventId}`);
   }
 
   const predictionMs = parseTimestamp(input.predictionTimestamp, "predictionTimestamp");

--- a/benchmarks/native-evidence-v1/protocol.ts
+++ b/benchmarks/native-evidence-v1/protocol.ts
@@ -10,9 +10,16 @@ export const NATIVE_SPLIT_PROTOCOL_ID = "nep.native-split.v1" as const;
 export type FrozenBlindTargetBinding = {
   readonly participantId: string;
   readonly predictionTimestamp: string;
+  readonly family: PilotTaskDefinition["family"];
   readonly taskId: string;
   readonly taskVersion: number;
   readonly contentFingerprint: `sha256:${string}`;
+  readonly supportLevel: number;
+  readonly revealAllowed: boolean;
+  readonly transferDistance: PilotTaskDefinition["task"]["transferDistance"];
+  readonly contextId: string;
+  readonly stimulusFormGroup: string;
+  readonly scoringContractId: string;
 };
 
 export type FrozenNativeSplitProtocol = {
@@ -82,7 +89,38 @@ function freezeBlindTargetBinding(
   if (!/^sha256:[0-9a-f]{64}$/.test(binding.contentFingerprint)) {
     throw new Error(`blind target contentFingerprint must be sha256: ${targetEventId}`);
   }
+  if (!Number.isInteger(binding.supportLevel) || binding.supportLevel < 0) {
+    throw new Error(`blind target supportLevel must be a nonnegative integer: ${targetEventId}`);
+  }
+  if (!binding.contextId) {
+    throw new Error(`blind target contextId must be non-empty: ${targetEventId}`);
+  }
+  if (!binding.stimulusFormGroup) {
+    throw new Error(`blind target stimulusFormGroup must be non-empty: ${targetEventId}`);
+  }
+  if (!binding.scoringContractId) {
+    throw new Error(`blind target scoringContractId must be non-empty: ${targetEventId}`);
+  }
   return Object.freeze({ ...binding });
+}
+
+function currentTaskMatchesBinding(
+  currentTask: PilotTaskDefinition,
+  binding: FrozenBlindTargetBinding,
+): boolean {
+  return (
+    binding.family === currentTask.family &&
+    binding.taskId === currentTask.task.id &&
+    binding.taskVersion === currentTask.task.version &&
+    binding.contentFingerprint === currentTask.contentFingerprint &&
+    binding.supportLevel === currentTask.task.support.level &&
+    binding.revealAllowed === currentTask.task.support.revealAllowed &&
+    binding.transferDistance === currentTask.task.transferDistance &&
+    binding.contextId === currentTask.contextId &&
+    binding.stimulusFormGroup === currentTask.stimulusFormGroup &&
+    binding.scoringContractId === currentTask.scoringContractId &&
+    binding.scoringContractId === currentTask.task.scoringContractId
+  );
 }
 
 export function buildFrozenNativeSplitProtocol(
@@ -271,11 +309,7 @@ export function buildBlindPredictionFeatureRow(
   if (targetBinding.predictionTimestamp !== input.predictionTimestamp) {
     throw new Error(`predictionTimestamp differs from frozen blind target: ${input.targetEventId}`);
   }
-  if (
-    targetBinding.taskId !== input.currentTask.task.id ||
-    targetBinding.taskVersion !== input.currentTask.task.version ||
-    targetBinding.contentFingerprint !== input.currentTask.contentFingerprint
-  ) {
+  if (!currentTaskMatchesBinding(input.currentTask, targetBinding)) {
     throw new Error(`currentTask differs from frozen blind target: ${input.targetEventId}`);
   }
 

--- a/benchmarks/native-evidence-v1/protocol.ts
+++ b/benchmarks/native-evidence-v1/protocol.ts
@@ -118,7 +118,20 @@ export function selectAuthorizedTrainPrefixEvents(
   events: readonly SyntheticPilotEvent[],
 ): readonly SyntheticPilotEvent[] {
   const fitCutoffMs = parseTimestamp(protocol.fitCutoff, "fitCutoff");
-  const eventsById = new Map(events.map((event) => [event.evidence.eventId, event]));
+  const requiredPrefixIds = new Set(
+    protocol.trainingParticipantIds.flatMap(
+      (participantId) => protocol.trainPrefixEventIdsByParticipant[participantId] ?? [],
+    ),
+  );
+  const eventsById = new Map<string, SyntheticPilotEvent>();
+  for (const event of events) {
+    const eventId = event.evidence.eventId;
+    if (!requiredPrefixIds.has(eventId)) continue;
+    if (eventsById.has(eventId)) {
+      throw new Error(`frozen TRAIN prefix event is ambiguous due to duplicate eventId: ${eventId}`);
+    }
+    eventsById.set(eventId, event);
+  }
   const selected: SyntheticPilotEvent[] = [];
 
   for (const participantId of protocol.trainingParticipantIds) {
@@ -158,15 +171,20 @@ export function selectFrozenPredictionHistory(
   }
 
   const allowedIds = new Set(protocol.trainPrefixEventIdsByParticipant[participantId] ?? []);
-  const selected = events.filter(
-    (event) => event.participantId === participantId && allowedIds.has(event.evidence.eventId),
-  );
-  if (selected.length !== allowedIds.size) {
-    const present = new Set(selected.map((event) => event.evidence.eventId));
-    const missing = [...allowedIds].filter((eventId) => !present.has(eventId));
+  const selectedById = new Map<string, SyntheticPilotEvent>();
+  for (const event of events) {
+    const eventId = event.evidence.eventId;
+    if (event.participantId !== participantId || !allowedIds.has(eventId)) continue;
+    if (selectedById.has(eventId)) {
+      throw new Error(`frozen prediction history has duplicate prefix eventId: ${eventId}`);
+    }
+    selectedById.set(eventId, event);
+  }
+  if (selectedById.size !== allowedIds.size) {
+    const missing = [...allowedIds].filter((eventId) => !selectedById.has(eventId));
     throw new Error(`frozen prediction history is missing prefix events: ${missing.join(",")}`);
   }
-  return Object.freeze([...selected]);
+  return Object.freeze([...selectedById.values()]);
 }
 
 export function buildBlindPredictionFeatureRow(

--- a/benchmarks/native-evidence-v1/requirements.lock
+++ b/benchmarks/native-evidence-v1/requirements.lock
@@ -1,0 +1,5 @@
+# Research-only dependencies for Spec #005 N2 synthetic predictor plumbing.
+# Keep isolated from the production Next.js runtime.
+numpy==2.2.3
+scipy==1.15.2
+scikit-learn==1.6.1

--- a/benchmarks/native-evidence-v1/requirements.lock
+++ b/benchmarks/native-evidence-v1/requirements.lock
@@ -3,3 +3,6 @@
 numpy==2.2.3
 scipy==1.15.2
 scikit-learn==1.6.1
+pandas==2.2.3
+requests==2.32.3
+pyBKT @ git+https://github.com/CAHLR/pyBKT.git@06fc180ae72c117458acc527f8ec90cc8e0581c1

--- a/benchmarks/native-evidence-v1/run-manifest.test.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.test.ts
@@ -19,11 +19,13 @@ function buildFixture() {
   const participantId = "manifest-p";
   const tasks = buildFrozenPilotTaskMatrix();
   const trace = buildSyntheticTrace(participantId);
+  const delayedTask = buildPilotTaskDefinition("delayed-free-recall");
+  const coldTask = buildPilotTaskDefinition("free-recall");
   const row = buildPredictionFeatureRow({
     participantId,
     targetEventId: `${participantId}:e05`,
     predictionTimestamp: "2026-09-02T09:00:00.000Z",
-    currentTask: buildPilotTaskDefinition("delayed-free-recall"),
+    currentTask: delayedTask,
     history: trace,
   });
   const protocol = buildFrozenNativeSplitProtocol({
@@ -42,9 +44,21 @@ function buildFixture() {
       "manifest-cold": [],
     },
     blindTargetEventIds: [`${participantId}:e05`, "manifest-cold:target"],
-    blindTargetParticipantIdByEventId: {
-      [`${participantId}:e05`]: participantId,
-      "manifest-cold:target": "manifest-cold",
+    blindTargetBindings: {
+      [`${participantId}:e05`]: {
+        participantId,
+        predictionTimestamp: "2026-09-02T09:00:00.000Z",
+        taskId: delayedTask.task.id,
+        taskVersion: delayedTask.task.version,
+        contentFingerprint: delayedTask.contentFingerprint,
+      },
+      "manifest-cold:target": {
+        participantId: "manifest-cold",
+        predictionTimestamp: "2026-09-02T10:00:00.000Z",
+        taskId: coldTask.task.id,
+        taskVersion: coldTask.task.version,
+        contentFingerprint: coldTask.contentFingerprint,
+      },
     },
   });
 
@@ -157,9 +171,21 @@ describe("native pilot full synthetic run manifest", () => {
     expect(first.split.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(first.split.trainingParticipantIds).toEqual(["manifest-p"]);
     expect(first.split.heldOutParticipantIds).toEqual(["manifest-cold"]);
-    expect(first.split.blindTargetParticipantIdByEventId).toEqual({
-      "manifest-cold:target": "manifest-cold",
-      "manifest-p:e05": "manifest-p",
+    expect(first.split.blindTargetBindings).toEqual({
+      "manifest-cold:target": {
+        participantId: "manifest-cold",
+        predictionTimestamp: "2026-09-02T10:00:00.000Z",
+        taskId: buildPilotTaskDefinition("free-recall").task.id,
+        taskVersion: 1,
+        contentFingerprint: buildPilotTaskDefinition("free-recall").contentFingerprint,
+      },
+      "manifest-p:e05": {
+        participantId: "manifest-p",
+        predictionTimestamp: "2026-09-02T09:00:00.000Z",
+        taskId: buildPilotTaskDefinition("delayed-free-recall").task.id,
+        taskVersion: 1,
+        contentFingerprint: buildPilotTaskDefinition("delayed-free-recall").contentFingerprint,
+      },
     });
     expect(first.causalPolicy.blindBlockFeedbackForbidden).toBe(true);
     expect(first.featureRows[0]?.predictionBindingDigest).toMatch(/^sha256:[0-9a-f]{64}$/);

--- a/benchmarks/native-evidence-v1/run-manifest.test.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPredictionFeatureRow } from "./features";
+import { buildFrozenNativeSplitProtocol } from "./protocol";
+import {
+  buildSyntheticNativeRunManifest,
+  type SyntheticPredictorArtifactBinding,
+} from "./run-manifest";
+import { SyntheticPilotStore } from "./store";
+import { buildFrozenPilotTaskMatrix, buildPilotTaskDefinition } from "./task-matrix";
+import { buildSyntheticTrace } from "./synthetic";
+
+const SHA_A = `sha256:${"a".repeat(64)}` as const;
+const SHA_B = `sha256:${"b".repeat(64)}` as const;
+const SHA_C = `sha256:${"c".repeat(64)}` as const;
+const SHA_D = `sha256:${"d".repeat(64)}` as const;
+
+function buildFixture() {
+  const participantId = "manifest-p";
+  const tasks = buildFrozenPilotTaskMatrix();
+  const trace = buildSyntheticTrace(participantId);
+  const row = buildPredictionFeatureRow({
+    participantId,
+    targetEventId: `${participantId}:e05`,
+    predictionTimestamp: "2026-09-02T09:00:00.000Z",
+    currentTask: buildPilotTaskDefinition("delayed-free-recall"),
+    history: trace,
+  });
+  const protocol = buildFrozenNativeSplitProtocol({
+    frozenAt: "2026-08-31T00:00:00.000Z",
+    fitCutoff: "2026-09-01T23:00:00.000Z",
+    fitCompletedAt: "2026-09-01T23:05:00.000Z",
+    trainingParticipantIds: [participantId],
+    heldOutParticipantIds: ["manifest-cold"],
+    trainPrefixEventIdsByParticipant: {
+      [participantId]: [
+        `${participantId}:e01`,
+        `${participantId}:e02`,
+        `${participantId}:e03`,
+        `${participantId}:e04`,
+      ],
+      "manifest-cold": [],
+    },
+    blindTargetEventIds: [`${participantId}:e05`, "manifest-cold:target"],
+  });
+
+  const store = new SyntheticPilotStore();
+  const feature = store.registerArtifact("feature:manifest-p", "feature", [participantId]);
+  const model = store.registerArtifact("model:native", "model", [], [feature.artifactId]);
+  const prediction = store.registerArtifact(
+    "prediction:manifest-p:e05",
+    "prediction",
+    [],
+    [model.artifactId],
+  );
+  store.registerArtifact("result:synthetic", "result", [], [prediction.artifactId]);
+
+  const predictorArtifacts: readonly SyntheticPredictorArtifactBinding[] = [
+    {
+      lane: "b0-native",
+      availability: "available",
+      specFingerprint: SHA_A,
+      transformFingerprint: null,
+      fittedModelFingerprint: SHA_B,
+      predictionFingerprint: SHA_C,
+      nonEstimabilityReason: null,
+    },
+    {
+      lane: "b2-native",
+      availability: "available",
+      specFingerprint: SHA_A,
+      transformFingerprint: SHA_B,
+      fittedModelFingerprint: SHA_C,
+      predictionFingerprint: SHA_D,
+      nonEstimabilityReason: null,
+    },
+    {
+      lane: "b2-basis-native",
+      availability: "available",
+      specFingerprint: SHA_A,
+      transformFingerprint: SHA_B,
+      fittedModelFingerprint: SHA_C,
+      predictionFingerprint: SHA_D,
+      nonEstimabilityReason: null,
+    },
+    {
+      lane: "b3-native",
+      availability: "available",
+      specFingerprint: SHA_A,
+      transformFingerprint: SHA_B,
+      fittedModelFingerprint: SHA_C,
+      predictionFingerprint: SHA_D,
+      nonEstimabilityReason: null,
+    },
+    {
+      lane: "bkt-native",
+      availability: "available",
+      specFingerprint: SHA_A,
+      transformFingerprint: null,
+      fittedModelFingerprint: SHA_C,
+      predictionFingerprint: SHA_D,
+      nonEstimabilityReason: null,
+    },
+  ];
+
+  return {
+    tasks,
+    row,
+    protocol,
+    artifacts: store.listValidArtifacts(),
+    predictorArtifacts,
+  };
+}
+
+describe("native pilot full synthetic run manifest", () => {
+  it("binds split, lineage, fingerprints, coverage and claim boundaries deterministically", () => {
+    const fixture = buildFixture();
+    const input = {
+      tasks: fixture.tasks,
+      rows: [fixture.row],
+      protocol: fixture.protocol,
+      artifacts: fixture.artifacts,
+      predictorArtifacts: fixture.predictorArtifacts,
+      coverage: {
+        eligibleOpportunityCount: 2,
+        observedOutcomeCount: 0,
+        emittedPredictionCount: 0,
+        acceptedHistoryEventCount: fixture.row.acceptedHistoryEventIds.length,
+        rejectedHistoryEventCount: 0,
+        learnerCount: 2,
+        attemptCount: 4,
+      },
+      bkt: {
+        diagnosticsArtifactDigest: SHA_D,
+        diagnosticsUnavailableReason: null,
+        convergenceAssurance: "convergence-observed" as const,
+        stabilityAssurance: "unresolved-pending-reviewed-train-only-tolerances" as const,
+      },
+    };
+
+    const first = buildSyntheticNativeRunManifest(input);
+    const second = buildSyntheticNativeRunManifest({
+      ...input,
+      tasks: [...input.tasks].reverse(),
+      artifacts: [...input.artifacts].reverse(),
+      predictorArtifacts: [...input.predictorArtifacts].reverse(),
+    });
+
+    expect(first.manifestDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(first.manifestDigest).toBe(second.manifestDigest);
+    expect(first.status).toBe("synthetic-plumbing-only");
+    expect(first.dataPolicy.humanDataIncluded).toBe(false);
+    expect(first.split.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(first.split.trainingParticipantIds).toEqual(["manifest-p"]);
+    expect(first.split.heldOutParticipantIds).toEqual(["manifest-cold"]);
+    expect(first.causalPolicy.blindBlockFeedbackForbidden).toBe(true);
+    expect(first.featureRows[0]?.predictionBindingDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(first.artifacts.find((artifact) => artifact.artifactId === "result:synthetic")?.participantIds).toEqual([
+      "manifest-p",
+    ]);
+    expect(first.predictorArtifacts).toHaveLength(5);
+    expect(first.contrasts).toEqual({
+      b3MinusB2: null,
+      b3MinusB2Basis: null,
+      reason: "synthetic-data-cannot-rank-models",
+    });
+    expect(first.utilityGate.predictiveKeepSimplifyEnabled).toBe(false);
+    expect(first.decision.status).toBe("disabled-synthetic-only");
+    expect(first.forbiddenClaims).toContain("learner-model-validity");
+    expect(first.forbiddenClaims).toContain("predictive-superiority");
+  });
+
+  it("fails closed on incomplete lane, impossible coverage or ambiguous BKT diagnostics", () => {
+    const fixture = buildFixture();
+    const base = {
+      tasks: fixture.tasks,
+      rows: [fixture.row],
+      protocol: fixture.protocol,
+      artifacts: fixture.artifacts,
+      predictorArtifacts: fixture.predictorArtifacts,
+      coverage: {
+        eligibleOpportunityCount: 1,
+        observedOutcomeCount: 0,
+        emittedPredictionCount: 0,
+        acceptedHistoryEventCount: 4,
+        rejectedHistoryEventCount: 0,
+        learnerCount: 1,
+        attemptCount: 4,
+      },
+      bkt: {
+        diagnosticsArtifactDigest: SHA_D,
+        diagnosticsUnavailableReason: null,
+        convergenceAssurance: "convergence-observed" as const,
+        stabilityAssurance: "unresolved-pending-reviewed-train-only-tolerances" as const,
+      },
+    };
+
+    expect(() =>
+      buildSyntheticNativeRunManifest({
+        ...base,
+        predictorArtifacts: base.predictorArtifacts.filter((lane) => lane.lane !== "b3-native"),
+      }),
+    ).toThrow("predictorArtifacts missing lane: b3-native");
+
+    expect(() =>
+      buildSyntheticNativeRunManifest({
+        ...base,
+        coverage: { ...base.coverage, observedOutcomeCount: 2 },
+      }),
+    ).toThrow("coverage.observedOutcomeCount cannot exceed eligibleOpportunityCount");
+
+    expect(() =>
+      buildSyntheticNativeRunManifest({
+        ...base,
+        bkt: {
+          ...base.bkt,
+          diagnosticsArtifactDigest: null,
+          diagnosticsUnavailableReason: null,
+        },
+      }),
+    ).toThrow("missing BKT diagnostics digest requires diagnosticsUnavailableReason");
+  });
+});

--- a/benchmarks/native-evidence-v1/run-manifest.test.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.test.ts
@@ -15,6 +15,21 @@ const SHA_B = `sha256:${"b".repeat(64)}` as const;
 const SHA_C = `sha256:${"c".repeat(64)}` as const;
 const SHA_D = `sha256:${"d".repeat(64)}` as const;
 
+function frozenTaskBinding(definition: ReturnType<typeof buildPilotTaskDefinition>) {
+  return {
+    family: definition.family,
+    taskId: definition.task.id,
+    taskVersion: definition.task.version,
+    contentFingerprint: definition.contentFingerprint,
+    supportLevel: definition.task.support.level,
+    revealAllowed: definition.task.support.revealAllowed,
+    transferDistance: definition.task.transferDistance,
+    contextId: definition.contextId,
+    stimulusFormGroup: definition.stimulusFormGroup,
+    scoringContractId: definition.scoringContractId,
+  } as const;
+}
+
 function buildFixture() {
   const participantId = "manifest-p";
   const tasks = buildFrozenPilotTaskMatrix();
@@ -48,16 +63,12 @@ function buildFixture() {
       [`${participantId}:e05`]: {
         participantId,
         predictionTimestamp: "2026-09-02T09:00:00.000Z",
-        taskId: delayedTask.task.id,
-        taskVersion: delayedTask.task.version,
-        contentFingerprint: delayedTask.contentFingerprint,
+        ...frozenTaskBinding(delayedTask),
       },
       "manifest-cold:target": {
         participantId: "manifest-cold",
         predictionTimestamp: "2026-09-02T10:00:00.000Z",
-        taskId: coldTask.task.id,
-        taskVersion: coldTask.task.version,
-        contentFingerprint: coldTask.contentFingerprint,
+        ...frozenTaskBinding(coldTask),
       },
     },
   });
@@ -164,6 +175,8 @@ describe("native pilot full synthetic run manifest", () => {
       predictorArtifacts: [...input.predictorArtifacts].reverse(),
     });
 
+    const coldTask = buildPilotTaskDefinition("free-recall");
+    const delayedTask = buildPilotTaskDefinition("delayed-free-recall");
     expect(first.manifestDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(first.manifestDigest).toBe(second.manifestDigest);
     expect(first.status).toBe("synthetic-plumbing-only");
@@ -175,16 +188,12 @@ describe("native pilot full synthetic run manifest", () => {
       "manifest-cold:target": {
         participantId: "manifest-cold",
         predictionTimestamp: "2026-09-02T10:00:00.000Z",
-        taskId: buildPilotTaskDefinition("free-recall").task.id,
-        taskVersion: 1,
-        contentFingerprint: buildPilotTaskDefinition("free-recall").contentFingerprint,
+        ...frozenTaskBinding(coldTask),
       },
       "manifest-p:e05": {
         participantId: "manifest-p",
         predictionTimestamp: "2026-09-02T09:00:00.000Z",
-        taskId: buildPilotTaskDefinition("delayed-free-recall").task.id,
-        taskVersion: 1,
-        contentFingerprint: buildPilotTaskDefinition("delayed-free-recall").contentFingerprint,
+        ...frozenTaskBinding(delayedTask),
       },
     });
     expect(first.causalPolicy.blindBlockFeedbackForbidden).toBe(true);

--- a/benchmarks/native-evidence-v1/run-manifest.test.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.test.ts
@@ -42,6 +42,10 @@ function buildFixture() {
       "manifest-cold": [],
     },
     blindTargetEventIds: [`${participantId}:e05`, "manifest-cold:target"],
+    blindTargetParticipantIdByEventId: {
+      [`${participantId}:e05`]: participantId,
+      "manifest-cold:target": "manifest-cold",
+    },
   });
 
   const store = new SyntheticPilotStore();
@@ -153,6 +157,10 @@ describe("native pilot full synthetic run manifest", () => {
     expect(first.split.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(first.split.trainingParticipantIds).toEqual(["manifest-p"]);
     expect(first.split.heldOutParticipantIds).toEqual(["manifest-cold"]);
+    expect(first.split.blindTargetParticipantIdByEventId).toEqual({
+      "manifest-cold:target": "manifest-cold",
+      "manifest-p:e05": "manifest-p",
+    });
     expect(first.causalPolicy.blindBlockFeedbackForbidden).toBe(true);
     expect(first.featureRows[0]?.predictionBindingDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(first.artifacts.find((artifact) => artifact.artifactId === "result:synthetic")?.participantIds).toEqual([

--- a/benchmarks/native-evidence-v1/run-manifest.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.ts
@@ -220,6 +220,13 @@ export function buildSyntheticNativeRunManifest(input: BuildSyntheticNativeRunMa
         .map(([participantId, eventIds]) => [participantId, Object.freeze([...eventIds].sort())]),
     ),
   );
+  const blindTargetParticipantIdByEventId = Object.freeze(
+    Object.fromEntries(
+      Object.entries(input.protocol.blindTargetParticipantIdByEventId).sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    ),
+  );
   const splitPayload = Object.freeze({
     protocolId: input.protocol.protocolId,
     frozenAt: input.protocol.frozenAt,
@@ -229,6 +236,7 @@ export function buildSyntheticNativeRunManifest(input: BuildSyntheticNativeRunMa
     heldOutParticipantIds: Object.freeze([...input.protocol.heldOutParticipantIds].sort()),
     trainPrefixEventIdsByParticipant,
     blindTargetEventIds: Object.freeze([...input.protocol.blindTargetEventIds].sort()),
+    blindTargetParticipantIdByEventId,
   });
   const split = Object.freeze({ ...splitPayload, digest: digestJson(splitPayload) });
 

--- a/benchmarks/native-evidence-v1/run-manifest.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.ts
@@ -1,0 +1,310 @@
+import crypto from "node:crypto";
+
+import { NATIVE_METRIC_SETTINGS, NATIVE_PREDICTOR_SETTINGS } from "./manifest";
+import type { FrozenNativeSplitProtocol } from "./protocol";
+import type {
+  PilotTaskDefinition,
+  PredictionFeatureRow,
+  SyntheticArtifactRecord,
+} from "./types";
+import {
+  NATIVE_PILOT_CONTRACT_ID,
+  NATIVE_PREDICTOR_CONTRACT_ID,
+  SYNTHETIC_ONLY_STATUS,
+} from "./types";
+
+export const NATIVE_DECISION_RULE_ID = "nep.native-decision.v1" as const;
+
+export const NATIVE_FEATURE_AUDIT_POLICY = Object.freeze({
+  acceptedHistory: "reference-evidence-only",
+  b2: "strong-causal-history",
+  b2Basis: "deterministic-projector-basis-from-b2-counts",
+  b3: "projectLearnerState-over-the-same-accepted-history",
+  missingNumeric: "explicit-indicator",
+  categoricalVocabulary: "prospective-task-matrix-plus-unknown",
+  trainConstantColumns: "drop",
+  exactDuplicateColumns: "drop-stable-name-order-b2-preferred",
+  fitScope: "TRAIN-only",
+});
+
+export const NATIVE_SOURCE_RIGHTS = Object.freeze([
+  Object.freeze({
+    id: "core-frontier",
+    revision: "ef42f2cf96f9aa079505ad73c83c0555a470bfab",
+    role: "canonical-core-contract-donor",
+    rights: "repository-owned",
+  }),
+  Object.freeze({
+    id: "native-spec-amendment",
+    revision: "34013121cb9ab6850d15fa09a06ed3a46da44486",
+    role: "reviewed-experiment-contract",
+    rights: "repository-owned",
+  }),
+  Object.freeze({
+    id: "slam-benchmark-donor",
+    revision: "490fbcd0fcfbf161a475a17463445410ef67e99e",
+    role: "manifest-statistics-pattern-donor-only",
+    rights: "repository-owned-derived-code",
+  }),
+  Object.freeze({
+    id: "scikit-learn",
+    revision: "f159b78dc59f250cdde8fe391a21f0bc871960ad",
+    role: "common-logistic-estimator",
+    rights: "BSD-3-Clause",
+  }),
+  Object.freeze({
+    id: "pyBKT",
+    revision: "06fc180ae72c117458acc527f8ec90cc8e0581c1",
+    role: "conditional-classical-comparator",
+    rights: "MIT",
+  }),
+] as const);
+
+export type SyntheticPredictorLane =
+  | "b0-native"
+  | "b2-native"
+  | "b2-basis-native"
+  | "b3-native"
+  | "bkt-native";
+
+export type SyntheticPredictorArtifactBinding = {
+  readonly lane: SyntheticPredictorLane;
+  readonly availability: "available" | "not-estimable" | "not-run";
+  readonly specFingerprint: `sha256:${string}` | null;
+  readonly transformFingerprint: `sha256:${string}` | null;
+  readonly fittedModelFingerprint: `sha256:${string}` | null;
+  readonly predictionFingerprint: `sha256:${string}` | null;
+  readonly nonEstimabilityReason: string | null;
+};
+
+export type SyntheticCoverageSummary = {
+  readonly eligibleOpportunityCount: number;
+  readonly observedOutcomeCount: number;
+  readonly emittedPredictionCount: number;
+  readonly acceptedHistoryEventCount: number;
+  readonly rejectedHistoryEventCount: number;
+  readonly learnerCount: number;
+  readonly attemptCount: number;
+};
+
+export type SyntheticBktRunBinding = {
+  readonly diagnosticsArtifactDigest: `sha256:${string}` | null;
+  readonly diagnosticsUnavailableReason: string | null;
+  readonly convergenceAssurance: "convergence-observed" | "convergence-unverified" | "not-run";
+  readonly stabilityAssurance:
+    | "unresolved-pending-reviewed-train-only-tolerances"
+    | "reviewed"
+    | "not-run";
+};
+
+export type BuildSyntheticNativeRunManifestInput = {
+  readonly tasks: readonly PilotTaskDefinition[];
+  readonly rows: readonly PredictionFeatureRow[];
+  readonly protocol: FrozenNativeSplitProtocol;
+  readonly artifacts: readonly SyntheticArtifactRecord[];
+  readonly predictorArtifacts: readonly SyntheticPredictorArtifactBinding[];
+  readonly coverage: SyntheticCoverageSummary;
+  readonly bkt: SyntheticBktRunBinding;
+};
+
+function digestJson(value: unknown): `sha256:${string}` {
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex")}`;
+}
+
+function assertNonnegativeInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a nonnegative integer`);
+  }
+}
+
+function validateCoverage(coverage: SyntheticCoverageSummary): void {
+  for (const [field, value] of Object.entries(coverage)) {
+    assertNonnegativeInteger(value, `coverage.${field}`);
+  }
+  if (coverage.observedOutcomeCount > coverage.eligibleOpportunityCount) {
+    throw new Error("coverage.observedOutcomeCount cannot exceed eligibleOpportunityCount");
+  }
+  if (coverage.emittedPredictionCount > coverage.eligibleOpportunityCount) {
+    throw new Error("coverage.emittedPredictionCount cannot exceed eligibleOpportunityCount");
+  }
+}
+
+function freezePredictorArtifacts(
+  bindings: readonly SyntheticPredictorArtifactBinding[],
+): readonly SyntheticPredictorArtifactBinding[] {
+  const expected: readonly SyntheticPredictorLane[] = [
+    "b0-native",
+    "b2-native",
+    "b2-basis-native",
+    "b3-native",
+    "bkt-native",
+  ];
+  const byLane = new Map(bindings.map((binding) => [binding.lane, binding]));
+  if (byLane.size !== bindings.length) {
+    throw new Error("predictorArtifacts must contain unique lanes");
+  }
+  for (const lane of expected) {
+    if (!byLane.has(lane)) throw new Error(`predictorArtifacts missing lane: ${lane}`);
+  }
+  for (const binding of bindings) {
+    if (binding.availability === "not-estimable" && !binding.nonEstimabilityReason) {
+      throw new Error(`not-estimable lane must record a reason: ${binding.lane}`);
+    }
+    if (binding.availability !== "not-estimable" && binding.nonEstimabilityReason) {
+      throw new Error(`only not-estimable lanes may record nonEstimabilityReason: ${binding.lane}`);
+    }
+  }
+  return Object.freeze(
+    bindings
+      .map((binding) => Object.freeze({ ...binding }))
+      .sort((left, right) => left.lane.localeCompare(right.lane)),
+  );
+}
+
+function freezeBkt(binding: SyntheticBktRunBinding): SyntheticBktRunBinding {
+  if (binding.diagnosticsArtifactDigest === null && !binding.diagnosticsUnavailableReason) {
+    throw new Error("missing BKT diagnostics digest requires diagnosticsUnavailableReason");
+  }
+  if (binding.diagnosticsArtifactDigest !== null && binding.diagnosticsUnavailableReason !== null) {
+    throw new Error("BKT diagnostics reason must be null when a digest is present");
+  }
+  return Object.freeze({ ...binding });
+}
+
+export function buildSyntheticNativeRunManifest(input: BuildSyntheticNativeRunManifestInput) {
+  validateCoverage(input.coverage);
+  const predictorArtifacts = freezePredictorArtifacts(input.predictorArtifacts);
+  const bkt = freezeBkt(input.bkt);
+
+  const taskDefinitions = Object.freeze(
+    input.tasks
+      .map((definition) =>
+        Object.freeze({
+          family: definition.family,
+          taskId: definition.task.id,
+          taskVersion: definition.task.version,
+          contentFingerprint: definition.contentFingerprint,
+          contextId: definition.contextId,
+          stimulusFormGroup: definition.stimulusFormGroup,
+        }),
+      )
+      .sort((left, right) => left.taskId.localeCompare(right.taskId)),
+  );
+
+  const featureRows = Object.freeze(
+    input.rows
+      .map((row) => {
+        const featureDigest = digestJson({ b2: row.b2, b2Basis: row.b2Basis, b3: row.b3 });
+        return Object.freeze({
+          participantId: row.participantId,
+          targetEventId: row.targetEventId,
+          predictionTimestamp: row.predictionTimestamp,
+          acceptedHistoryEventIds: Object.freeze([...row.acceptedHistoryEventIds]),
+          featureDigest,
+          predictionBindingDigest: digestJson({
+            participantId: row.participantId,
+            targetEventId: row.targetEventId,
+            predictionTimestamp: row.predictionTimestamp,
+            acceptedHistoryEventIds: row.acceptedHistoryEventIds,
+            featureDigest,
+          }),
+        });
+      })
+      .sort((left, right) => left.targetEventId.localeCompare(right.targetEventId)),
+  );
+
+  const trainPrefixEventIdsByParticipant = Object.freeze(
+    Object.fromEntries(
+      Object.entries(input.protocol.trainPrefixEventIdsByParticipant)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([participantId, eventIds]) => [participantId, Object.freeze([...eventIds].sort())]),
+    ),
+  );
+  const splitPayload = Object.freeze({
+    protocolId: input.protocol.protocolId,
+    frozenAt: input.protocol.frozenAt,
+    fitCutoff: input.protocol.fitCutoff,
+    fitCompletedAt: input.protocol.fitCompletedAt,
+    trainingParticipantIds: Object.freeze([...input.protocol.trainingParticipantIds].sort()),
+    heldOutParticipantIds: Object.freeze([...input.protocol.heldOutParticipantIds].sort()),
+    trainPrefixEventIdsByParticipant,
+    blindTargetEventIds: Object.freeze([...input.protocol.blindTargetEventIds].sort()),
+  });
+  const split = Object.freeze({ ...splitPayload, digest: digestJson(splitPayload) });
+
+  const artifacts = Object.freeze(
+    input.artifacts
+      .map((artifact) =>
+        Object.freeze({
+          ...artifact,
+          participantIds: Object.freeze([...artifact.participantIds].sort()),
+          dependsOnArtifactIds: Object.freeze([...artifact.dependsOnArtifactIds].sort()),
+        }),
+      )
+      .sort((left, right) => left.artifactId.localeCompare(right.artifactId)),
+  );
+
+  const payload = Object.freeze({
+    status: SYNTHETIC_ONLY_STATUS,
+    purpose: "full-synthetic-run-binding" as const,
+    pilotContractId: NATIVE_PILOT_CONTRACT_ID,
+    predictorContractId: NATIVE_PREDICTOR_CONTRACT_ID,
+    decisionRuleId: NATIVE_DECISION_RULE_ID,
+    dataPolicy: Object.freeze({
+      source: "synthetic-only" as const,
+      humanDataIncluded: false as const,
+      externalCorpusRowsIncluded: false as const,
+      redistributionDecision: "not-applicable" as const,
+    }),
+    sourceRights: NATIVE_SOURCE_RIGHTS,
+    predictor: NATIVE_PREDICTOR_SETTINGS,
+    metrics: NATIVE_METRIC_SETTINGS,
+    featureAuditPolicy: NATIVE_FEATURE_AUDIT_POLICY,
+    causalPolicy: Object.freeze({
+      currentOutcomeForbidden: true as const,
+      futureOutcomeForbidden: true as const,
+      strictOccurredBeforePrediction: true as const,
+      strictAvailableBeforePrediction: true as const,
+      equalTimestampExcluded: true as const,
+      trainOnlyTransforms: true as const,
+      blindBlockFeedbackForbidden: true as const,
+    }),
+    utilityGate: Object.freeze({
+      status: "unresolved" as const,
+      deltaHistory: null,
+      deltaBasis: null,
+      justificationArtifactDigest: null,
+      predictiveKeepSimplifyEnabled: false as const,
+    }),
+    split,
+    taskDefinitions,
+    featureRows,
+    predictorArtifacts,
+    artifacts,
+    coverage: Object.freeze({ ...input.coverage }),
+    contrasts: Object.freeze({
+      b3MinusB2: null,
+      b3MinusB2Basis: null,
+      reason: "synthetic-data-cannot-rank-models" as const,
+    }),
+    attribution: "unresolved-synthetic-only" as const,
+    bkt,
+    decision: Object.freeze({
+      status: "disabled-synthetic-only" as const,
+      reason: "no-human-outcomes-and-utility-margins-unresolved" as const,
+    }),
+    forbiddenClaims: Object.freeze([
+      "learner-model-validity",
+      "predictive-superiority",
+      "learning-efficacy",
+      "retention-validity",
+      "transfer-validity",
+      "mastery",
+      "CEFR",
+      "calibrated",
+      "production-authority",
+    ]),
+  });
+
+  return Object.freeze({ ...payload, manifestDigest: digestJson(payload) });
+}

--- a/benchmarks/native-evidence-v1/run-manifest.ts
+++ b/benchmarks/native-evidence-v1/run-manifest.ts
@@ -220,11 +220,11 @@ export function buildSyntheticNativeRunManifest(input: BuildSyntheticNativeRunMa
         .map(([participantId, eventIds]) => [participantId, Object.freeze([...eventIds].sort())]),
     ),
   );
-  const blindTargetParticipantIdByEventId = Object.freeze(
+  const blindTargetBindings = Object.freeze(
     Object.fromEntries(
-      Object.entries(input.protocol.blindTargetParticipantIdByEventId).sort(([left], [right]) =>
-        left.localeCompare(right),
-      ),
+      Object.entries(input.protocol.blindTargetBindings)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([targetEventId, binding]) => [targetEventId, Object.freeze({ ...binding })]),
     ),
   );
   const splitPayload = Object.freeze({
@@ -236,7 +236,7 @@ export function buildSyntheticNativeRunManifest(input: BuildSyntheticNativeRunMa
     heldOutParticipantIds: Object.freeze([...input.protocol.heldOutParticipantIds].sort()),
     trainPrefixEventIdsByParticipant,
     blindTargetEventIds: Object.freeze([...input.protocol.blindTargetEventIds].sort()),
-    blindTargetParticipantIdByEventId,
+    blindTargetBindings,
   });
   const split = Object.freeze({ ...splitPayload, digest: digestJson(splitPayload) });
 

--- a/benchmarks/native-evidence-v1/scripts/__init__.py
+++ b/benchmarks/native-evidence-v1/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Research-only N2 predictor plumbing for the Nếp native evidence pilot."""

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from hashlib import sha256
+from importlib.metadata import version as package_version
+import inspect
+import json
+from pathlib import Path
+from threading import Lock
 from typing import Sequence
 
 import numpy as np
 import pandas as pd
+from pyBKT.fit import EM_fit, E_step
 from pyBKT.models import Model
 
 PYBKT_SOURCE_REVISION = "06fc180ae72c117458acc527f8ec90cc8e0581c1"
@@ -20,6 +27,23 @@ BKT_DEFAULTS = {
 }
 
 REQUIRED_COLUMNS = ("order_id", "skill_name", "correct", "user_id")
+_OBSERVER_LOCK = Lock()
+
+
+@dataclass(frozen=True)
+class BktBackendInspection:
+    source_revision: str
+    package_version: str
+    backend_kind: str
+    model_source_path: str
+    em_source_path: str
+    e_step_source_path: str
+    model_source_sha256: str | None
+    em_source_sha256: str | None
+    e_step_source_sha256: str | None
+    effective_em_tolerance: float | None
+    effective_em_max_iterations: int | None
+    tolerance_comparison: str
 
 
 @dataclass(frozen=True)
@@ -32,6 +56,33 @@ class BktComparatorMetadata:
     forgets: bool
     backend_default_num_fits: int
     backend_default_forgets: bool
+    model_type: tuple[bool, ...]
+    parameterization: str
+    backend: BktBackendInspection
+
+
+@dataclass(frozen=True)
+class BktStartDiagnostic:
+    start_index: int
+    iteration_count: int
+    final_log_likelihood: float
+    final_delta: float | None
+    finite_likelihood_trace: bool
+    stopping_reason: str
+    initial_parameter_fingerprint: str
+    final_parameter_fingerprint: str
+
+
+@dataclass(frozen=True)
+class BktDiagnosticRun:
+    backend: BktBackendInspection
+    starts: tuple[BktStartDiagnostic, ...]
+    selected_start_index: int | None
+    parity_parameters_equal: bool
+    parity_predictions_equal: bool
+    selected_predictions_finite: bool
+    convergence_assurance: str
+    stability_assurance: str
 
 
 @dataclass
@@ -51,6 +102,75 @@ class FrozenBktComparator:
 
     def fitted_parameters(self) -> pd.DataFrame:
         return self.model.params().copy()
+
+
+def _sha256_file(path: str) -> str | None:
+    if not path:
+        return None
+    try:
+        return sha256(Path(path).read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _resolve_effective_em_defaults(source: str) -> tuple[float | None, int | None, str]:
+    signature = inspect.signature(EM_fit.EM_fit)
+    tolerance_default = signature.parameters["tol"].default
+    maxiter_default = signature.parameters["maxiter"].default
+
+    tolerance: float | None
+    if isinstance(tolerance_default, (int, float)):
+        tolerance = float(tolerance_default)
+    elif tolerance_default is None and "tol = 1e-3" in source:
+        tolerance = 1e-3
+    elif tolerance_default is None and "tol = 0.005" in source:
+        tolerance = 0.005
+    else:
+        tolerance = None
+
+    max_iterations: int | None
+    if isinstance(maxiter_default, int):
+        max_iterations = maxiter_default
+    elif maxiter_default is None and "maxiter = 100" in source:
+        max_iterations = 100
+    else:
+        max_iterations = None
+
+    if "<= tol" in source:
+        comparison = "<="
+    elif "< tol" in source:
+        comparison = "<"
+    else:
+        comparison = "unknown"
+    return tolerance, max_iterations, comparison
+
+
+def inspect_installed_bkt_backend() -> BktBackendInspection:
+    installed_version = package_version("pyBKT")
+    model_source_path = inspect.getsourcefile(Model) or ""
+    em_source_path = inspect.getsourcefile(EM_fit.EM_fit) or ""
+    e_step_source_path = str(getattr(E_step, "__file__", "") or "")
+    em_source = inspect.getsource(EM_fit.EM_fit)
+    tolerance, max_iterations, comparison = _resolve_effective_em_defaults(em_source)
+
+    suffix = Path(e_step_source_path).suffix.lower()
+    compiled_suffixes = {".so", ".pyd", ".dll", ".dylib"}
+    backend_kind = "compiled-e-step" if suffix in compiled_suffixes else "python-e-step"
+
+    return BktBackendInspection(
+        source_revision=PYBKT_SOURCE_REVISION,
+        package_version=installed_version,
+        backend_kind=backend_kind,
+        model_source_path=model_source_path,
+        em_source_path=em_source_path,
+        e_step_source_path=e_step_source_path,
+        model_source_sha256=_sha256_file(model_source_path),
+        em_source_sha256=_sha256_file(em_source_path),
+        e_step_source_sha256=_sha256_file(e_step_source_path),
+        effective_em_tolerance=tolerance,
+        effective_em_max_iterations=max_iterations,
+        tolerance_comparison=comparison,
+    )
 
 
 def validate_bkt_frame(data: pd.DataFrame) -> pd.DataFrame:
@@ -79,20 +199,176 @@ def validate_bkt_frame(data: pd.DataFrame) -> pd.DataFrame:
 
 def fit_source_faithful_bkt(train_data: pd.DataFrame) -> FrozenBktComparator:
     frame = validate_bkt_frame(train_data)
+    backend = inspect_installed_bkt_backend()
+    if backend.package_version != PYBKT_PACKAGE_VERSION:
+        raise RuntimeError(
+            f"pyBKT package version mismatch: expected {PYBKT_PACKAGE_VERSION}, got {backend.package_version}"
+        )
+
     model = Model(seed=PYBKT_SEED, num_fits=PYBKT_NUM_FITS, parallel=False)
     model.fit(data=frame, defaults=BKT_DEFAULTS, forgets=False)
+    model_type = tuple(bool(value) for value in model.model_type)
+    if any(model_type):
+        raise RuntimeError("BKT-native must remain the pooled four-parameter model without variants")
 
     metadata = BktComparatorMetadata(
         source_revision=PYBKT_SOURCE_REVISION,
-        package_version=PYBKT_PACKAGE_VERSION,
+        package_version=backend.package_version,
         seed=PYBKT_SEED,
         num_fits=PYBKT_NUM_FITS,
         parallel=False,
         forgets=False,
         backend_default_num_fits=int(Model.DEFAULTS["num_fits"]),
         backend_default_forgets=bool(Model.DEFAULTS["forgets"]),
+        model_type=model_type,
+        parameterization="prior-learn-guess-slip-no-forgetting",
+        backend=backend,
     )
     return FrozenBktComparator(model=model, metadata=metadata)
+
+
+def _parameter_fingerprint(model: dict[str, object]) -> str:
+    payload: dict[str, object] = {}
+    for name in ("prior", "learns", "guesses", "slips", "forgets"):
+        value = model.get(name)
+        if isinstance(value, np.ndarray):
+            payload[name] = np.asarray(value, dtype=np.float64).reshape(-1).tolist()
+        elif isinstance(value, (int, float, np.floating, np.integer)):
+            payload[name] = float(value)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return f"sha256:{sha256(encoded).hexdigest()}"
+
+
+def _stopping_reason(
+    trace: np.ndarray,
+    backend: BktBackendInspection,
+) -> tuple[float | None, str]:
+    flat = np.asarray(trace, dtype=np.float64).reshape(-1)
+    if flat.size == 0 or not np.all(np.isfinite(flat)):
+        return None, "nonfinite-likelihood"
+
+    final_delta = None if flat.size < 2 else float(abs(flat[-1] - flat[-2]))
+    if backend.effective_em_max_iterations is not None and flat.size >= backend.effective_em_max_iterations:
+        return final_delta, "max-iterations"
+
+    tolerance = backend.effective_em_tolerance
+    if tolerance is not None and final_delta is not None and flat.size >= 3:
+        passed = final_delta <= tolerance if backend.tolerance_comparison == "<=" else final_delta < tolerance
+        if passed:
+            return final_delta, "backend-tolerance"
+    return final_delta, "backend-returned-early-unclassified"
+
+
+def _selected_start_index(starts: Sequence[BktStartDiagnostic]) -> int | None:
+    best_index: int | None = None
+    best_likelihood = float("-inf")
+    for start in starts:
+        if start.final_log_likelihood > best_likelihood:
+            best_likelihood = start.final_log_likelihood
+            best_index = start.start_index
+    return best_index
+
+
+def _parameters_equal(left: pd.DataFrame, right: pd.DataFrame) -> bool:
+    left_sorted = left.sort_index()
+    right_sorted = right.sort_index()
+    if not left_sorted.index.equals(right_sorted.index):
+        return False
+    if list(left_sorted.columns) != list(right_sorted.columns):
+        return False
+    try:
+        return bool(
+            np.allclose(
+                left_sorted.to_numpy(dtype=np.float64),
+                right_sorted.to_numpy(dtype=np.float64),
+                atol=1e-12,
+                rtol=1e-12,
+            )
+        )
+    except (TypeError, ValueError):
+        return left_sorted.equals(right_sorted)
+
+
+def fit_bkt_with_diagnostics(
+    train_data: pd.DataFrame,
+    *,
+    parity_data: pd.DataFrame | None = None,
+) -> BktDiagnosticRun:
+    """Observe the pinned EM traces without changing initialization, EM, selection, or prediction.
+
+    This observer is diagnostic only. A parity failure makes the observer untrustworthy; it must not
+    make the untouched source-faithful comparator unavailable.
+    """
+
+    frame = validate_bkt_frame(train_data)
+    parity_frame = frame if parity_data is None else validate_bkt_frame(parity_data)
+    backend = inspect_installed_bkt_backend()
+    starts: list[BktStartDiagnostic] = []
+
+    with _OBSERVER_LOCK:
+        original_em_fit = EM_fit.EM_fit
+
+        def observed_em_fit(model: dict[str, object], data: dict[str, object], *args: object, **kwargs: object):
+            initial_fingerprint = _parameter_fingerprint(model)
+            fitted_model, trace = original_em_fit(model, data, *args, **kwargs)
+            flat = np.asarray(trace, dtype=np.float64).reshape(-1)
+            final_delta, stopping_reason = _stopping_reason(flat, backend)
+            final_log_likelihood = float(flat[-1]) if flat.size else float("nan")
+            starts.append(
+                BktStartDiagnostic(
+                    start_index=len(starts),
+                    iteration_count=int(flat.size),
+                    final_log_likelihood=final_log_likelihood,
+                    final_delta=final_delta,
+                    finite_likelihood_trace=bool(flat.size > 0 and np.all(np.isfinite(flat))),
+                    stopping_reason=stopping_reason,
+                    initial_parameter_fingerprint=initial_fingerprint,
+                    final_parameter_fingerprint=_parameter_fingerprint(fitted_model),
+                )
+            )
+            return fitted_model, trace
+
+        EM_fit.EM_fit = observed_em_fit
+        try:
+            instrumented = fit_source_faithful_bkt(frame)
+        finally:
+            EM_fit.EM_fit = original_em_fit
+
+    untouched = fit_source_faithful_bkt(frame)
+    instrumented_predictions = instrumented.predict_error_probabilities(parity_frame)
+    untouched_predictions = untouched.predict_error_probabilities(parity_frame)
+    parity_predictions_equal = bool(
+        np.allclose(instrumented_predictions, untouched_predictions, atol=1e-12, rtol=1e-12)
+    )
+    parity_parameters_equal = _parameters_equal(
+        instrumented.fitted_parameters(),
+        untouched.fitted_parameters(),
+    )
+    selected_predictions_finite = bool(
+        np.all(np.isfinite(instrumented_predictions))
+        and np.all((instrumented_predictions >= 0) & (instrumented_predictions <= 1))
+    )
+
+    tolerance_starts = sum(
+        1
+        for start in starts
+        if start.finite_likelihood_trace and start.stopping_reason == "backend-tolerance"
+    )
+    if parity_parameters_equal and parity_predictions_equal and selected_predictions_finite and tolerance_starts >= 2:
+        convergence_assurance = "convergence-observed"
+    else:
+        convergence_assurance = "convergence-unverified"
+
+    return BktDiagnosticRun(
+        backend=backend,
+        starts=tuple(starts),
+        selected_start_index=_selected_start_index(starts),
+        parity_parameters_equal=parity_parameters_equal,
+        parity_predictions_equal=parity_predictions_equal,
+        selected_predictions_finite=selected_predictions_finite,
+        convergence_assurance=convergence_assurance,
+        stability_assurance="unresolved-pending-reviewed-train-only-tolerances",
+    )
 
 
 def build_bkt_frame(

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from pyBKT.models import Model
+
+PYBKT_SOURCE_REVISION = "06fc180ae72c117458acc527f8ec90cc8e0581c1"
+PYBKT_PACKAGE_VERSION = "1.4.3"
+PYBKT_SEED = 143
+PYBKT_NUM_FITS = 5
+
+BKT_DEFAULTS = {
+    "order_id": "order_id",
+    "skill_name": "skill_name",
+    "correct": "correct",
+    "user_id": "user_id",
+}
+
+REQUIRED_COLUMNS = ("order_id", "skill_name", "correct", "user_id")
+
+
+@dataclass(frozen=True)
+class BktComparatorMetadata:
+    source_revision: str
+    package_version: str
+    seed: int
+    num_fits: int
+    parallel: bool
+    forgets: bool
+    backend_default_num_fits: int
+    backend_default_forgets: bool
+
+
+@dataclass
+class FrozenBktComparator:
+    model: Model
+    metadata: BktComparatorMetadata
+
+    def predict_error_probabilities(self, causal_sequence: pd.DataFrame) -> np.ndarray:
+        frame = validate_bkt_frame(causal_sequence)
+        predicted = self.model.predict(data=frame.copy())
+        if "correct_predictions" not in predicted.columns:
+            raise RuntimeError("pyBKT prediction frame omitted correct_predictions")
+        correct = predicted["correct_predictions"].to_numpy(dtype=np.float64, copy=True)
+        if not np.all(np.isfinite(correct)) or np.any(correct < 0) or np.any(correct > 1):
+            raise RuntimeError("pyBKT emitted invalid correctness probabilities")
+        return 1.0 - correct
+
+    def fitted_parameters(self) -> pd.DataFrame:
+        return self.model.params().copy()
+
+
+def validate_bkt_frame(data: pd.DataFrame) -> pd.DataFrame:
+    missing = [column for column in REQUIRED_COLUMNS if column not in data.columns]
+    if missing:
+        raise ValueError(f"pyBKT frame missing required columns: {missing}")
+    if data.empty:
+        raise ValueError("pyBKT frame must not be empty")
+
+    frame = data.copy()
+    correctness = frame["correct"].tolist()
+    if any(value not in (0, 1) for value in correctness):
+        raise ValueError("pyBKT correctness must be binary 0/1 for this comparator")
+    if frame["user_id"].isna().any() or frame["skill_name"].isna().any():
+        raise ValueError("pyBKT user_id and skill_name must be observed")
+
+    for _, learner_frame in frame.groupby("user_id", sort=False):
+        order = learner_frame["order_id"].tolist()
+        if order != sorted(order):
+            raise ValueError("pyBKT order_id must be monotone within learner")
+        if len(order) != len(set(order)):
+            raise ValueError("pyBKT order_id must be unique within learner")
+
+    return frame
+
+
+def fit_source_faithful_bkt(train_data: pd.DataFrame) -> FrozenBktComparator:
+    frame = validate_bkt_frame(train_data)
+    model = Model(seed=PYBKT_SEED, num_fits=PYBKT_NUM_FITS, parallel=False)
+    model.fit(data=frame, defaults=BKT_DEFAULTS, forgets=False)
+
+    metadata = BktComparatorMetadata(
+        source_revision=PYBKT_SOURCE_REVISION,
+        package_version=PYBKT_PACKAGE_VERSION,
+        seed=PYBKT_SEED,
+        num_fits=PYBKT_NUM_FITS,
+        parallel=False,
+        forgets=False,
+        backend_default_num_fits=int(Model.DEFAULTS["num_fits"]),
+        backend_default_forgets=bool(Model.DEFAULTS["forgets"]),
+    )
+    return FrozenBktComparator(model=model, metadata=metadata)
+
+
+def build_bkt_frame(
+    *,
+    participant_ids: Sequence[str],
+    correctness: Sequence[int],
+    skill_name: str = "present-subject-verb-agreement",
+) -> pd.DataFrame:
+    if len(participant_ids) != len(correctness):
+        raise ValueError("participant_ids and correctness must have equal length")
+    next_order: dict[str, int] = {}
+    rows: list[dict[str, object]] = []
+    for participant_id, correct in zip(participant_ids, correctness, strict=True):
+        order_id = next_order.get(participant_id, 0)
+        next_order[participant_id] = order_id + 1
+        rows.append(
+            {
+                "order_id": order_id,
+                "skill_name": skill_name,
+                "correct": correct,
+                "user_id": participant_id,
+            }
+        )
+    return validate_bkt_frame(pd.DataFrame(rows))

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from hashlib import sha256
 import importlib.util
@@ -75,10 +76,21 @@ class BktStartDiagnostic:
 
 
 @dataclass(frozen=True)
+class BktStartPredictionComparison:
+    start_index: int
+    final_log_likelihood_gap_from_selected: float
+    final_log_likelihood_gap_per_observation: float
+    mean_abs_error_probability_difference_from_selected: float
+    max_abs_error_probability_difference_from_selected: float
+
+
+@dataclass(frozen=True)
 class BktDiagnosticRun:
     backend: BktBackendInspection
     starts: tuple[BktStartDiagnostic, ...]
     selected_start_index: int | None
+    start_prediction_comparisons: tuple[BktStartPredictionComparison, ...]
+    selected_start_prediction_matches_public: bool
     parity_parameters_equal: bool
     parity_predictions_equal: bool
     selected_predictions_finite: bool
@@ -303,6 +315,85 @@ def _parameters_equal(left: pd.DataFrame, right: pd.DataFrame) -> bool:
         return left_sorted.equals(right_sorted)
 
 
+def _finalize_observed_start_model(
+    raw_model: dict[str, object],
+    selected_model: dict[str, object],
+) -> dict[str, object]:
+    finalized = deepcopy(raw_model)
+    transitions = np.asarray(finalized["As"], dtype=np.float64)
+    prior = np.asarray(finalized["pi_0"], dtype=np.float64)
+    finalized["learns"] = transitions[:, 1, 0].copy()
+    finalized["forgets"] = transitions[:, 0, 1].copy()
+    finalized["prior"] = float(prior[1][0])
+    finalized["resource_names"] = deepcopy(selected_model["resource_names"])
+    finalized["gs_names"] = deepcopy(selected_model["gs_names"])
+    return finalized
+
+
+def _predict_observed_start(
+    comparator: FrozenBktComparator,
+    raw_model: dict[str, object],
+    causal_sequence: pd.DataFrame,
+) -> np.ndarray:
+    fitted = comparator.model.fit_model
+    if not isinstance(fitted, dict) or len(fitted) != 1:
+        raise RuntimeError("BKT-native stability observer expects exactly one fitted skill")
+    skill = next(iter(fitted))
+    selected_model = fitted[skill]
+    if not isinstance(selected_model, dict):
+        raise RuntimeError("BKT-native selected model has unexpected shape")
+
+    replay_model = deepcopy(comparator.model)
+    replay_model.fit_model = {
+        skill: _finalize_observed_start_model(raw_model, selected_model),
+    }
+    replay = FrozenBktComparator(model=replay_model, metadata=comparator.metadata)
+    return replay.predict_error_probabilities(causal_sequence)
+
+
+def _compare_start_predictions(
+    comparator: FrozenBktComparator,
+    captured_models: Sequence[dict[str, object]],
+    starts: Sequence[BktStartDiagnostic],
+    selected_start_index: int | None,
+    parity_frame: pd.DataFrame,
+) -> tuple[tuple[BktStartPredictionComparison, ...], bool]:
+    if selected_start_index is None or len(captured_models) != len(starts):
+        return tuple(), False
+
+    public_predictions = comparator.predict_error_probabilities(parity_frame)
+    selected_predictions = _predict_observed_start(
+        comparator,
+        captured_models[selected_start_index],
+        parity_frame,
+    )
+    selected_matches_public = bool(
+        np.allclose(selected_predictions, public_predictions, atol=1e-12, rtol=1e-12)
+    )
+    selected_likelihood = starts[selected_start_index].final_log_likelihood
+    observation_count = len(parity_frame)
+
+    comparisons: list[BktStartPredictionComparison] = []
+    for start, raw_model in zip(starts, captured_models, strict=True):
+        predictions = _predict_observed_start(comparator, raw_model, parity_frame)
+        absolute_difference = np.abs(predictions - selected_predictions)
+        likelihood_gap = selected_likelihood - start.final_log_likelihood
+        comparisons.append(
+            BktStartPredictionComparison(
+                start_index=start.start_index,
+                final_log_likelihood_gap_from_selected=float(likelihood_gap),
+                final_log_likelihood_gap_per_observation=float(likelihood_gap / observation_count),
+                mean_abs_error_probability_difference_from_selected=float(
+                    np.mean(absolute_difference)
+                ),
+                max_abs_error_probability_difference_from_selected=float(
+                    np.max(absolute_difference)
+                ),
+            )
+        )
+    return tuple(comparisons), selected_matches_public
+
+
 def fit_bkt_with_diagnostics(
     train_data: pd.DataFrame,
     *,
@@ -310,14 +401,16 @@ def fit_bkt_with_diagnostics(
 ) -> BktDiagnosticRun:
     """Observe the pinned EM traces without changing initialization, EM, selection, or prediction.
 
-    This observer is diagnostic only. A parity failure makes the observer untrustworthy; it must not
-    make the untouched source-faithful comparator unavailable.
+    `parity_data` is a TRAIN-only numerical replay surface, not an evaluation set. The observer is
+    diagnostic only. A parity failure makes the observer untrustworthy; it must not make the
+    untouched source-faithful comparator unavailable.
     """
 
     frame = validate_bkt_frame(train_data)
     parity_frame = frame if parity_data is None else validate_bkt_frame(parity_data)
     backend = inspect_installed_bkt_backend()
     starts: list[BktStartDiagnostic] = []
+    captured_models: list[dict[str, object]] = []
 
     with _OBSERVER_LOCK:
         original_em_fit = EM_fit.EM_fit
@@ -325,6 +418,7 @@ def fit_bkt_with_diagnostics(
         def observed_em_fit(model: dict[str, object], data: dict[str, object], *args: object, **kwargs: object):
             initial_fingerprint = _parameter_fingerprint(model)
             fitted_model, trace = original_em_fit(model, data, *args, **kwargs)
+            captured_models.append(deepcopy(fitted_model))
             flat = np.asarray(trace, dtype=np.float64).reshape(-1)
             final_delta, stopping_reason = _stopping_reason(flat, backend)
             final_log_likelihood = float(flat[-1]) if flat.size else float("nan")
@@ -362,13 +456,27 @@ def fit_bkt_with_diagnostics(
         np.all(np.isfinite(instrumented_predictions))
         and np.all((instrumented_predictions >= 0) & (instrumented_predictions <= 1))
     )
+    selected_start_index = _selected_start_index(starts)
+    start_prediction_comparisons, selected_start_prediction_matches_public = _compare_start_predictions(
+        instrumented,
+        captured_models,
+        starts,
+        selected_start_index,
+        parity_frame,
+    )
 
     tolerance_starts = sum(
         1
         for start in starts
         if start.finite_likelihood_trace and start.stopping_reason == "backend-tolerance"
     )
-    if parity_parameters_equal and parity_predictions_equal and selected_predictions_finite and tolerance_starts >= 2:
+    if (
+        parity_parameters_equal
+        and parity_predictions_equal
+        and selected_predictions_finite
+        and selected_start_prediction_matches_public
+        and tolerance_starts >= 2
+    ):
         convergence_assurance = "convergence-observed"
     else:
         convergence_assurance = "convergence-unverified"
@@ -376,7 +484,9 @@ def fit_bkt_with_diagnostics(
     return BktDiagnosticRun(
         backend=backend,
         starts=tuple(starts),
-        selected_start_index=_selected_start_index(starts),
+        selected_start_index=selected_start_index,
+        start_prediction_comparisons=start_prediction_comparisons,
+        selected_start_prediction_matches_public=selected_start_prediction_matches_public,
         parity_parameters_equal=parity_parameters_equal,
         parity_predictions_equal=parity_predictions_equal,
         selected_predictions_finite=selected_predictions_finite,

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -116,15 +116,17 @@ def _sha256_file(path: str) -> str | None:
 
 def _resolve_effective_em_defaults(source: str) -> tuple[float | None, int | None, str]:
     signature = inspect.signature(EM_fit.EM_fit)
-    tolerance_default = signature.parameters["tol"].default
-    maxiter_default = signature.parameters["maxiter"].default
+    tolerance_parameter = signature.parameters.get("tol")
+    maxiter_parameter = signature.parameters.get("maxiter")
+    tolerance_default = None if tolerance_parameter is None else tolerance_parameter.default
+    maxiter_default = None if maxiter_parameter is None else maxiter_parameter.default
 
     tolerance: float | None
     if isinstance(tolerance_default, (int, float)):
         tolerance = float(tolerance_default)
-    elif tolerance_default is None and "tol = 1e-3" in source:
+    elif "tol = 1e-3" in source or "tol=1e-3" in source:
         tolerance = 1e-3
-    elif tolerance_default is None and "tol = 0.005" in source:
+    elif "tol = 0.005" in source or "tol=0.005" in source:
         tolerance = 0.005
     else:
         tolerance = None
@@ -132,7 +134,7 @@ def _resolve_effective_em_defaults(source: str) -> tuple[float | None, int | Non
     max_iterations: int | None
     if isinstance(maxiter_default, int):
         max_iterations = maxiter_default
-    elif maxiter_default is None and "maxiter = 100" in source:
+    elif "maxiter = 100" in source or "maxiter=100" in source:
         max_iterations = 100
     else:
         max_iterations = None
@@ -146,12 +148,12 @@ def _resolve_effective_em_defaults(source: str) -> tuple[float | None, int | Non
     return tolerance, max_iterations, comparison
 
 
-def _resolve_e_step_source(em_source: str, em_source_path: str) -> tuple[str, str]:
-    if "E_step.run(" in em_source:
+def _resolve_e_step_source(em_module_source: str, em_source_path: str) -> tuple[str, str]:
+    if "E_step.run(" in em_module_source:
         spec = importlib.util.find_spec("pyBKT.fit.E_step")
         origin = "" if spec is None or spec.origin is None else str(spec.origin)
         return "compiled-e-step", origin
-    if "def run(" in em_source:
+    if "def run(" in em_module_source:
         # The pure-Python package embeds the E-step implementation in EM_fit.py itself.
         return "python-e-step", em_source_path
     return "unknown", ""
@@ -160,10 +162,10 @@ def _resolve_e_step_source(em_source: str, em_source_path: str) -> tuple[str, st
 def inspect_installed_bkt_backend() -> BktBackendInspection:
     installed_version = package_version("pyBKT")
     model_source_path = inspect.getsourcefile(Model) or ""
-    em_source_path = inspect.getsourcefile(EM_fit.EM_fit) or ""
-    em_source = inspect.getsource(EM_fit.EM_fit)
-    tolerance, max_iterations, comparison = _resolve_effective_em_defaults(em_source)
-    backend_kind, e_step_source_path = _resolve_e_step_source(em_source, em_source_path)
+    em_source_path = inspect.getsourcefile(EM_fit) or inspect.getsourcefile(EM_fit.EM_fit) or ""
+    em_module_source = inspect.getsource(EM_fit)
+    tolerance, max_iterations, comparison = _resolve_effective_em_defaults(em_module_source)
+    backend_kind, e_step_source_path = _resolve_e_step_source(em_module_source, em_source_path)
 
     return BktBackendInspection(
         source_revision=PYBKT_SOURCE_REVISION,
@@ -205,12 +207,16 @@ def validate_bkt_frame(data: pd.DataFrame) -> pd.DataFrame:
     return frame
 
 
-def fit_source_faithful_bkt(train_data: pd.DataFrame) -> FrozenBktComparator:
+def fit_source_faithful_bkt(
+    train_data: pd.DataFrame,
+    *,
+    backend: BktBackendInspection | None = None,
+) -> FrozenBktComparator:
     frame = validate_bkt_frame(train_data)
-    backend = inspect_installed_bkt_backend()
-    if backend.package_version != PYBKT_PACKAGE_VERSION:
+    resolved_backend = inspect_installed_bkt_backend() if backend is None else backend
+    if resolved_backend.package_version != PYBKT_PACKAGE_VERSION:
         raise RuntimeError(
-            f"pyBKT package version mismatch: expected {PYBKT_PACKAGE_VERSION}, got {backend.package_version}"
+            f"pyBKT package version mismatch: expected {PYBKT_PACKAGE_VERSION}, got {resolved_backend.package_version}"
         )
 
     model = Model(seed=PYBKT_SEED, num_fits=PYBKT_NUM_FITS, parallel=False)
@@ -221,7 +227,7 @@ def fit_source_faithful_bkt(train_data: pd.DataFrame) -> FrozenBktComparator:
 
     metadata = BktComparatorMetadata(
         source_revision=PYBKT_SOURCE_REVISION,
-        package_version=backend.package_version,
+        package_version=resolved_backend.package_version,
         seed=PYBKT_SEED,
         num_fits=PYBKT_NUM_FITS,
         parallel=False,
@@ -230,7 +236,7 @@ def fit_source_faithful_bkt(train_data: pd.DataFrame) -> FrozenBktComparator:
         backend_default_forgets=bool(Model.DEFAULTS["forgets"]),
         model_type=model_type,
         parameterization="prior-learn-guess-slip-no-forgetting",
-        backend=backend,
+        backend=resolved_backend,
     )
     return FrozenBktComparator(model=model, metadata=metadata)
 
@@ -338,11 +344,11 @@ def fit_bkt_with_diagnostics(
 
         EM_fit.EM_fit = observed_em_fit
         try:
-            instrumented = fit_source_faithful_bkt(frame)
+            instrumented = fit_source_faithful_bkt(frame, backend=backend)
         finally:
             EM_fit.EM_fit = original_em_fit
 
-    untouched = fit_source_faithful_bkt(frame)
+    untouched = fit_source_faithful_bkt(frame, backend=backend)
     instrumented_predictions = instrumented.predict_error_probabilities(parity_frame)
     untouched_predictions = untouched.predict_error_probabilities(parity_frame)
     parity_predictions_equal = bool(

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -104,6 +104,14 @@ class FrozenBktComparator:
     metadata: BktComparatorMetadata
 
     def predict_error_probabilities(self, causal_sequence: pd.DataFrame) -> np.ndarray:
+        """Return source-faithful one-step predictions for a fully observed causal sequence.
+
+        This surface is intended for TRAIN-only diagnostics and replay. Outcomes supplied in earlier
+        rows update pyBKT's state for later rows, so callers MUST NOT pass a blind evaluation block
+        here and then treat every row as pre-outcome. Use `predict_blind_next_error_probability()`
+        for a frozen target whose label must not affect any other target prediction.
+        """
+
         frame = validate_bkt_frame(causal_sequence)
         predicted = self.model.predict(data=frame.copy())
         if "correct_predictions" not in predicted.columns:
@@ -112,6 +120,38 @@ class FrozenBktComparator:
         if not np.all(np.isfinite(correct)) or np.any(correct < 0) or np.any(correct > 1):
             raise RuntimeError("pyBKT emitted invalid correctness probabilities")
         return 1.0 - correct
+
+    def predict_blind_next_error_probability(
+        self,
+        *,
+        participant_id: str,
+        skill_name: str,
+        authorized_history: pd.DataFrame | None = None,
+    ) -> float:
+        """Predict one target without consuming its outcome or another blind-block outcome.
+
+        `authorized_history` contains only outcomes that the frozen protocol permits before this
+        target. The target itself is appended with an internal placeholder outcome because pyBKT's
+        public prediction API requires an observed-row shape; one-step prediction for that target
+        is computed before that placeholder can update state. No target outcome is accepted by this
+        API, which prevents accidental current-label or prior blind-block-label feedback.
+        """
+
+        if not participant_id:
+            raise ValueError("participant_id must be non-empty")
+        if not skill_name:
+            raise ValueError("skill_name must be non-empty")
+        fitted = self.model.fit_model
+        if not isinstance(fitted, dict) or skill_name not in fitted:
+            raise ValueError(f"pyBKT target skill {skill_name!r} is not fitted")
+
+        sequence = _build_blind_prediction_sequence(
+            participant_id=participant_id,
+            skill_name=skill_name,
+            authorized_history=authorized_history,
+        )
+        probabilities = self.predict_error_probabilities(sequence)
+        return float(probabilities[-1])
 
     def fitted_parameters(self) -> pd.DataFrame:
         return self.model.params().copy()
@@ -217,6 +257,42 @@ def validate_bkt_frame(data: pd.DataFrame) -> pd.DataFrame:
             raise ValueError("pyBKT order_id must be unique within learner")
 
     return frame
+
+
+def _build_blind_prediction_sequence(
+    *,
+    participant_id: str,
+    skill_name: str,
+    authorized_history: pd.DataFrame | None,
+) -> pd.DataFrame:
+    if authorized_history is None or authorized_history.empty:
+        history_rows: list[dict[str, object]] = []
+    else:
+        history = validate_bkt_frame(authorized_history)
+        if any(value != participant_id for value in history["user_id"].tolist()):
+            raise ValueError("blind pyBKT history must contain exactly the target participant")
+        if any(value != skill_name for value in history["skill_name"].tolist()):
+            raise ValueError("blind pyBKT history must contain exactly the target skill")
+        history_rows = [
+            {
+                "order_id": index,
+                "skill_name": skill_name,
+                "correct": int(row.correct),
+                "user_id": participant_id,
+            }
+            for index, row in enumerate(history.itertuples(index=False))
+        ]
+
+    rows = [
+        *history_rows,
+        {
+            "order_id": len(history_rows),
+            "skill_name": skill_name,
+            "correct": 0,
+            "user_id": participant_id,
+        },
+    ]
+    return validate_bkt_frame(pd.DataFrame(rows))
 
 
 def fit_source_faithful_bkt(
@@ -357,9 +433,12 @@ def _compare_start_predictions(
     starts: Sequence[BktStartDiagnostic],
     selected_start_index: int | None,
     parity_frame: pd.DataFrame,
+    train_observation_count: int,
 ) -> tuple[tuple[BktStartPredictionComparison, ...], bool]:
     if selected_start_index is None or len(captured_models) != len(starts):
         return tuple(), False
+    if train_observation_count <= 0:
+        raise ValueError("train_observation_count must be positive")
 
     public_predictions = comparator.predict_error_probabilities(parity_frame)
     selected_predictions = _predict_observed_start(
@@ -371,7 +450,6 @@ def _compare_start_predictions(
         np.allclose(selected_predictions, public_predictions, atol=1e-12, rtol=1e-12)
     )
     selected_likelihood = starts[selected_start_index].final_log_likelihood
-    observation_count = len(parity_frame)
 
     comparisons: list[BktStartPredictionComparison] = []
     for start, raw_model in zip(starts, captured_models, strict=True):
@@ -382,7 +460,9 @@ def _compare_start_predictions(
             BktStartPredictionComparison(
                 start_index=start.start_index,
                 final_log_likelihood_gap_from_selected=float(likelihood_gap),
-                final_log_likelihood_gap_per_observation=float(likelihood_gap / observation_count),
+                final_log_likelihood_gap_per_observation=float(
+                    likelihood_gap / train_observation_count
+                ),
                 mean_abs_error_probability_difference_from_selected=float(
                     np.mean(absolute_difference)
                 ),
@@ -463,6 +543,7 @@ def fit_bkt_with_diagnostics(
         starts,
         selected_start_index,
         parity_frame,
+        len(frame),
     )
 
     tolerance_starts = sum(

--- a/benchmarks/native-evidence-v1/scripts/bkt.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
+import importlib.util
 from importlib.metadata import version as package_version
 import inspect
 import json
@@ -11,7 +12,7 @@ from typing import Sequence
 
 import numpy as np
 import pandas as pd
-from pyBKT.fit import EM_fit, E_step
+from pyBKT.fit import EM_fit
 from pyBKT.models import Model
 
 PYBKT_SOURCE_REVISION = "06fc180ae72c117458acc527f8ec90cc8e0581c1"
@@ -145,17 +146,24 @@ def _resolve_effective_em_defaults(source: str) -> tuple[float | None, int | Non
     return tolerance, max_iterations, comparison
 
 
+def _resolve_e_step_source(em_source: str, em_source_path: str) -> tuple[str, str]:
+    if "E_step.run(" in em_source:
+        spec = importlib.util.find_spec("pyBKT.fit.E_step")
+        origin = "" if spec is None or spec.origin is None else str(spec.origin)
+        return "compiled-e-step", origin
+    if "def run(" in em_source:
+        # The pure-Python package embeds the E-step implementation in EM_fit.py itself.
+        return "python-e-step", em_source_path
+    return "unknown", ""
+
+
 def inspect_installed_bkt_backend() -> BktBackendInspection:
     installed_version = package_version("pyBKT")
     model_source_path = inspect.getsourcefile(Model) or ""
     em_source_path = inspect.getsourcefile(EM_fit.EM_fit) or ""
-    e_step_source_path = str(getattr(E_step, "__file__", "") or "")
     em_source = inspect.getsource(EM_fit.EM_fit)
     tolerance, max_iterations, comparison = _resolve_effective_em_defaults(em_source)
-
-    suffix = Path(e_step_source_path).suffix.lower()
-    compiled_suffixes = {".so", ".pyd", ".dll", ".dylib"}
-    backend_kind = "compiled-e-step" if suffix in compiled_suffixes else "python-e-step"
+    backend_kind, e_step_source_path = _resolve_e_step_source(em_source, em_source_path)
 
     return BktBackendInspection(
         source_revision=PYBKT_SOURCE_REVISION,

--- a/benchmarks/native-evidence-v1/scripts/bkt_stability.py
+++ b/benchmarks/native-evidence-v1/scripts/bkt_stability.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .bkt import BktDiagnosticRun, build_bkt_frame, fit_bkt_with_diagnostics
+
+
+@dataclass(frozen=True)
+class BktStabilityToleranceFreeze:
+    status: str
+    near_best_final_log_likelihood_gap_per_observation: None
+    max_abs_error_probability_difference_from_selected: None
+    mean_abs_error_probability_difference_from_selected: None
+    reviewer_required: bool
+    test_labels_permitted: bool
+    rationale: str
+
+
+@dataclass(frozen=True)
+class BktStabilityStressCase:
+    case_id: str
+    learner_count: int
+    row_count: int
+    positive_count: int
+    diagnostic: BktDiagnosticRun
+
+
+@dataclass(frozen=True)
+class BktStabilityStressReport:
+    status: str
+    evidence_scope: str
+    cases: tuple[BktStabilityStressCase, ...]
+    tolerance_freeze: BktStabilityToleranceFreeze
+
+
+def _frame_from_patterns(case_id: str, patterns: Sequence[Sequence[int]]):
+    learners: list[str] = []
+    outcomes: list[int] = []
+    for learner_index, pattern in enumerate(patterns):
+        learner_id = f"{case_id}-learner-{learner_index}"
+        for outcome in pattern:
+            learners.append(learner_id)
+            outcomes.append(outcome)
+    return build_bkt_frame(participant_ids=learners, correctness=outcomes)
+
+
+def _stress_cases():
+    return (
+        (
+            "mixed-progression",
+            (
+                (0, 0, 1, 1, 1),
+                (0, 1, 0, 1, 1),
+                (1, 0, 1, 1, 1),
+                (0, 0, 0, 1, 1),
+                (1, 1, 0, 1, 1),
+                (0, 1, 1, 0, 1),
+                (1, 0, 0, 1, 0),
+                (0, 1, 0, 0, 1),
+            ),
+        ),
+        (
+            "weak-alternating-signal",
+            (
+                (0, 1, 0, 1, 0, 1),
+                (1, 0, 1, 0, 1, 0),
+                (0, 1, 1, 0, 0, 1),
+                (1, 0, 0, 1, 1, 0),
+                (0, 0, 1, 1, 0, 1),
+                (1, 1, 0, 0, 1, 0),
+                (0, 1, 0, 0, 1, 1),
+                (1, 0, 1, 1, 0, 0),
+            ),
+        ),
+        (
+            "sparse-error-boundary",
+            (
+                (1, 1, 1, 1, 1, 0),
+                (1, 1, 1, 1, 0, 1),
+                (1, 1, 1, 0, 1, 1),
+                (1, 1, 0, 1, 1, 1),
+                (1, 0, 1, 1, 1, 1),
+                (0, 1, 1, 1, 1, 1),
+                (1, 1, 1, 1, 1, 1),
+                (1, 1, 1, 1, 1, 1),
+            ),
+        ),
+    )
+
+
+def build_train_only_stability_stress_report() -> BktStabilityStressReport:
+    cases: list[BktStabilityStressCase] = []
+    for case_id, patterns in _stress_cases():
+        frame = _frame_from_patterns(case_id, patterns)
+        diagnostic = fit_bkt_with_diagnostics(frame, parity_data=frame)
+        cases.append(
+            BktStabilityStressCase(
+                case_id=case_id,
+                learner_count=int(frame["user_id"].nunique()),
+                row_count=len(frame),
+                positive_count=int(frame["correct"].sum()),
+                diagnostic=diagnostic,
+            )
+        )
+
+    return BktStabilityStressReport(
+        status="review-required",
+        evidence_scope="TRAIN-only-synthetic-numerical-stress",
+        cases=tuple(cases),
+        tolerance_freeze=BktStabilityToleranceFreeze(
+            status="unresolved-pending-independent-review",
+            near_best_final_log_likelihood_gap_per_observation=None,
+            max_abs_error_probability_difference_from_selected=None,
+            mean_abs_error_probability_difference_from_selected=None,
+            reviewer_required=True,
+            test_labels_permitted=False,
+            rationale=(
+                "The harness records likelihood gaps and prediction divergence before any N3 outcomes. "
+                "Numerical thresholds remain null so implementation authors cannot tune them to synthetic or future TEST results. "
+                "An independent reviewer must freeze or reject tolerances from this TRAIN-only stress evidence."
+            ),
+        ),
+    )

--- a/benchmarks/native-evidence-v1/scripts/decision.py
+++ b/benchmarks/native-evidence-v1/scripts/decision.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .metrics import Interval, PairedContrastInterval
+
+
+class RealityDecision(str, Enum):
+    KEEP = "KEEP"
+    KEEP_REPRESENTATION_ONLY = "KEEP_REPRESENTATION_ONLY"
+    SIMPLIFY = "SIMPLIFY"
+    REDESIGN = "REDESIGN"
+    GATHER_MORE_EVIDENCE = "GATHER_MORE_EVIDENCE"
+
+
+@dataclass(frozen=True)
+class UtilityMargins:
+    delta_history: float | None
+    delta_basis: float | None
+    approved: bool
+    justification_artifact: str | None
+
+    @property
+    def resolved(self) -> bool:
+        return (
+            self.approved
+            and self.delta_history is not None
+            and self.delta_basis is not None
+            and self.delta_history >= 0
+            and self.delta_basis >= 0
+            and bool(self.justification_artifact)
+        )
+
+
+@dataclass(frozen=True)
+class DecisionInput:
+    history: PairedContrastInterval
+    basis: PairedContrastInterval
+    utility: UtilityMargins
+    instrumentation_valid: bool = True
+    semantic_mapping_valid: bool = True
+
+
+@dataclass(frozen=True)
+class DecisionResult:
+    decision: RealityDecision
+    attribution: str
+    reason: str
+
+
+def _log_loss_win(interval: Interval | None, margin: float) -> bool:
+    # Difference is B3 - control; negative is better. Entire interval must clear approved utility.
+    return interval is not None and interval.upper < -margin
+
+
+def _log_loss_material_benefit_excluded(interval: Interval | None, margin: float) -> bool:
+    # Entire interval lies above the utility benefit boundary, so material benefit is excluded.
+    return interval is not None and interval.lower > -margin
+
+
+def _brier_supports_win(interval: Interval | None) -> bool:
+    return interval is not None and interval.upper <= 0
+
+
+def _brier_demonstrates_benefit(interval: Interval | None) -> bool:
+    return interval is not None and interval.upper < 0
+
+
+def decide_native_representation(input_: DecisionInput) -> DecisionResult:
+    if not input_.instrumentation_valid or not input_.semantic_mapping_valid:
+        return DecisionResult(
+            decision=RealityDecision.REDESIGN,
+            attribution="measurement-failure",
+            reason="Instrumentation or prospective evidence semantics failed before predictive attribution.",
+        )
+
+    if not input_.utility.resolved:
+        return DecisionResult(
+            decision=RealityDecision.GATHER_MORE_EVIDENCE,
+            attribution="utility-unresolved",
+            reason="Predictive KEEP/SIMPLIFY is disabled until both utility margins are independently approved.",
+        )
+
+    assert input_.utility.delta_history is not None
+    assert input_.utility.delta_basis is not None
+    history_margin = input_.utility.delta_history
+    basis_margin = input_.utility.delta_basis
+
+    history_win = _log_loss_win(input_.history.log_loss, history_margin)
+    basis_win = _log_loss_win(input_.basis.log_loss, basis_margin)
+    history_brier_ok = _brier_supports_win(input_.history.brier)
+    basis_brier_ok = _brier_supports_win(input_.basis.brier)
+
+    if history_win and basis_win and history_brier_ok and basis_brier_ok:
+        return DecisionResult(
+            decision=RealityDecision.KEEP,
+            attribution="incremental-representation-signal",
+            reason=(
+                "B3 clears both approved log-loss utility margins and neither Brier contrast contradicts the win. "
+                "This supports incremental predictive signal under the frozen experiment, not new causal information."
+            ),
+        )
+
+    if history_win and history_brier_ok and not basis_win:
+        basis_equivalent_or_unresolved = (
+            input_.basis.log_loss is None
+            or input_.basis.log_loss.lower <= 0 <= input_.basis.log_loss.upper
+        )
+        if basis_equivalent_or_unresolved:
+            return DecisionResult(
+                decision=RealityDecision.KEEP_REPRESENTATION_ONLY,
+                attribution="history-reencoding-not-new-information",
+                reason=(
+                    "B3 beats the strong history lane but does not beat the algebraic B2-basis control. "
+                    "At most the representation/encoding is useful; no new learner-state information is established."
+                ),
+            )
+
+    history_excluded = _log_loss_material_benefit_excluded(input_.history.log_loss, history_margin)
+    basis_excluded = _log_loss_material_benefit_excluded(input_.basis.log_loss, basis_margin)
+    no_brier_win = not _brier_demonstrates_benefit(input_.history.brier) and not _brier_demonstrates_benefit(
+        input_.basis.brier
+    )
+    if history_excluded and basis_excluded and no_brier_win:
+        return DecisionResult(
+            decision=RealityDecision.SIMPLIFY,
+            attribution="material-benefit-excluded",
+            reason=(
+                "Both contrasts exclude the pre-approved material log-loss benefit and Brier provides no clear rescue. "
+                "The tested Nếp augmentation should be simplified rather than protected."
+            ),
+        )
+
+    return DecisionResult(
+        decision=RealityDecision.GATHER_MORE_EVIDENCE,
+        attribution="inconclusive-two-control-comparison",
+        reason="The two-control intervals do not justify KEEP, representation-only retention, or SIMPLIFY.",
+    )

--- a/benchmarks/native-evidence-v1/scripts/decision.py
+++ b/benchmarks/native-evidence-v1/scripts/decision.py
@@ -40,6 +40,7 @@ class DecisionInput:
     utility: UtilityMargins
     instrumentation_valid: bool = True
     semantic_mapping_valid: bool = True
+    basis_prediction_equivalent: bool = False
 
 
 @dataclass(frozen=True)
@@ -102,20 +103,15 @@ def decide_native_representation(input_: DecisionInput) -> DecisionResult:
             ),
         )
 
-    if history_win and history_brier_ok and not basis_win:
-        basis_equivalent_or_unresolved = (
-            input_.basis.log_loss is None
-            or input_.basis.log_loss.lower <= 0 <= input_.basis.log_loss.upper
+    if history_win and history_brier_ok and input_.basis_prediction_equivalent:
+        return DecisionResult(
+            decision=RealityDecision.KEEP_REPRESENTATION_ONLY,
+            attribution="history-reencoding-not-new-information",
+            reason=(
+                "B3 beats the strong history lane while its frozen predictions are exactly equivalent to B2-basis. "
+                "At most the representation/encoding is useful; no incremental learner-state information is established."
+            ),
         )
-        if basis_equivalent_or_unresolved:
-            return DecisionResult(
-                decision=RealityDecision.KEEP_REPRESENTATION_ONLY,
-                attribution="history-reencoding-not-new-information",
-                reason=(
-                    "B3 beats the strong history lane but does not beat the algebraic B2-basis control. "
-                    "At most the representation/encoding is useful; no new learner-state information is established."
-                ),
-            )
 
     history_excluded = _log_loss_material_benefit_excluded(input_.history.log_loss, history_margin)
     basis_excluded = _log_loss_material_benefit_excluded(input_.basis.log_loss, basis_margin)

--- a/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
+++ b/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.bkt import build_bkt_frame, fit_bkt_with_diagnostics, fit_source_faithful_bkt  # noqa: E402
+from scripts.bkt_stability import build_train_only_stability_stress_report  # noqa: E402
 
 
 def _training_frame():
@@ -58,18 +59,21 @@ def build_report() -> dict[str, object]:
         {str(key): _json_value(value) for key, value in record.items()}
         for record in parameter_frame.to_dict(orient="records")
     ]
+    stability_stress = build_train_only_stability_stress_report()
 
     return {
         "status": "synthetic-plumbing-only",
-        "purpose": "pyBKT-backend-observer-parity",
+        "purpose": "pyBKT-backend-observer-parity-and-TRAIN-only-stability-review",
         "forbiddenClaims": [
             "learner-model-validity",
             "predictive-superiority",
             "mastery",
             "calibrated",
+            "stability-approved",
         ],
         "diagnostic": asdict(diagnostic),
         "selectedParameters": parameter_records,
+        "stabilityStress": asdict(stability_stress),
     }
 
 

--- a/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
+++ b/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .bkt import build_bkt_frame, fit_bkt_with_diagnostics, fit_source_faithful_bkt
+
+
+def _training_frame():
+    learners: list[str] = []
+    outcomes: list[int] = []
+    patterns = (
+        (0, 0, 1, 1, 1),
+        (0, 1, 0, 1, 1),
+        (1, 0, 1, 1, 1),
+        (0, 0, 0, 1, 1),
+        (1, 1, 0, 1, 1),
+        (0, 1, 1, 0, 1),
+        (1, 0, 0, 1, 0),
+        (0, 1, 0, 0, 1),
+    )
+    for learner_index, pattern in enumerate(patterns):
+        learner_id = f"synthetic-bkt-observer-{learner_index}"
+        for outcome in pattern:
+            learners.append(learner_id)
+            outcomes.append(outcome)
+    return build_bkt_frame(participant_ids=learners, correctness=outcomes)
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        return float(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def build_report() -> dict[str, object]:
+    frame = _training_frame()
+    diagnostic = fit_bkt_with_diagnostics(frame)
+    comparator = fit_source_faithful_bkt(frame, backend=diagnostic.backend)
+    parameter_frame = comparator.fitted_parameters().reset_index()
+    parameter_records = [
+        {str(key): _json_value(value) for key, value in record.items()}
+        for record in parameter_frame.to_dict(orient="records")
+    ]
+
+    return {
+        "status": "synthetic-plumbing-only",
+        "purpose": "pyBKT-backend-observer-parity",
+        "forbiddenClaims": [
+            "learner-model-validity",
+            "predictive-superiority",
+            "mastery",
+            "calibrated",
+        ],
+        "diagnostic": asdict(diagnostic),
+        "selectedParameters": parameter_records,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(build_report(), sort_keys=True, indent=2, allow_nan=False),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
+++ b/benchmarks/native-evidence-v1/scripts/emit_bkt_diagnostics.py
@@ -4,11 +4,16 @@ import argparse
 from dataclasses import asdict
 import json
 from pathlib import Path
+import sys
 from typing import Any
 
 import numpy as np
 
-from .bkt import build_bkt_frame, fit_bkt_with_diagnostics, fit_source_faithful_bkt
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.bkt import build_bkt_frame, fit_bkt_with_diagnostics, fit_source_faithful_bkt  # noqa: E402
 
 
 def _training_frame():
@@ -33,9 +38,9 @@ def _training_frame():
 
 
 def _json_value(value: Any) -> Any:
-    if isinstance(value, (np.integer,)):
+    if isinstance(value, np.integer):
         return int(value)
-    if isinstance(value, (np.floating,)):
+    if isinstance(value, np.floating):
         return float(value)
     if isinstance(value, np.ndarray):
         return value.tolist()

--- a/benchmarks/native-evidence-v1/scripts/metrics.py
+++ b/benchmarks/native-evidence-v1/scripts/metrics.py
@@ -36,6 +36,10 @@ class BinaryMetricBundle:
 class LearnerMetricBundle:
     learner_count: int
     learner_with_outcome_count: int
+    planned_row_count: int
+    observed_row_count: int
+    learner_outcome_coverage: float | None
+    row_outcome_coverage: float | None
     mean_per_learner_log_loss: float | None
     mean_per_learner_brier: float | None
     attempt_weighted: BinaryMetricBundle | None
@@ -110,6 +114,7 @@ def evaluate_by_learner(
     probabilities: Sequence[float],
     *,
     planned_learner_ids: Sequence[str] | None = None,
+    planned_row_count: int | None = None,
 ) -> LearnerMetricBundle:
     if not (len(participant_ids) == len(labels) == len(probabilities)):
         raise ValueError("participant_ids, labels and probabilities must have equal length")
@@ -121,11 +126,26 @@ def evaluate_by_learner(
         learner_labels.append(label)
         learner_probabilities.append(probability)
 
+    planned_learners = (
+        set(planned_learner_ids) if planned_learner_ids is not None else set(grouped)
+    )
+    unexpected_learners = set(grouped) - planned_learners
+    if unexpected_learners:
+        raise ValueError(
+            f"observed outcomes include learners outside the frozen plan: {sorted(unexpected_learners)}"
+        )
+
+    resolved_planned_row_count = len(labels) if planned_row_count is None else planned_row_count
+    if resolved_planned_row_count < 0:
+        raise ValueError("planned_row_count must be nonnegative")
+    if len(labels) > resolved_planned_row_count:
+        raise ValueError("observed outcome rows cannot exceed planned_row_count")
+
     by_learner = {
         participant_id: evaluate_binary_probabilities(learner_labels, learner_probabilities)
         for participant_id, (learner_labels, learner_probabilities) in sorted(grouped.items())
     }
-    learner_count = len(set(planned_learner_ids)) if planned_learner_ids is not None else len(grouped)
+    learner_count = len(planned_learners)
 
     if by_learner:
         mean_log_loss = float(np.mean([bundle.log_loss for bundle in by_learner.values()]))
@@ -136,9 +156,20 @@ def evaluate_by_learner(
         mean_brier = None
         attempt_weighted = None
 
+    learner_coverage = len(by_learner) / learner_count if learner_count > 0 else None
+    row_coverage = (
+        len(labels) / resolved_planned_row_count
+        if resolved_planned_row_count > 0
+        else None
+    )
+
     return LearnerMetricBundle(
         learner_count=learner_count,
         learner_with_outcome_count=len(by_learner),
+        planned_row_count=resolved_planned_row_count,
+        observed_row_count=len(labels),
+        learner_outcome_coverage=learner_coverage,
+        row_outcome_coverage=row_coverage,
         mean_per_learner_log_loss=mean_log_loss,
         mean_per_learner_brier=mean_brier,
         attempt_weighted=attempt_weighted,

--- a/benchmarks/native-evidence-v1/scripts/metrics.py
+++ b/benchmarks/native-evidence-v1/scripts/metrics.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping, Sequence
+
+import numpy as np
+from sklearn.metrics import roc_auc_score
+
+LOG_LOSS_EPSILON = 1e-15
+CALIBRATION_BIN_COUNT = 5
+
+
+@dataclass(frozen=True)
+class CalibrationBin:
+    lower: float
+    upper: float
+    count: int
+    mean_probability: float | None
+    observed_error_rate: float | None
+
+
+@dataclass(frozen=True)
+class BinaryMetricBundle:
+    row_count: int
+    positive_count: int
+    log_loss: float
+    brier: float
+    auc: float | None
+    auc_unavailable_reason: str | None
+    clipped_probability_count: int
+    calibration_bins: tuple[CalibrationBin, ...]
+
+
+@dataclass(frozen=True)
+class LearnerMetricBundle:
+    learner_count: int
+    learner_with_outcome_count: int
+    mean_per_learner_log_loss: float | None
+    mean_per_learner_brier: float | None
+    attempt_weighted: BinaryMetricBundle | None
+    by_learner: Mapping[str, BinaryMetricBundle]
+
+
+def _validate(labels: Sequence[int], probabilities: Sequence[float]) -> None:
+    if len(labels) != len(probabilities):
+        raise ValueError("labels and probabilities must have equal length")
+    if any(label not in {0, 1} for label in labels):
+        raise ValueError("labels must be binary 0/1")
+    for probability in probabilities:
+        if not math.isfinite(probability) or probability < 0.0 or probability > 1.0:
+            raise ValueError("probabilities must be finite and within [0, 1]")
+
+
+def evaluate_binary_probabilities(
+    labels: Sequence[int], probabilities: Sequence[float]
+) -> BinaryMetricBundle:
+    _validate(labels, probabilities)
+    if not labels:
+        raise ValueError("cannot evaluate an empty prediction set")
+
+    label_array = np.asarray(labels, dtype=np.int64)
+    probability_array = np.asarray(probabilities, dtype=np.float64)
+    clipped = np.clip(probability_array, LOG_LOSS_EPSILON, 1.0 - LOG_LOSS_EPSILON)
+    clipped_probability_count = int(np.count_nonzero(clipped != probability_array))
+    row_losses = -(label_array * np.log(clipped) + (1 - label_array) * np.log(1 - clipped))
+    row_brier = np.square(probability_array - label_array)
+
+    if len(set(labels)) < 2:
+        auc = None
+        auc_reason = "one-class-subset"
+    else:
+        auc = float(roc_auc_score(label_array, probability_array))
+        auc_reason = None
+
+    bins: list[CalibrationBin] = []
+    for bin_index in range(CALIBRATION_BIN_COUNT):
+        lower = bin_index / CALIBRATION_BIN_COUNT
+        upper = (bin_index + 1) / CALIBRATION_BIN_COUNT
+        if bin_index == CALIBRATION_BIN_COUNT - 1:
+            mask = (probability_array >= lower) & (probability_array <= upper)
+        else:
+            mask = (probability_array >= lower) & (probability_array < upper)
+        count = int(np.count_nonzero(mask))
+        bins.append(
+            CalibrationBin(
+                lower=lower,
+                upper=upper,
+                count=count,
+                mean_probability=float(np.mean(probability_array[mask])) if count else None,
+                observed_error_rate=float(np.mean(label_array[mask])) if count else None,
+            )
+        )
+
+    return BinaryMetricBundle(
+        row_count=len(labels),
+        positive_count=int(np.sum(label_array)),
+        log_loss=float(np.mean(row_losses)),
+        brier=float(np.mean(row_brier)),
+        auc=auc,
+        auc_unavailable_reason=auc_reason,
+        clipped_probability_count=clipped_probability_count,
+        calibration_bins=tuple(bins),
+    )
+
+
+def evaluate_by_learner(
+    participant_ids: Sequence[str],
+    labels: Sequence[int],
+    probabilities: Sequence[float],
+    *,
+    planned_learner_ids: Sequence[str] | None = None,
+) -> LearnerMetricBundle:
+    if not (len(participant_ids) == len(labels) == len(probabilities)):
+        raise ValueError("participant_ids, labels and probabilities must have equal length")
+    _validate(labels, probabilities)
+
+    grouped: dict[str, tuple[list[int], list[float]]] = {}
+    for participant_id, label, probability in zip(participant_ids, labels, probabilities, strict=True):
+        learner_labels, learner_probabilities = grouped.setdefault(participant_id, ([], []))
+        learner_labels.append(label)
+        learner_probabilities.append(probability)
+
+    by_learner = {
+        participant_id: evaluate_binary_probabilities(learner_labels, learner_probabilities)
+        for participant_id, (learner_labels, learner_probabilities) in sorted(grouped.items())
+    }
+    learner_count = len(set(planned_learner_ids)) if planned_learner_ids is not None else len(grouped)
+
+    if by_learner:
+        mean_log_loss = float(np.mean([bundle.log_loss for bundle in by_learner.values()]))
+        mean_brier = float(np.mean([bundle.brier for bundle in by_learner.values()]))
+        attempt_weighted = evaluate_binary_probabilities(labels, probabilities)
+    else:
+        mean_log_loss = None
+        mean_brier = None
+        attempt_weighted = None
+
+    return LearnerMetricBundle(
+        learner_count=learner_count,
+        learner_with_outcome_count=len(by_learner),
+        mean_per_learner_log_loss=mean_log_loss,
+        mean_per_learner_brier=mean_brier,
+        attempt_weighted=attempt_weighted,
+        by_learner=by_learner,
+    )
+
+
+@dataclass(frozen=True)
+class Interval:
+    lower: float
+    upper: float
+
+
+@dataclass(frozen=True)
+class PairedContrastInterval:
+    learner_count: int
+    log_loss: Interval | None
+    brier: Interval | None
+    descriptive_log_loss_difference: float | None
+    descriptive_brier_difference: float | None
+
+
+def paired_learner_bootstrap(
+    target: LearnerMetricBundle,
+    controls: Mapping[str, LearnerMetricBundle],
+    *,
+    draws: int = 2000,
+    seed: int = 143,
+) -> Mapping[str, PairedContrastInterval]:
+    if draws <= 0:
+        raise ValueError("draws must be positive")
+
+    control_names = tuple(sorted(controls))
+    shared_ids = set(target.by_learner)
+    for control in controls.values():
+        shared_ids &= set(control.by_learner)
+    learner_ids = tuple(sorted(shared_ids))
+
+    if not learner_ids:
+        return {
+            name: PairedContrastInterval(0, None, None, None, None)
+            for name in control_names
+        }
+
+    descriptive: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+    for name in control_names:
+        control = controls[name]
+        log_differences = np.asarray(
+            [target.by_learner[learner_id].log_loss - control.by_learner[learner_id].log_loss for learner_id in learner_ids],
+            dtype=np.float64,
+        )
+        brier_differences = np.asarray(
+            [target.by_learner[learner_id].brier - control.by_learner[learner_id].brier for learner_id in learner_ids],
+            dtype=np.float64,
+        )
+        descriptive[name] = (log_differences, brier_differences)
+
+    if len(learner_ids) < 2:
+        return {
+            name: PairedContrastInterval(
+                learner_count=1,
+                log_loss=None,
+                brier=None,
+                descriptive_log_loss_difference=float(np.mean(values[0])),
+                descriptive_brier_difference=float(np.mean(values[1])),
+            )
+            for name, values in descriptive.items()
+        }
+
+    rng = np.random.default_rng(seed)
+    sampled_indices = rng.integers(0, len(learner_ids), size=(draws, len(learner_ids)))
+    result: dict[str, PairedContrastInterval] = {}
+
+    for name, (log_differences, brier_differences) in descriptive.items():
+        boot_log = np.mean(log_differences[sampled_indices], axis=1)
+        boot_brier = np.mean(brier_differences[sampled_indices], axis=1)
+        log_lower, log_upper = np.percentile(boot_log, [2.5, 97.5])
+        brier_lower, brier_upper = np.percentile(boot_brier, [2.5, 97.5])
+        result[name] = PairedContrastInterval(
+            learner_count=len(learner_ids),
+            log_loss=Interval(float(log_lower), float(log_upper)),
+            brier=Interval(float(brier_lower), float(brier_upper)),
+            descriptive_log_loss_difference=float(np.mean(log_differences)),
+            descriptive_brier_difference=float(np.mean(brier_differences)),
+        )
+
+    return result

--- a/benchmarks/native-evidence-v1/scripts/metrics.py
+++ b/benchmarks/native-evidence-v1/scripts/metrics.py
@@ -36,6 +36,7 @@ class BinaryMetricBundle:
 class LearnerMetricBundle:
     learner_count: int
     learner_with_outcome_count: int
+    planned_learner_ids: tuple[str, ...]
     planned_row_count: int
     observed_row_count: int
     learner_outcome_coverage: float | None
@@ -145,7 +146,8 @@ def evaluate_by_learner(
         participant_id: evaluate_binary_probabilities(learner_labels, learner_probabilities)
         for participant_id, (learner_labels, learner_probabilities) in sorted(grouped.items())
     }
-    learner_count = len(planned_learners)
+    planned_learner_tuple = tuple(sorted(planned_learners))
+    learner_count = len(planned_learner_tuple)
 
     if by_learner:
         mean_log_loss = float(np.mean([bundle.log_loss for bundle in by_learner.values()]))
@@ -166,6 +168,7 @@ def evaluate_by_learner(
     return LearnerMetricBundle(
         learner_count=learner_count,
         learner_with_outcome_count=len(by_learner),
+        planned_learner_ids=planned_learner_tuple,
         planned_row_count=resolved_planned_row_count,
         observed_row_count=len(labels),
         learner_outcome_coverage=learner_coverage,
@@ -192,6 +195,44 @@ class PairedContrastInterval:
     descriptive_brier_difference: float | None
 
 
+def _assert_paired_metric_alignment(
+    target: LearnerMetricBundle,
+    control: LearnerMetricBundle,
+    control_name: str,
+) -> None:
+    if target.planned_learner_ids != control.planned_learner_ids:
+        raise ValueError(
+            f"paired comparison requires identical planned learners: {control_name}"
+        )
+    if target.planned_row_count != control.planned_row_count:
+        raise ValueError(
+            f"paired comparison requires identical planned row count: {control_name}"
+        )
+    if target.observed_row_count != control.observed_row_count:
+        raise ValueError(
+            f"paired comparison refuses complete-case row selection: {control_name}"
+        )
+
+    target_ids = set(target.by_learner)
+    control_ids = set(control.by_learner)
+    if target_ids != control_ids:
+        raise ValueError(
+            f"paired comparison refuses complete-case learner selection: {control_name}"
+        )
+
+    for learner_id in sorted(target_ids):
+        target_metric = target.by_learner[learner_id]
+        control_metric = control.by_learner[learner_id]
+        if target_metric.row_count != control_metric.row_count:
+            raise ValueError(
+                f"paired comparison requires identical rows per learner: {control_name}:{learner_id}"
+            )
+        if target_metric.positive_count != control_metric.positive_count:
+            raise ValueError(
+                f"paired comparison requires identical labels per learner: {control_name}:{learner_id}"
+            )
+
+
 def paired_learner_bootstrap(
     target: LearnerMetricBundle,
     controls: Mapping[str, LearnerMetricBundle],
@@ -203,11 +244,10 @@ def paired_learner_bootstrap(
         raise ValueError("draws must be positive")
 
     control_names = tuple(sorted(controls))
-    shared_ids = set(target.by_learner)
-    for control in controls.values():
-        shared_ids &= set(control.by_learner)
-    learner_ids = tuple(sorted(shared_ids))
+    for name in control_names:
+        _assert_paired_metric_alignment(target, controls[name], name)
 
+    learner_ids = tuple(sorted(target.by_learner))
     if not learner_ids:
         return {
             name: PairedContrastInterval(0, None, None, None, None)

--- a/benchmarks/native-evidence-v1/scripts/metrics.py
+++ b/benchmarks/native-evidence-v1/scripts/metrics.py
@@ -33,12 +33,21 @@ class BinaryMetricBundle:
 
 
 @dataclass(frozen=True)
+class RowOutcomeBinding:
+    row_id: str
+    participant_id: str
+    label: int
+
+
+@dataclass(frozen=True)
 class LearnerMetricBundle:
     learner_count: int
     learner_with_outcome_count: int
     planned_learner_ids: tuple[str, ...]
     planned_row_count: int
+    planned_row_ids: tuple[str, ...] | None
     observed_row_count: int
+    observed_row_bindings: tuple[RowOutcomeBinding, ...] | None
     learner_outcome_coverage: float | None
     row_outcome_coverage: float | None
     mean_per_learner_log_loss: float | None
@@ -55,6 +64,15 @@ def _validate(labels: Sequence[int], probabilities: Sequence[float]) -> None:
     for probability in probabilities:
         if not math.isfinite(probability) or probability < 0.0 or probability > 1.0:
             raise ValueError("probabilities must be finite and within [0, 1]")
+
+
+def _validate_row_ids(row_ids: Sequence[str], field: str) -> tuple[str, ...]:
+    normalized = tuple(str(row_id).strip() for row_id in row_ids)
+    if any(not row_id for row_id in normalized):
+        raise ValueError(f"{field} must contain only non-empty row ids")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"{field} must contain unique row ids")
+    return normalized
 
 
 def evaluate_binary_probabilities(
@@ -114,12 +132,23 @@ def evaluate_by_learner(
     labels: Sequence[int],
     probabilities: Sequence[float],
     *,
+    row_ids: Sequence[str] | None = None,
     planned_learner_ids: Sequence[str] | None = None,
     planned_row_count: int | None = None,
+    planned_row_ids: Sequence[str] | None = None,
 ) -> LearnerMetricBundle:
     if not (len(participant_ids) == len(labels) == len(probabilities)):
         raise ValueError("participant_ids, labels and probabilities must have equal length")
+    if row_ids is not None and len(row_ids) != len(labels):
+        raise ValueError("row_ids, labels and probabilities must have equal length")
     _validate(labels, probabilities)
+
+    normalized_row_ids = _validate_row_ids(row_ids, "row_ids") if row_ids is not None else None
+    normalized_planned_row_ids = (
+        _validate_row_ids(planned_row_ids, "planned_row_ids")
+        if planned_row_ids is not None
+        else None
+    )
 
     grouped: dict[str, tuple[list[int], list[float]]] = {}
     for participant_id, label, probability in zip(participant_ids, labels, probabilities, strict=True):
@@ -136,11 +165,42 @@ def evaluate_by_learner(
             f"observed outcomes include learners outside the frozen plan: {sorted(unexpected_learners)}"
         )
 
-    resolved_planned_row_count = len(labels) if planned_row_count is None else planned_row_count
+    if normalized_planned_row_ids is not None:
+        resolved_planned_row_count = len(normalized_planned_row_ids)
+        if planned_row_count is not None and planned_row_count != resolved_planned_row_count:
+            raise ValueError("planned_row_count must equal the number of planned_row_ids")
+    else:
+        resolved_planned_row_count = len(labels) if planned_row_count is None else planned_row_count
+
     if resolved_planned_row_count < 0:
         raise ValueError("planned_row_count must be nonnegative")
     if len(labels) > resolved_planned_row_count:
         raise ValueError("observed outcome rows cannot exceed planned_row_count")
+
+    observed_row_bindings: tuple[RowOutcomeBinding, ...] | None = None
+    if normalized_row_ids is not None:
+        if normalized_planned_row_ids is not None:
+            planned_row_id_set = set(normalized_planned_row_ids)
+            unexpected_rows = set(normalized_row_ids) - planned_row_id_set
+            if unexpected_rows:
+                raise ValueError(
+                    f"observed outcomes include rows outside the frozen plan: {sorted(unexpected_rows)}"
+                )
+        observed_row_bindings = tuple(
+            sorted(
+                (
+                    RowOutcomeBinding(
+                        row_id=row_id,
+                        participant_id=participant_id,
+                        label=label,
+                    )
+                    for row_id, participant_id, label in zip(
+                        normalized_row_ids, participant_ids, labels, strict=True
+                    )
+                ),
+                key=lambda binding: binding.row_id,
+            )
+        )
 
     by_learner = {
         participant_id: evaluate_binary_probabilities(learner_labels, learner_probabilities)
@@ -170,7 +230,13 @@ def evaluate_by_learner(
         learner_with_outcome_count=len(by_learner),
         planned_learner_ids=planned_learner_tuple,
         planned_row_count=resolved_planned_row_count,
+        planned_row_ids=(
+            tuple(sorted(normalized_planned_row_ids))
+            if normalized_planned_row_ids is not None
+            else None
+        ),
         observed_row_count=len(labels),
+        observed_row_bindings=observed_row_bindings,
         learner_outcome_coverage=learner_coverage,
         row_outcome_coverage=row_coverage,
         mean_per_learner_log_loss=mean_log_loss,
@@ -208,9 +274,25 @@ def _assert_paired_metric_alignment(
         raise ValueError(
             f"paired comparison requires identical planned row count: {control_name}"
         )
+    if target.planned_row_ids is None or control.planned_row_ids is None:
+        raise ValueError(
+            f"paired comparison requires explicit frozen planned row ids: {control_name}"
+        )
+    if target.planned_row_ids != control.planned_row_ids:
+        raise ValueError(
+            f"paired comparison requires identical planned row ids: {control_name}"
+        )
     if target.observed_row_count != control.observed_row_count:
         raise ValueError(
             f"paired comparison refuses complete-case row selection: {control_name}"
+        )
+    if target.observed_row_bindings is None or control.observed_row_bindings is None:
+        raise ValueError(
+            f"paired comparison requires explicit observed row ids: {control_name}"
+        )
+    if target.observed_row_bindings != control.observed_row_bindings:
+        raise ValueError(
+            f"paired comparison requires identical observed row identity, learner and label bindings: {control_name}"
         )
 
     target_ids = set(target.by_learner)

--- a/benchmarks/native-evidence-v1/scripts/predictor.py
+++ b/benchmarks/native-evidence-v1/scripts/predictor.py
@@ -4,8 +4,10 @@ from dataclasses import asdict, dataclass
 from hashlib import sha256
 import json
 from typing import Mapping, Sequence
+import warnings
 
 import numpy as np
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 
 from .preprocessing import FeatureRow, FrozenFeatureTransform, fit_feature_transform
@@ -85,6 +87,25 @@ class FrozenPredictor:
         return probabilities[:, positive_index].astype(np.float64, copy=False)
 
 
+def _unavailable_predictor(
+    *,
+    transform: FrozenFeatureTransform,
+    train_row_count: int,
+    train_positive_count: int,
+    spec: PredictorSpec,
+    reason: str,
+) -> FrozenPredictor:
+    return FrozenPredictor(
+        feature_transform=transform,
+        model=None,
+        availability="not-estimable",
+        unavailable_reason=reason,
+        train_row_count=train_row_count,
+        train_positive_count=train_positive_count,
+        spec=spec,
+    )
+
+
 def fit_common_logistic_predictor(
     train_rows: Sequence[FeatureRow],
     train_labels: Sequence[int],
@@ -102,24 +123,20 @@ def fit_common_logistic_predictor(
     transform = fit_feature_transform(train_rows, categorical_domains=categorical_domains)
     positives = int(sum(train_labels))
     if len(set(train_labels)) < 2:
-        return FrozenPredictor(
-            feature_transform=transform,
-            model=None,
-            availability="not-estimable",
-            unavailable_reason="one-class-train",
+        return _unavailable_predictor(
+            transform=transform,
             train_row_count=len(train_rows),
             train_positive_count=positives,
             spec=spec,
+            reason="one-class-train",
         )
     if not transform.retained_columns:
-        return FrozenPredictor(
-            feature_transform=transform,
-            model=None,
-            availability="not-estimable",
-            unavailable_reason="no-nonconstant-features",
+        return _unavailable_predictor(
+            transform=transform,
             train_row_count=len(train_rows),
             train_positive_count=positives,
             spec=spec,
+            reason="no-nonconstant-features",
         )
 
     matrix = transform.transform(train_rows)
@@ -132,7 +149,24 @@ def fit_common_logistic_predictor(
         max_iter=spec.max_iter,
         tol=spec.tol,
     )
-    model.fit(matrix, np.asarray(train_labels, dtype=np.int64))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", ConvergenceWarning)
+        model.fit(matrix, np.asarray(train_labels, dtype=np.int64))
+
+    convergence_warning = any(
+        issubclass(warning.category, ConvergenceWarning) for warning in caught
+    )
+    hit_iteration_limit = bool(
+        model.n_iter_.size > 0 and np.any(model.n_iter_.astype(np.int64) >= spec.max_iter)
+    )
+    if convergence_warning or hit_iteration_limit:
+        return _unavailable_predictor(
+            transform=transform,
+            train_row_count=len(train_rows),
+            train_positive_count=positives,
+            spec=spec,
+            reason="nonconvergence",
+        )
 
     return FrozenPredictor(
         feature_transform=transform,

--- a/benchmarks/native-evidence-v1/scripts/predictor.py
+++ b/benchmarks/native-evidence-v1/scripts/predictor.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from .preprocessing import FeatureRow, FrozenFeatureTransform, fit_feature_transform
+
+
+@dataclass(frozen=True)
+class PredictorSpec:
+    penalty: str = "l2"
+    C: float = 1.0
+    solver: str = "lbfgs"
+    fit_intercept: bool = True
+    class_weight: None = None
+    max_iter: int = 1000
+    tol: float = 1e-8
+    random_state: int = 143
+
+
+@dataclass(frozen=True)
+class FrozenPredictor:
+    feature_transform: FrozenFeatureTransform
+    model: LogisticRegression | None
+    availability: str
+    unavailable_reason: str | None
+    train_row_count: int
+    train_positive_count: int
+    spec: PredictorSpec
+
+    def predict_error_probability(self, rows: Sequence[FeatureRow]) -> np.ndarray:
+        if self.model is None:
+            raise RuntimeError(f"predictor is unavailable: {self.unavailable_reason}")
+        matrix = self.feature_transform.transform(rows)
+        probabilities = self.model.predict_proba(matrix)
+        classes = list(self.model.classes_)
+        positive_index = classes.index(1)
+        return probabilities[:, positive_index].astype(np.float64, copy=False)
+
+
+def fit_common_logistic_predictor(
+    train_rows: Sequence[FeatureRow],
+    train_labels: Sequence[int],
+    *,
+    categorical_domains: Mapping[str, Sequence[str]],
+    spec: PredictorSpec = PredictorSpec(),
+) -> FrozenPredictor:
+    if len(train_rows) != len(train_labels):
+        raise ValueError("train_rows and train_labels must have equal length")
+    if not train_rows:
+        raise ValueError("cannot fit predictor without TRAIN rows")
+    if any(label not in {0, 1} for label in train_labels):
+        raise ValueError("train_labels must be binary 0/1")
+
+    transform = fit_feature_transform(train_rows, categorical_domains=categorical_domains)
+    positives = int(sum(train_labels))
+    if len(set(train_labels)) < 2:
+        return FrozenPredictor(
+            feature_transform=transform,
+            model=None,
+            availability="not-estimable",
+            unavailable_reason="one-class-train",
+            train_row_count=len(train_rows),
+            train_positive_count=positives,
+            spec=spec,
+        )
+    if not transform.retained_columns:
+        return FrozenPredictor(
+            feature_transform=transform,
+            model=None,
+            availability="not-estimable",
+            unavailable_reason="no-nonconstant-features",
+            train_row_count=len(train_rows),
+            train_positive_count=positives,
+            spec=spec,
+        )
+
+    matrix = transform.transform(train_rows)
+    model = LogisticRegression(
+        penalty=spec.penalty,
+        C=spec.C,
+        solver=spec.solver,
+        fit_intercept=spec.fit_intercept,
+        class_weight=spec.class_weight,
+        max_iter=spec.max_iter,
+        tol=spec.tol,
+        random_state=spec.random_state,
+    )
+    model.fit(matrix, np.asarray(train_labels, dtype=np.int64))
+
+    return FrozenPredictor(
+        feature_transform=transform,
+        model=model,
+        availability="available",
+        unavailable_reason=None,
+        train_row_count=len(train_rows),
+        train_positive_count=positives,
+        spec=spec,
+    )
+
+
+@dataclass(frozen=True)
+class PrevalenceBaseline:
+    alpha: float
+    beta: float
+    train_row_count: int
+    train_positive_count: int
+
+    @property
+    def error_probability(self) -> float:
+        return (self.train_positive_count + self.alpha) / (
+            self.train_row_count + self.alpha + self.beta
+        )
+
+    def predict(self, row_count: int) -> np.ndarray:
+        if row_count < 0:
+            raise ValueError("row_count must be nonnegative")
+        return np.full(row_count, self.error_probability, dtype=np.float64)
+
+
+def fit_prevalence_baseline(
+    train_labels: Sequence[int], *, alpha: float = 1.0, beta: float = 1.0
+) -> PrevalenceBaseline:
+    if alpha <= 0 or beta <= 0:
+        raise ValueError("alpha and beta must be positive")
+    if any(label not in {0, 1} for label in train_labels):
+        raise ValueError("train_labels must be binary 0/1")
+    return PrevalenceBaseline(
+        alpha=alpha,
+        beta=beta,
+        train_row_count=len(train_labels),
+        train_positive_count=int(sum(train_labels)),
+    )

--- a/benchmarks/native-evidence-v1/scripts/predictor.py
+++ b/benchmarks/native-evidence-v1/scripts/predictor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
 from typing import Mapping, Sequence
 
 import numpy as np
@@ -18,7 +20,24 @@ class PredictorSpec:
     class_weight: None = None
     max_iter: int = 1000
     tol: float = 1e-8
-    random_state: int = 143
+
+
+def _fingerprint_json(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return f"sha256:{sha256(encoded).hexdigest()}"
+
+
+def fingerprint_predictor_spec(spec: PredictorSpec) -> str:
+    return _fingerprint_json(asdict(spec))
+
+
+def fingerprint_feature_transform(transform: FrozenFeatureTransform) -> str:
+    return _fingerprint_json(asdict(transform))
 
 
 @dataclass(frozen=True)
@@ -30,6 +49,31 @@ class FrozenPredictor:
     train_row_count: int
     train_positive_count: int
     spec: PredictorSpec
+
+    @property
+    def spec_fingerprint(self) -> str:
+        return fingerprint_predictor_spec(self.spec)
+
+    @property
+    def transform_fingerprint(self) -> str:
+        return fingerprint_feature_transform(self.feature_transform)
+
+    @property
+    def fitted_artifact_fingerprint(self) -> str:
+        payload: dict[str, object] = {
+            "availability": self.availability,
+            "unavailable_reason": self.unavailable_reason,
+            "train_row_count": self.train_row_count,
+            "train_positive_count": self.train_positive_count,
+            "spec_fingerprint": self.spec_fingerprint,
+            "transform_fingerprint": self.transform_fingerprint,
+        }
+        if self.model is not None:
+            payload["classes"] = self.model.classes_.astype(np.int64).tolist()
+            payload["coef"] = self.model.coef_.astype(np.float64).tolist()
+            payload["intercept"] = self.model.intercept_.astype(np.float64).tolist()
+            payload["n_iter"] = self.model.n_iter_.astype(np.int64).tolist()
+        return _fingerprint_json(payload)
 
     def predict_error_probability(self, rows: Sequence[FeatureRow]) -> np.ndarray:
         if self.model is None:
@@ -87,7 +131,6 @@ def fit_common_logistic_predictor(
         class_weight=spec.class_weight,
         max_iter=spec.max_iter,
         tol=spec.tol,
-        random_state=spec.random_state,
     )
     model.fit(matrix, np.asarray(train_labels, dtype=np.int64))
 

--- a/benchmarks/native-evidence-v1/scripts/preprocessing.py
+++ b/benchmarks/native-evidence-v1/scripts/preprocessing.py
@@ -66,8 +66,8 @@ def _validate_numeric(value: FeatureValue, name: str) -> float | None:
     return number
 
 
-def _is_availability_mask(name: str) -> bool:
-    return name.startswith("missing:")
+def _is_unknown_channel(name: str) -> bool:
+    return name.startswith("missing:") or (name.startswith("cat:") and name.endswith("=unknown"))
 
 
 def fit_feature_transform(
@@ -131,11 +131,10 @@ def fit_feature_transform(
     candidate_indices: list[int] = []
     for index, name in enumerate(raw_names):
         column = raw_matrix[:, index]
-        # Availability is a semantic property, not a candidate model signal. Preserve every
-        # numeric missingness mask even when TRAIN happens to contain no missing values, otherwise
-        # a future missing value collapses to standardized zero and becomes indistinguishable from
-        # an observed mean value.
-        if _is_availability_mask(name):
+        # Missing/unknown is a semantic state, not an observed zero. Preserve these channels even
+        # when TRAIN contains no missing or unknown values; otherwise a future unknown can collapse
+        # to a zero vector or observed mean after TRAIN-only constant pruning.
+        if _is_unknown_channel(name):
             candidate_indices.append(index)
         elif column.size == 0 or np.all(column == column[0]):
             dropped_constants.append(name)
@@ -146,7 +145,7 @@ def fit_feature_transform(
     dropped_duplicates: list[tuple[str, str]] = []
     for index in candidate_indices:
         name = raw_names[index]
-        if _is_availability_mask(name):
+        if _is_unknown_channel(name):
             retained_indices.append(index)
             continue
 
@@ -154,7 +153,7 @@ def fit_feature_transform(
         duplicate_of: str | None = None
         for retained_index in retained_indices:
             retained_name = raw_names[retained_index]
-            if _is_availability_mask(retained_name):
+            if _is_unknown_channel(retained_name):
                 continue
             if np.array_equal(column, raw_matrix[:, retained_index]):
                 duplicate_of = retained_name

--- a/benchmarks/native-evidence-v1/scripts/preprocessing.py
+++ b/benchmarks/native-evidence-v1/scripts/preprocessing.py
@@ -45,7 +45,13 @@ class FrozenFeatureTransform:
 
 
 def _is_nonnegative_transform(name: str) -> bool:
-    return name.endswith("_count") or name.startswith("seconds_since_") or "_seconds_" in name
+    return (
+        name.endswith("_count")
+        or name.endswith("_positive")
+        or name.endswith("_negative")
+        or name.startswith("seconds_since_")
+        or "_seconds_" in name
+    )
 
 
 def _preferred_column_order(name: str) -> tuple[int, str]:

--- a/benchmarks/native-evidence-v1/scripts/preprocessing.py
+++ b/benchmarks/native-evidence-v1/scripts/preprocessing.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping, Sequence
+
+import numpy as np
+
+FeatureValue = float | int | str | None
+FeatureRow = Mapping[str, FeatureValue]
+
+
+@dataclass(frozen=True)
+class NumericTransform:
+    source_name: str
+    output_name: str
+    mean: float
+    scale: float
+    log1p: bool
+    missing_output_name: str
+
+
+@dataclass(frozen=True)
+class CategoricalTransform:
+    source_name: str
+    categories: tuple[str, ...]
+    output_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FrozenFeatureTransform:
+    numeric: tuple[NumericTransform, ...]
+    categorical: tuple[CategoricalTransform, ...]
+    retained_columns: tuple[str, ...]
+    dropped_constant_columns: tuple[str, ...]
+    dropped_duplicate_columns: tuple[tuple[str, str], ...]
+
+    def transform(self, rows: Sequence[FeatureRow]) -> np.ndarray:
+        raw_names, raw_matrix = _materialize_columns(rows, self.numeric, self.categorical)
+        name_to_index = {name: index for index, name in enumerate(raw_names)}
+        indices = [name_to_index[name] for name in self.retained_columns]
+        if not rows:
+            return np.zeros((0, len(indices)), dtype=np.float64)
+        return raw_matrix[:, indices]
+
+
+def _is_nonnegative_transform(name: str) -> bool:
+    return name.endswith("_count") or name.startswith("seconds_since_") or "_seconds_" in name
+
+
+def _preferred_column_order(name: str) -> tuple[int, str]:
+    # Shared B2 columns must survive exact-duplicate pruning before basis/Nếp derivatives.
+    if name.startswith("basis_") or name.startswith("nep_"):
+        return (1, name)
+    return (0, name)
+
+
+def _validate_numeric(value: FeatureValue, name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"numeric feature {name!r} received non-numeric value {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"numeric feature {name!r} must be finite")
+    return number
+
+
+def fit_feature_transform(
+    rows: Sequence[FeatureRow],
+    *,
+    categorical_domains: Mapping[str, Sequence[str]],
+) -> FrozenFeatureTransform:
+    if not rows:
+        raise ValueError("cannot fit feature transform without TRAIN rows")
+
+    all_names = sorted({name for row in rows for name in row}, key=_preferred_column_order)
+    categorical_names = set(categorical_domains)
+    numeric_names = [name for name in all_names if name not in categorical_names]
+
+    numeric_transforms: list[NumericTransform] = []
+    for name in numeric_names:
+        values = [_validate_numeric(row.get(name), name) for row in rows]
+        log1p = _is_nonnegative_transform(name)
+        observed: list[float] = []
+        for value in values:
+            if value is None:
+                continue
+            if log1p:
+                if value < 0:
+                    raise ValueError(f"feature {name!r} is declared nonnegative but received {value}")
+                value = math.log1p(value)
+            observed.append(value)
+
+        mean = float(np.mean(observed)) if observed else 0.0
+        standard_deviation = float(np.std(observed, ddof=0)) if observed else 0.0
+        scale = standard_deviation if standard_deviation > 0 else 1.0
+        numeric_transforms.append(
+            NumericTransform(
+                source_name=name,
+                output_name=f"num:{name}",
+                mean=mean,
+                scale=scale,
+                log1p=log1p,
+                missing_output_name=f"missing:{name}",
+            )
+        )
+
+    categorical_transforms: list[CategoricalTransform] = []
+    for name in sorted(categorical_domains, key=_preferred_column_order):
+        declared = tuple(dict.fromkeys(str(value) for value in categorical_domains[name]))
+        if "unknown" not in declared:
+            raise ValueError(f"categorical feature {name!r} must declare an explicit 'unknown' category")
+        if not declared:
+            raise ValueError(f"categorical feature {name!r} has no declared categories")
+        categorical_transforms.append(
+            CategoricalTransform(
+                source_name=name,
+                categories=declared,
+                output_names=tuple(f"cat:{name}={category}" for category in declared),
+            )
+        )
+
+    raw_names, raw_matrix = _materialize_columns(rows, tuple(numeric_transforms), tuple(categorical_transforms))
+
+    dropped_constants: list[str] = []
+    candidate_indices: list[int] = []
+    for index, name in enumerate(raw_names):
+        column = raw_matrix[:, index]
+        if column.size == 0 or np.all(column == column[0]):
+            dropped_constants.append(name)
+        else:
+            candidate_indices.append(index)
+
+    retained_indices: list[int] = []
+    dropped_duplicates: list[tuple[str, str]] = []
+    for index in candidate_indices:
+        column = raw_matrix[:, index]
+        duplicate_of: str | None = None
+        for retained_index in retained_indices:
+            if np.array_equal(column, raw_matrix[:, retained_index]):
+                duplicate_of = raw_names[retained_index]
+                break
+        if duplicate_of is None:
+            retained_indices.append(index)
+        else:
+            dropped_duplicates.append((raw_names[index], duplicate_of))
+
+    return FrozenFeatureTransform(
+        numeric=tuple(numeric_transforms),
+        categorical=tuple(categorical_transforms),
+        retained_columns=tuple(raw_names[index] for index in retained_indices),
+        dropped_constant_columns=tuple(dropped_constants),
+        dropped_duplicate_columns=tuple(dropped_duplicates),
+    )
+
+
+def _materialize_columns(
+    rows: Sequence[FeatureRow],
+    numeric: Sequence[NumericTransform],
+    categorical: Sequence[CategoricalTransform],
+) -> tuple[tuple[str, ...], np.ndarray]:
+    names: list[str] = []
+    for transform in numeric:
+        names.extend((transform.output_name, transform.missing_output_name))
+    for transform in categorical:
+        names.extend(transform.output_names)
+
+    matrix = np.zeros((len(rows), len(names)), dtype=np.float64)
+    cursor = 0
+
+    for transform in numeric:
+        for row_index, row in enumerate(rows):
+            value = _validate_numeric(row.get(transform.source_name), transform.source_name)
+            if value is None:
+                matrix[row_index, cursor] = 0.0
+                matrix[row_index, cursor + 1] = 1.0
+                continue
+            if transform.log1p:
+                if value < 0:
+                    raise ValueError(
+                        f"feature {transform.source_name!r} is declared nonnegative but received {value}"
+                    )
+                value = math.log1p(value)
+            matrix[row_index, cursor] = (value - transform.mean) / transform.scale
+            matrix[row_index, cursor + 1] = 0.0
+        cursor += 2
+
+    for transform in categorical:
+        category_to_offset = {category: offset for offset, category in enumerate(transform.categories)}
+        unknown_offset = category_to_offset["unknown"]
+        for row_index, row in enumerate(rows):
+            raw_value = row.get(transform.source_name)
+            category = "unknown" if raw_value is None else str(raw_value)
+            offset = category_to_offset.get(category, unknown_offset)
+            matrix[row_index, cursor + offset] = 1.0
+        cursor += len(transform.categories)
+
+    return tuple(names), matrix

--- a/benchmarks/native-evidence-v1/scripts/preprocessing.py
+++ b/benchmarks/native-evidence-v1/scripts/preprocessing.py
@@ -66,6 +66,10 @@ def _validate_numeric(value: FeatureValue, name: str) -> float | None:
     return number
 
 
+def _is_availability_mask(name: str) -> bool:
+    return name.startswith("missing:")
+
+
 def fit_feature_transform(
     rows: Sequence[FeatureRow],
     *,
@@ -127,7 +131,13 @@ def fit_feature_transform(
     candidate_indices: list[int] = []
     for index, name in enumerate(raw_names):
         column = raw_matrix[:, index]
-        if column.size == 0 or np.all(column == column[0]):
+        # Availability is a semantic property, not a candidate model signal. Preserve every
+        # numeric missingness mask even when TRAIN happens to contain no missing values, otherwise
+        # a future missing value collapses to standardized zero and becomes indistinguishable from
+        # an observed mean value.
+        if _is_availability_mask(name):
+            candidate_indices.append(index)
+        elif column.size == 0 or np.all(column == column[0]):
             dropped_constants.append(name)
         else:
             candidate_indices.append(index)
@@ -135,16 +145,24 @@ def fit_feature_transform(
     retained_indices: list[int] = []
     dropped_duplicates: list[tuple[str, str]] = []
     for index in candidate_indices:
+        name = raw_names[index]
+        if _is_availability_mask(name):
+            retained_indices.append(index)
+            continue
+
         column = raw_matrix[:, index]
         duplicate_of: str | None = None
         for retained_index in retained_indices:
+            retained_name = raw_names[retained_index]
+            if _is_availability_mask(retained_name):
+                continue
             if np.array_equal(column, raw_matrix[:, retained_index]):
-                duplicate_of = raw_names[retained_index]
+                duplicate_of = retained_name
                 break
         if duplicate_of is None:
             retained_indices.append(index)
         else:
-            dropped_duplicates.append((raw_names[index], duplicate_of))
+            dropped_duplicates.append((name, duplicate_of))
 
     return FrozenFeatureTransform(
         numeric=tuple(numeric_transforms),

--- a/benchmarks/native-evidence-v1/store.ts
+++ b/benchmarks/native-evidence-v1/store.ts
@@ -60,14 +60,36 @@ export class SyntheticPilotStore {
     artifactId: string,
     kind: SyntheticArtifactKind,
     participantIds: readonly string[],
+    dependsOnArtifactIds: readonly string[] = [],
   ): SyntheticArtifactRecord {
     if (this.artifacts.has(artifactId)) {
       throw new Error(`Duplicate synthetic artifact id: ${artifactId}`);
     }
+
+    const dependencyIds = [...new Set(dependsOnArtifactIds)].sort();
+    if (dependencyIds.includes(artifactId)) {
+      throw new Error(`Synthetic artifact cannot depend on itself: ${artifactId}`);
+    }
+
+    const effectiveParticipantIds = new Set(participantIds);
+    for (const dependencyId of dependencyIds) {
+      const dependency = this.artifacts.get(dependencyId);
+      if (!dependency) {
+        throw new Error(`Synthetic artifact dependency is missing: ${dependencyId}`);
+      }
+      if (!dependency.valid) {
+        throw new Error(`Synthetic artifact dependency is invalidated: ${dependencyId}`);
+      }
+      for (const participantId of dependency.participantIds) {
+        effectiveParticipantIds.add(participantId);
+      }
+    }
+
     const record: SyntheticArtifactRecord = Object.freeze({
       artifactId,
       kind,
-      participantIds: Object.freeze([...new Set(participantIds)].sort()),
+      participantIds: Object.freeze([...effectiveParticipantIds].sort()),
+      dependsOnArtifactIds: Object.freeze(dependencyIds),
       valid: true,
       invalidatedReason: null,
     });

--- a/benchmarks/native-evidence-v1/store.ts
+++ b/benchmarks/native-evidence-v1/store.ts
@@ -1,0 +1,113 @@
+import { computeCanonicalEvidenceDigest } from "@/lib/core/certified-evidence";
+
+import {
+  SYNTHETIC_ONLY_STATUS,
+  type SyntheticArtifactKind,
+  type SyntheticArtifactRecord,
+  type SyntheticPilotEvent,
+} from "./types";
+
+export type SyntheticParticipantExport = {
+  readonly status: typeof SYNTHETIC_ONLY_STATUS;
+  readonly participantId: string;
+  readonly events: readonly {
+    readonly eventId: string;
+    readonly family: string;
+    readonly occurredAt: string;
+    readonly availableAt: string;
+    readonly evidenceDigest: string;
+  }[];
+};
+
+export class SyntheticPilotStore {
+  private readonly eventsByParticipant = new Map<string, SyntheticPilotEvent[]>();
+  private readonly artifacts = new Map<string, SyntheticArtifactRecord>();
+
+  addEvent(event: SyntheticPilotEvent): void {
+    const current = this.eventsByParticipant.get(event.participantId) ?? [];
+    current.push(event);
+    this.eventsByParticipant.set(event.participantId, current);
+  }
+
+  addEvents(events: readonly SyntheticPilotEvent[]): void {
+    for (const event of events) this.addEvent(event);
+  }
+
+  getEvents(participantId: string): readonly SyntheticPilotEvent[] {
+    return Object.freeze([...(this.eventsByParticipant.get(participantId) ?? [])]);
+  }
+
+  exportParticipant(participantId: string): SyntheticParticipantExport {
+    const events = this.eventsByParticipant.get(participantId) ?? [];
+    return Object.freeze({
+      status: SYNTHETIC_ONLY_STATUS,
+      participantId,
+      events: Object.freeze(
+        events.map((event) =>
+          Object.freeze({
+            eventId: event.evidence.eventId,
+            family: event.taskDefinition.family,
+            occurredAt: event.evidence.occurredAt,
+            availableAt: event.availableAt,
+            evidenceDigest: computeCanonicalEvidenceDigest(event.evidence),
+          }),
+        ),
+      ),
+    });
+  }
+
+  registerArtifact(
+    artifactId: string,
+    kind: SyntheticArtifactKind,
+    participantIds: readonly string[],
+  ): SyntheticArtifactRecord {
+    if (this.artifacts.has(artifactId)) {
+      throw new Error(`Duplicate synthetic artifact id: ${artifactId}`);
+    }
+    const record: SyntheticArtifactRecord = Object.freeze({
+      artifactId,
+      kind,
+      participantIds: Object.freeze([...new Set(participantIds)].sort()),
+      valid: true,
+      invalidatedReason: null,
+    });
+    this.artifacts.set(artifactId, record);
+    return record;
+  }
+
+  getArtifact(artifactId: string): SyntheticArtifactRecord | null {
+    return this.artifacts.get(artifactId) ?? null;
+  }
+
+  listValidArtifacts(): readonly SyntheticArtifactRecord[] {
+    return Object.freeze([...this.artifacts.values()].filter((artifact) => artifact.valid));
+  }
+
+  deleteParticipant(participantId: string): {
+    readonly participantId: string;
+    readonly removedEventCount: number;
+    readonly invalidatedArtifactIds: readonly string[];
+  } {
+    const removedEventCount = this.eventsByParticipant.get(participantId)?.length ?? 0;
+    this.eventsByParticipant.delete(participantId);
+
+    const invalidatedArtifactIds: string[] = [];
+    for (const [artifactId, artifact] of this.artifacts.entries()) {
+      if (!artifact.valid || !artifact.participantIds.includes(participantId)) continue;
+      const invalidated: SyntheticArtifactRecord = Object.freeze({
+        ...artifact,
+        valid: false,
+        invalidatedReason: `participant-deleted:${participantId}`,
+      });
+      this.artifacts.set(artifactId, invalidated);
+      invalidatedArtifactIds.push(artifactId);
+    }
+
+    invalidatedArtifactIds.sort();
+    return Object.freeze({
+      participantId,
+      removedEventCount,
+      invalidatedArtifactIds: Object.freeze(invalidatedArtifactIds),
+    });
+  }
+}

--- a/benchmarks/native-evidence-v1/synthetic.ts
+++ b/benchmarks/native-evidence-v1/synthetic.ts
@@ -1,0 +1,211 @@
+import {
+  validateReferenceCoreEvidence,
+  type CoreEvidenceCandidate,
+  type ReferenceEvidenceValidationResult,
+} from "@/lib/core/certified-evidence";
+import type { DiagnosticPayload } from "@/lib/core/diagnostics";
+import type { CoreObservation } from "@/lib/core/observation";
+
+import { buildPilotTaskDefinition, type BuildPilotTaskOptions } from "./task-matrix";
+import {
+  NATIVE_PILOT_TARGET_ID,
+  type PilotTaskDefinition,
+  type PilotTaskFamily,
+  type SyntheticPilotEvent,
+} from "./types";
+
+const SYNTHETIC_EVALUATOR_FINGERPRINT = "native-pilot-synthetic-deterministic-v1" as const;
+
+export type SyntheticAttemptInput = {
+  readonly participantId: string;
+  readonly family: PilotTaskFamily;
+  readonly eventId: string;
+  readonly occurredAt: string;
+  readonly availableAt: string;
+  readonly success: boolean;
+  readonly revealUsed?: boolean;
+  readonly responseLatencyMs?: number | null;
+  readonly taskOptions?: BuildPilotTaskOptions;
+};
+
+export type SyntheticEvidenceFixture = {
+  readonly taskDefinition: PilotTaskDefinition;
+  readonly observation: CoreObservation;
+  readonly candidate: CoreEvidenceCandidate;
+  readonly validation: ReferenceEvidenceValidationResult;
+};
+
+function buildPayload(
+  taskDefinition: PilotTaskDefinition,
+  success: boolean,
+  responseLatencyMs: number | null,
+): DiagnosticPayload {
+  if (
+    taskDefinition.family === "recognition-independent" ||
+    taskDefinition.family === "recognition-supported"
+  ) {
+    return {
+      kind: "comprehension",
+      taskId: taskDefinition.task.id,
+      responseCorrect: success,
+      responseLatencyMs,
+      supportLevel: taskDefinition.task.support.level,
+      targetedConstructs: [NATIVE_PILOT_TARGET_ID],
+    };
+  }
+
+  return {
+    kind: "controlled-response",
+    taskId: taskDefinition.task.id,
+    observedResponse: true,
+    responseCorrect: success,
+    matchedTargetIds: success ? [NATIVE_PILOT_TARGET_ID] : [],
+    missingTargetIds: success ? [] : [NATIVE_PILOT_TARGET_ID],
+    evaluatorRuleId: "native-pilot.binary-v1",
+  };
+}
+
+export function createSyntheticEvidenceFixture(input: SyntheticAttemptInput): SyntheticEvidenceFixture {
+  const taskDefinition = buildPilotTaskDefinition(input.family, input.taskOptions);
+  const role = taskDefinition.task.allowedEvidenceRoles[0];
+  if (!role) throw new Error(`Native pilot task ${taskDefinition.task.id} has no evidence role`);
+
+  const responseLatencyMs = input.responseLatencyMs ?? null;
+  const revealUsed = input.revealUsed ?? false;
+  const observationId = `obs:${input.participantId}:${input.eventId}`;
+
+  const observation: CoreObservation = Object.freeze({
+    observationId,
+    targetId: NATIVE_PILOT_TARGET_ID,
+    activity: taskDefinition.task.activity,
+    payload: buildPayload(taskDefinition, input.success, responseLatencyMs),
+    confidence: 1,
+    calibration: Object.freeze({
+      validationState: "unvalidated",
+      decision: "shadow",
+      benchmarkId: null,
+      modelFingerprint: SYNTHETIC_EVALUATOR_FINGERPRINT,
+      scope: Object.freeze({
+        activity: taskDefinition.task.activity,
+        construct: NATIVE_PILOT_TARGET_ID,
+        requiredPopulationTags: ["synthetic-only"],
+      }),
+      metrics: Object.freeze({ sampleSize: 0 }),
+    }),
+    authority: "none",
+    provenance: Object.freeze({
+      evaluator: SYNTHETIC_EVALUATOR_FINGERPRINT,
+      evaluatorKind: "deterministic",
+      sources: taskDefinition.task.sources,
+    }),
+    context: Object.freeze({
+      populationTags: ["synthetic-only"],
+      construct: NATIVE_PILOT_TARGET_ID,
+      promptContext: taskDefinition.family,
+    }),
+    contextId: taskDefinition.contextId,
+    createdAt: input.occurredAt,
+  });
+
+  const candidate: CoreEvidenceCandidate = Object.freeze({
+    eventId: input.eventId,
+    taskId: taskDefinition.task.id,
+    targetId: NATIVE_PILOT_TARGET_ID,
+    role,
+    observationId,
+    outcome: Object.freeze({ kind: "binary" as const, success: input.success }),
+    evaluatorConfidence: 1,
+    attempt: Object.freeze({
+      supportLevel: taskDefinition.task.support.level,
+      revealUsed,
+      responseLatencyMs,
+      responseModality: taskDefinition.task.responseModality,
+      contextId: taskDefinition.contextId,
+    }),
+    occurredAt: input.occurredAt,
+  });
+
+  return Object.freeze({
+    taskDefinition,
+    observation,
+    candidate,
+    validation: validateReferenceCoreEvidence(taskDefinition.task, observation, candidate),
+  });
+}
+
+export function issueSyntheticPilotEvent(input: SyntheticAttemptInput): SyntheticPilotEvent {
+  const fixture = createSyntheticEvidenceFixture(input);
+  if (!fixture.validation.ok) {
+    throw new Error(
+      `Synthetic evidence failed reference validation: ${JSON.stringify(fixture.validation.problems)}`,
+    );
+  }
+
+  return Object.freeze({
+    participantId: input.participantId,
+    taskDefinition: fixture.taskDefinition,
+    evidence: fixture.validation.evidence,
+    availableAt: input.availableAt,
+  });
+}
+
+export function buildSyntheticTrace(participantId = "synthetic-participant-a"): readonly SyntheticPilotEvent[] {
+  return Object.freeze([
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "recognition-independent",
+      eventId: `${participantId}:e01`,
+      occurredAt: "2026-09-01T09:00:00.000Z",
+      availableAt: "2026-09-01T09:00:01.000Z",
+      success: true,
+      responseLatencyMs: 1200,
+    }),
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "recognition-supported",
+      eventId: `${participantId}:e02`,
+      occurredAt: "2026-09-01T09:05:00.000Z",
+      availableAt: "2026-09-01T09:05:01.000Z",
+      success: false,
+      revealUsed: false,
+      responseLatencyMs: 1800,
+    }),
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "recognition-supported",
+      eventId: `${participantId}:e03`,
+      occurredAt: "2026-09-01T09:10:00.000Z",
+      availableAt: "2026-09-01T09:10:01.000Z",
+      success: true,
+      revealUsed: true,
+      responseLatencyMs: 1500,
+    }),
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "free-recall",
+      eventId: `${participantId}:e04`,
+      occurredAt: "2026-09-01T09:20:00.000Z",
+      availableAt: "2026-09-01T09:20:01.000Z",
+      success: false,
+      responseLatencyMs: 4200,
+    }),
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "delayed-free-recall",
+      eventId: `${participantId}:e05`,
+      occurredAt: "2026-09-02T09:00:00.000Z",
+      availableAt: "2026-09-02T09:00:01.000Z",
+      success: true,
+      responseLatencyMs: 3000,
+    }),
+    issueSyntheticPilotEvent({
+      participantId,
+      family: "near-transfer",
+      eventId: `${participantId}:e06`,
+      occurredAt: "2026-09-02T09:10:00.000Z",
+      availableAt: "2026-09-02T09:10:01.000Z",
+      success: true,
+      responseLatencyMs: 3500,
+    }),
+  ]);
+}

--- a/benchmarks/native-evidence-v1/task-matrix.ts
+++ b/benchmarks/native-evidence-v1/task-matrix.ts
@@ -1,0 +1,150 @@
+import crypto from "node:crypto";
+
+import type { CommunicationActivity } from "@/lib/core/domain";
+import type { CoreEvidenceRole } from "@/lib/core/evidence-role";
+import type { CoreTaskSpec, TransferDistance } from "@/lib/core/task";
+import { validateCoreTask } from "@/lib/core/task";
+import type { ResponseModality } from "@/lib/learning/evidence";
+
+import {
+  NATIVE_PILOT_CONTENT_SLICE,
+  NATIVE_PILOT_CONTRACT_ID,
+  NATIVE_PILOT_SCORING_CONTRACT_ID,
+  NATIVE_PILOT_TARGET_ID,
+  PILOT_TASK_FAMILIES,
+  type PilotTaskDefinition,
+  type PilotTaskFamily,
+} from "./types";
+
+type TaskFamilySemantics = {
+  readonly activity: CommunicationActivity;
+  readonly responseModality: ResponseModality;
+  readonly role: CoreEvidenceRole;
+  readonly supportLevel: number;
+  readonly revealAllowed: boolean;
+  readonly transferDistance: TransferDistance;
+  readonly defaultContextId: string;
+  readonly stimulusFormGroup: string;
+};
+
+const FAMILY_SEMANTICS: Readonly<Record<PilotTaskFamily, TaskFamilySemantics>> = Object.freeze({
+  "recognition-independent": Object.freeze({
+    activity: "reading-reception",
+    responseModality: "choice",
+    role: "meaning-recognition",
+    supportLevel: 0,
+    revealAllowed: false,
+    transferDistance: "same-context",
+    defaultContextId: "ctx-baseline-a",
+    stimulusFormGroup: "form-a",
+  }),
+  "recognition-supported": Object.freeze({
+    activity: "reading-reception",
+    responseModality: "choice",
+    role: "meaning-recognition",
+    supportLevel: 1,
+    revealAllowed: true,
+    transferDistance: "same-context",
+    defaultContextId: "ctx-baseline-a",
+    stimulusFormGroup: "form-b",
+  }),
+  "free-recall": Object.freeze({
+    activity: "written-production",
+    responseModality: "text",
+    role: "free-recall",
+    supportLevel: 0,
+    revealAllowed: false,
+    transferDistance: "same-context",
+    defaultContextId: "ctx-baseline-a",
+    stimulusFormGroup: "form-c",
+  }),
+  "delayed-free-recall": Object.freeze({
+    activity: "written-production",
+    responseModality: "text",
+    role: "free-recall",
+    supportLevel: 0,
+    revealAllowed: false,
+    transferDistance: "same-context",
+    defaultContextId: "ctx-baseline-a",
+    stimulusFormGroup: "form-d",
+  }),
+  "near-transfer": Object.freeze({
+    activity: "written-production",
+    responseModality: "text",
+    role: "near-transfer",
+    supportLevel: 0,
+    revealAllowed: false,
+    transferDistance: "near-transfer",
+    defaultContextId: "ctx-near-transfer-b",
+    stimulusFormGroup: "form-e",
+  }),
+});
+
+function sha256(value: string): `sha256:${string}` {
+  return `sha256:${crypto.createHash("sha256").update(value, "utf8").digest("hex")}`;
+}
+
+export type BuildPilotTaskOptions = {
+  readonly contextId?: string;
+  readonly stimulusFormGroup?: string;
+  readonly contentKey?: string;
+};
+
+export function buildPilotTaskDefinition(
+  family: PilotTaskFamily,
+  options: BuildPilotTaskOptions = {},
+): PilotTaskDefinition {
+  const semantics = FAMILY_SEMANTICS[family];
+  const contextId = options.contextId ?? semantics.defaultContextId;
+  const stimulusFormGroup = options.stimulusFormGroup ?? semantics.stimulusFormGroup;
+  const contentKey = options.contentKey ?? `${family}:${stimulusFormGroup}:v1`;
+  const taskId = `native-pilot-v1:${family}:${stimulusFormGroup}:${contextId}`;
+
+  const task: CoreTaskSpec = Object.freeze({
+    id: taskId,
+    version: 1,
+    targetIds: Object.freeze([NATIVE_PILOT_TARGET_ID]) as unknown as string[],
+    activity: semantics.activity,
+    responseModality: semantics.responseModality,
+    allowedEvidenceRoles: Object.freeze([semantics.role]) as unknown as CoreEvidenceRole[],
+    support: Object.freeze({
+      level: semantics.supportLevel,
+      revealAllowed: semantics.revealAllowed,
+    }),
+    transferDistance: semantics.transferDistance,
+    contextTags: Object.freeze([
+      NATIVE_PILOT_CONTENT_SLICE,
+      `pilot-family:${family}`,
+      `context:${contextId}`,
+      `stimulus-form-group:${stimulusFormGroup}`,
+    ]) as unknown as string[],
+    timeConstraintMs: null,
+    scoringContractId: NATIVE_PILOT_SCORING_CONTRACT_ID,
+    sources: Object.freeze([
+      Object.freeze({
+        sourceId: "spec:005-native-evidence-pilot-v1",
+        version: "1",
+        locator: "specs/005-native-evidence-pilot-v1/spec.md",
+      }),
+    ]) as unknown as CoreTaskSpec["sources"],
+  });
+
+  const problems = validateCoreTask(task);
+  if (problems.length > 0) {
+    throw new Error(`Invalid native pilot task ${taskId}: ${JSON.stringify(problems)}`);
+  }
+
+  return Object.freeze({
+    pilotContractId: NATIVE_PILOT_CONTRACT_ID,
+    family,
+    task,
+    contentFingerprint: sha256(contentKey),
+    contextId,
+    stimulusFormGroup,
+    scoringContractId: NATIVE_PILOT_SCORING_CONTRACT_ID,
+  });
+}
+
+export function buildFrozenPilotTaskMatrix(): readonly PilotTaskDefinition[] {
+  return Object.freeze(PILOT_TASK_FAMILIES.map((family) => buildPilotTaskDefinition(family)));
+}

--- a/benchmarks/native-evidence-v1/tests/test_bkt_blind_prediction.py
+++ b/benchmarks/native-evidence-v1/tests/test_bkt_blind_prediction.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.bkt import (  # noqa: E402
+    build_bkt_frame,
+    fit_bkt_with_diagnostics,
+    fit_source_faithful_bkt,
+)
+
+
+SKILL = "present-subject-verb-agreement"
+
+
+class BktBlindPredictionTests(unittest.TestCase):
+    def _training_frame(self) -> pd.DataFrame:
+        learners: list[str] = []
+        outcomes: list[int] = []
+        patterns = (
+            (0, 0, 1, 1),
+            (0, 1, 1, 1),
+            (1, 0, 1, 1),
+            (0, 0, 0, 1),
+            (1, 1, 1, 1),
+            (0, 1, 0, 1),
+        )
+        for learner_index, pattern in enumerate(patterns):
+            learner_id = f"bkt-train-{learner_index}"
+            for outcome in pattern:
+                learners.append(learner_id)
+                outcomes.append(outcome)
+        return build_bkt_frame(participant_ids=learners, correctness=outcomes)
+
+    def test_blind_next_prediction_never_accepts_the_current_target_outcome(self) -> None:
+        comparator = fit_source_faithful_bkt(self._training_frame())
+        history = build_bkt_frame(
+            participant_ids=["target", "target"],
+            correctness=[1, 0],
+        )
+
+        safe_probability = comparator.predict_blind_next_error_probability(
+            participant_id="target",
+            skill_name=SKILL,
+            authorized_history=history,
+        )
+
+        target_zero = pd.DataFrame(
+            [{"order_id": 2, "skill_name": SKILL, "correct": 0, "user_id": "target"}]
+        )
+        target_one = pd.DataFrame(
+            [{"order_id": 2, "skill_name": SKILL, "correct": 1, "user_id": "target"}]
+        )
+        sequence_zero = pd.concat([history, target_zero], ignore_index=True)
+        sequence_one = pd.concat([history, target_one], ignore_index=True)
+        diagnostic_zero = comparator.predict_error_probabilities(sequence_zero)[-1]
+        diagnostic_one = comparator.predict_error_probabilities(sequence_one)[-1]
+
+        self.assertTrue(np.isfinite(safe_probability))
+        self.assertGreaterEqual(safe_probability, 0.0)
+        self.assertLessEqual(safe_probability, 1.0)
+        self.assertAlmostEqual(diagnostic_zero, diagnostic_one, places=12)
+        self.assertAlmostEqual(safe_probability, diagnostic_zero, places=12)
+
+    def test_blind_prediction_supports_true_cold_start(self) -> None:
+        comparator = fit_source_faithful_bkt(self._training_frame())
+        probability = comparator.predict_blind_next_error_probability(
+            participant_id="new-learner",
+            skill_name=SKILL,
+            authorized_history=None,
+        )
+        self.assertTrue(np.isfinite(probability))
+        self.assertGreaterEqual(probability, 0.0)
+        self.assertLessEqual(probability, 1.0)
+
+    def test_blind_history_rejects_other_participants_and_skills(self) -> None:
+        comparator = fit_source_faithful_bkt(self._training_frame())
+        mixed_participants = build_bkt_frame(
+            participant_ids=["target", "other"],
+            correctness=[1, 0],
+        )
+        with self.assertRaisesRegex(ValueError, "target participant"):
+            comparator.predict_blind_next_error_probability(
+                participant_id="target",
+                skill_name=SKILL,
+                authorized_history=mixed_participants,
+            )
+
+        wrong_skill = build_bkt_frame(
+            participant_ids=["target", "target"],
+            correctness=[1, 0],
+            skill_name="different-skill",
+        )
+        with self.assertRaisesRegex(ValueError, "target skill"):
+            comparator.predict_blind_next_error_probability(
+                participant_id="target",
+                skill_name=SKILL,
+                authorized_history=wrong_skill,
+            )
+
+    def test_likelihood_gap_per_observation_uses_train_rows_not_parity_rows(self) -> None:
+        train = self._training_frame()
+        parity = build_bkt_frame(
+            participant_ids=["parity-a", "parity-a", "parity-b", "parity-b"],
+            correctness=[0, 1, 1, 0],
+        )
+        self.assertNotEqual(len(train), len(parity))
+
+        diagnostic = fit_bkt_with_diagnostics(train, parity_data=parity)
+        self.assertEqual(len(diagnostic.start_prediction_comparisons), len(diagnostic.starts))
+        for comparison in diagnostic.start_prediction_comparisons:
+            self.assertAlmostEqual(
+                comparison.final_log_likelihood_gap_per_observation,
+                comparison.final_log_likelihood_gap_from_selected / len(train),
+                places=15,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_bkt_comparator.py
+++ b/benchmarks/native-evidence-v1/tests/test_bkt_comparator.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.bkt import (  # noqa: E402
+    PYBKT_NUM_FITS,
+    PYBKT_PACKAGE_VERSION,
+    PYBKT_SEED,
+    PYBKT_SOURCE_REVISION,
+    build_bkt_frame,
+    fit_source_faithful_bkt,
+    validate_bkt_frame,
+)
+
+
+class BktComparatorTests(unittest.TestCase):
+    def _training_frame(self) -> pd.DataFrame:
+        learners: list[str] = []
+        outcomes: list[int] = []
+        patterns = (
+            (0, 0, 1, 1),
+            (0, 1, 1, 1),
+            (1, 0, 1, 1),
+            (0, 0, 0, 1),
+            (1, 1, 1, 1),
+            (0, 1, 0, 1),
+        )
+        for learner_index, pattern in enumerate(patterns):
+            learner_id = f"bkt-synthetic-{learner_index}"
+            for outcome in pattern:
+                learners.append(learner_id)
+                outcomes.append(outcome)
+        return build_bkt_frame(participant_ids=learners, correctness=outcomes)
+
+    def test_source_faithful_five_fit_api_produces_finite_predictions(self) -> None:
+        frame = self._training_frame()
+        comparator = fit_source_faithful_bkt(frame)
+        probabilities = comparator.predict_error_probabilities(frame)
+
+        self.assertEqual(probabilities.shape, (len(frame),))
+        self.assertTrue(np.all(np.isfinite(probabilities)))
+        self.assertTrue(np.all((probabilities >= 0) & (probabilities <= 1)))
+        self.assertEqual(comparator.metadata.source_revision, PYBKT_SOURCE_REVISION)
+        self.assertEqual(comparator.metadata.package_version, PYBKT_PACKAGE_VERSION)
+        self.assertEqual(comparator.metadata.seed, PYBKT_SEED)
+        self.assertEqual(comparator.metadata.num_fits, PYBKT_NUM_FITS)
+        self.assertFalse(comparator.metadata.parallel)
+        self.assertFalse(comparator.metadata.forgets)
+        self.assertEqual(comparator.metadata.backend_default_num_fits, 5)
+        self.assertFalse(comparator.metadata.backend_default_forgets)
+        self.assertFalse(comparator.fitted_parameters().empty)
+
+    def test_invalid_sequence_order_is_rejected_before_backend_fit(self) -> None:
+        frame = pd.DataFrame(
+            [
+                {"order_id": 1, "skill_name": "s", "correct": 1, "user_id": "u"},
+                {"order_id": 0, "skill_name": "s", "correct": 0, "user_id": "u"},
+            ]
+        )
+        with self.assertRaisesRegex(ValueError, "monotone"):
+            validate_bkt_frame(frame)
+
+    def test_nonbinary_outcome_is_rejected_for_declared_binary_comparator(self) -> None:
+        frame = pd.DataFrame(
+            [{"order_id": 0, "skill_name": "s", "correct": -1, "user_id": "u"}]
+        )
+        with self.assertRaisesRegex(ValueError, "binary 0/1"):
+            validate_bkt_frame(frame)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_bkt_diagnostics.py
+++ b/benchmarks/native-evidence-v1/tests/test_bkt_diagnostics.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.bkt import (  # noqa: E402
+    PYBKT_NUM_FITS,
+    PYBKT_PACKAGE_VERSION,
+    build_bkt_frame,
+    fit_bkt_with_diagnostics,
+    inspect_installed_bkt_backend,
+)
+
+
+class BktDiagnosticObserverTests(unittest.TestCase):
+    def _training_frame(self):
+        learners: list[str] = []
+        outcomes: list[int] = []
+        patterns = (
+            (0, 0, 1, 1, 1),
+            (0, 1, 0, 1, 1),
+            (1, 0, 1, 1, 1),
+            (0, 0, 0, 1, 1),
+            (1, 1, 0, 1, 1),
+            (0, 1, 1, 0, 1),
+            (1, 0, 0, 1, 0),
+            (0, 1, 0, 0, 1),
+        )
+        for learner_index, pattern in enumerate(patterns):
+            learner_id = f"bkt-diagnostic-{learner_index}"
+            for outcome in pattern:
+                learners.append(learner_id)
+                outcomes.append(outcome)
+        return build_bkt_frame(participant_ids=learners, correctness=outcomes)
+
+    def test_records_actual_installed_backend_and_effective_em_defaults(self) -> None:
+        backend = inspect_installed_bkt_backend()
+        self.assertEqual(backend.package_version, PYBKT_PACKAGE_VERSION)
+        self.assertIn(backend.backend_kind, {"compiled-e-step", "python-e-step"})
+        self.assertTrue(backend.model_source_path)
+        self.assertTrue(backend.em_source_path)
+        self.assertTrue(backend.e_step_source_path)
+        self.assertIsNotNone(backend.model_source_sha256)
+        self.assertIsNotNone(backend.em_source_sha256)
+        self.assertIsNotNone(backend.e_step_source_sha256)
+        self.assertIn(backend.effective_em_tolerance, {0.001, 0.005})
+        self.assertEqual(backend.effective_em_max_iterations, 100)
+        self.assertIn(backend.tolerance_comparison, {"<", "<="})
+
+    def test_observer_preserves_source_faithful_fit_and_records_all_starts(self) -> None:
+        frame = self._training_frame()
+        diagnostic = fit_bkt_with_diagnostics(frame)
+
+        self.assertEqual(len(diagnostic.starts), PYBKT_NUM_FITS)
+        self.assertTrue(diagnostic.parity_parameters_equal)
+        self.assertTrue(diagnostic.parity_predictions_equal)
+        self.assertTrue(diagnostic.selected_predictions_finite)
+        self.assertIsNotNone(diagnostic.selected_start_index)
+        self.assertEqual(
+            diagnostic.selected_start_index,
+            max(
+                range(len(diagnostic.starts)),
+                key=lambda index: diagnostic.starts[index].final_log_likelihood,
+            ),
+        )
+        self.assertTrue(all(start.iteration_count > 0 for start in diagnostic.starts))
+        self.assertTrue(
+            all(np.isfinite(start.final_log_likelihood) for start in diagnostic.starts)
+        )
+        self.assertTrue(
+            all(start.initial_parameter_fingerprint.startswith("sha256:") for start in diagnostic.starts)
+        )
+        self.assertTrue(
+            all(start.final_parameter_fingerprint.startswith("sha256:") for start in diagnostic.starts)
+        )
+        self.assertIn(
+            diagnostic.convergence_assurance,
+            {"convergence-observed", "convergence-unverified"},
+        )
+        self.assertEqual(
+            diagnostic.stability_assurance,
+            "unresolved-pending-reviewed-train-only-tolerances",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_decision_boundaries.py
+++ b/benchmarks/native-evidence-v1/tests/test_decision_boundaries.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.decision import (  # noqa: E402
+    DecisionInput,
+    RealityDecision,
+    UtilityMargins,
+    decide_native_representation,
+)
+from scripts.metrics import Interval, PairedContrastInterval  # noqa: E402
+
+
+def contrast(log_lower: float, log_upper: float, brier_lower: float, brier_upper: float):
+    return PairedContrastInterval(
+        learner_count=20,
+        log_loss=Interval(log_lower, log_upper),
+        brier=Interval(brier_lower, brier_upper),
+        descriptive_log_loss_difference=(log_lower + log_upper) / 2,
+        descriptive_brier_difference=(brier_lower + brier_upper) / 2,
+    )
+
+
+class DecisionBoundaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.utility = UtilityMargins(
+            delta_history=0.01,
+            delta_basis=0.005,
+            approved=True,
+            justification_artifact="synthetic-fixture-only.json",
+        )
+
+    def test_brier_conflict_blocks_keep_even_when_both_log_loss_intervals_win(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.02, 0.01),
+                basis=contrast(-0.05, -0.02, -0.02, -0.001),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
+
+    def test_brier_conflict_blocks_representation_only_even_with_exact_basis_equivalence(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.01, 0.01),
+                basis=contrast(0.0, 0.0, 0.0, 0.0),
+                utility=self.utility,
+                basis_prediction_equivalent=True,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
+
+    def test_log_loss_equality_at_keep_margin_is_not_a_win(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.05, -0.01, -0.02, -0.001),
+                basis=contrast(-0.04, -0.005, -0.02, -0.001),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
+
+    def test_log_loss_equality_at_simplify_boundary_does_not_exclude_material_benefit(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.01, 0.03, 0.0, 0.01),
+                basis=contrast(-0.005, 0.04, 0.0, 0.01),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
+
+    def test_zero_brier_upper_bound_supports_keep_but_is_not_a_simplify_rescue(self) -> None:
+        keep = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.02, 0.0),
+                basis=contrast(-0.05, -0.02, -0.02, 0.0),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(keep.decision, RealityDecision.KEEP)
+
+        simplify = decide_native_representation(
+            DecisionInput(
+                history=contrast(0.0, 0.03, -0.01, 0.0),
+                basis=contrast(0.0, 0.04, -0.01, 0.0),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(simplify.decision, RealityDecision.SIMPLIFY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_metric_coverage.py
+++ b/benchmarks/native-evidence-v1/tests/test_metric_coverage.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.metrics import evaluate_by_learner  # noqa: E402
+
+
+class MetricCoverageTests(unittest.TestCase):
+    def test_missing_rows_and_learners_reduce_reported_coverage_without_becoming_negative_labels(self) -> None:
+        bundle = evaluate_by_learner(
+            ["a", "a", "b"],
+            [0, 1, 0],
+            [0.2, 0.7, 0.3],
+            planned_learner_ids=["a", "b", "c"],
+            planned_row_count=5,
+        )
+
+        self.assertEqual(bundle.learner_count, 3)
+        self.assertEqual(bundle.learner_with_outcome_count, 2)
+        self.assertEqual(bundle.planned_row_count, 5)
+        self.assertEqual(bundle.observed_row_count, 3)
+        self.assertAlmostEqual(bundle.learner_outcome_coverage or 0.0, 2 / 3)
+        self.assertAlmostEqual(bundle.row_outcome_coverage or 0.0, 3 / 5)
+        self.assertEqual(sum(metric.row_count for metric in bundle.by_learner.values()), 3)
+
+    def test_observed_outcome_from_unplanned_learner_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "outside the frozen plan"):
+            evaluate_by_learner(
+                ["unexpected"],
+                [1],
+                [0.8],
+                planned_learner_ids=["planned"],
+                planned_row_count=1,
+            )
+
+    def test_observed_rows_cannot_exceed_frozen_planned_row_count(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot exceed planned_row_count"):
+            evaluate_by_learner(
+                ["a", "a"],
+                [0, 1],
+                [0.2, 0.8],
+                planned_learner_ids=["a"],
+                planned_row_count=1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_paired_alignment.py
+++ b/benchmarks/native-evidence-v1/tests/test_paired_alignment.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.metrics import evaluate_by_learner, paired_learner_bootstrap  # noqa: E402
+
+
+class PairedAlignmentTests(unittest.TestCase):
+    def test_missing_control_learner_is_rejected_instead_of_intersected_away(self) -> None:
+        target = evaluate_by_learner(
+            ["a", "b"],
+            [0, 1],
+            [0.2, 0.8],
+            planned_learner_ids=["a", "b"],
+            planned_row_count=2,
+        )
+        control = evaluate_by_learner(
+            ["a"],
+            [0],
+            [0.3],
+            planned_learner_ids=["a", "b"],
+            planned_row_count=2,
+        )
+
+        with self.assertRaisesRegex(ValueError, "complete-case row selection"):
+            paired_learner_bootstrap(target, {"history": control})
+
+    def test_changed_label_budget_is_rejected_even_when_row_counts_match(self) -> None:
+        target = evaluate_by_learner(
+            ["a", "a", "b", "b"],
+            [0, 1, 0, 1],
+            [0.2, 0.8, 0.3, 0.7],
+            planned_learner_ids=["a", "b"],
+            planned_row_count=4,
+        )
+        control = evaluate_by_learner(
+            ["a", "a", "b", "b"],
+            [0, 1, 1, 1],
+            [0.25, 0.75, 0.6, 0.8],
+            planned_learner_ids=["a", "b"],
+            planned_row_count=4,
+        )
+
+        with self.assertRaisesRegex(ValueError, "identical labels per learner"):
+            paired_learner_bootstrap(target, {"basis": control})
+
+    def test_different_frozen_plan_is_rejected_even_if_observed_rows_happen_to_match(self) -> None:
+        target = evaluate_by_learner(
+            ["a"],
+            [0],
+            [0.2],
+            planned_learner_ids=["a", "missing-a"],
+            planned_row_count=2,
+        )
+        control = evaluate_by_learner(
+            ["a"],
+            [0],
+            [0.3],
+            planned_learner_ids=["a", "missing-b"],
+            planned_row_count=2,
+        )
+
+        with self.assertRaisesRegex(ValueError, "identical planned learners"):
+            paired_learner_bootstrap(target, {"history": control})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_paired_alignment.py
+++ b/benchmarks/native-evidence-v1/tests/test_paired_alignment.py
@@ -17,56 +17,104 @@ class PairedAlignmentTests(unittest.TestCase):
             ["a", "b"],
             [0, 1],
             [0.2, 0.8],
+            row_ids=["a:r1", "b:r1"],
             planned_learner_ids=["a", "b"],
-            planned_row_count=2,
+            planned_row_ids=["a:r1", "b:r1"],
         )
         control = evaluate_by_learner(
             ["a"],
             [0],
             [0.3],
+            row_ids=["a:r1"],
             planned_learner_ids=["a", "b"],
-            planned_row_count=2,
+            planned_row_ids=["a:r1", "b:r1"],
         )
 
         with self.assertRaisesRegex(ValueError, "complete-case row selection"):
             paired_learner_bootstrap(target, {"history": control})
 
-    def test_changed_label_budget_is_rejected_even_when_row_counts_match(self) -> None:
+    def test_changed_label_binding_is_rejected_even_when_per_learner_counts_match(self) -> None:
+        row_ids = ["a:r1", "a:r2", "b:r1", "b:r2"]
         target = evaluate_by_learner(
             ["a", "a", "b", "b"],
             [0, 1, 0, 1],
             [0.2, 0.8, 0.3, 0.7],
+            row_ids=row_ids,
             planned_learner_ids=["a", "b"],
-            planned_row_count=4,
+            planned_row_ids=row_ids,
         )
         control = evaluate_by_learner(
             ["a", "a", "b", "b"],
-            [0, 1, 1, 1],
-            [0.25, 0.75, 0.6, 0.8],
+            [1, 0, 1, 0],
+            [0.75, 0.25, 0.6, 0.4],
+            row_ids=row_ids,
             planned_learner_ids=["a", "b"],
-            planned_row_count=4,
+            planned_row_ids=row_ids,
         )
 
-        with self.assertRaisesRegex(ValueError, "identical labels per learner"):
+        with self.assertRaisesRegex(ValueError, "row identity, learner and label bindings"):
             paired_learner_bootstrap(target, {"basis": control})
 
-    def test_different_frozen_plan_is_rejected_even_if_observed_rows_happen_to_match(self) -> None:
+    def test_same_counts_and_labels_cannot_hide_different_observed_rows(self) -> None:
+        planned_rows = ["a:r1", "a:r2", "a:r3", "b:r1"]
+        target = evaluate_by_learner(
+            ["a", "a", "b"],
+            [0, 1, 0],
+            [0.2, 0.8, 0.3],
+            row_ids=["a:r1", "a:r2", "b:r1"],
+            planned_learner_ids=["a", "b"],
+            planned_row_ids=planned_rows,
+        )
+        control = evaluate_by_learner(
+            ["a", "a", "b"],
+            [0, 1, 0],
+            [0.25, 0.75, 0.35],
+            row_ids=["a:r1", "a:r3", "b:r1"],
+            planned_learner_ids=["a", "b"],
+            planned_row_ids=planned_rows,
+        )
+
+        with self.assertRaisesRegex(ValueError, "row identity, learner and label bindings"):
+            paired_learner_bootstrap(target, {"history": control})
+
+    def test_different_frozen_row_plan_is_rejected_even_if_observed_rows_match(self) -> None:
         target = evaluate_by_learner(
             ["a"],
             [0],
             [0.2],
-            planned_learner_ids=["a", "missing-a"],
-            planned_row_count=2,
+            row_ids=["a:r1"],
+            planned_learner_ids=["a", "missing"],
+            planned_row_ids=["a:r1", "missing:r1"],
         )
         control = evaluate_by_learner(
             ["a"],
             [0],
             [0.3],
-            planned_learner_ids=["a", "missing-b"],
-            planned_row_count=2,
+            row_ids=["a:r1"],
+            planned_learner_ids=["a", "missing"],
+            planned_row_ids=["a:r1", "missing:r2"],
         )
 
-        with self.assertRaisesRegex(ValueError, "identical planned learners"):
+        with self.assertRaisesRegex(ValueError, "identical planned row ids"):
+            paired_learner_bootstrap(target, {"history": control})
+
+    def test_paired_comparison_requires_explicit_row_identity(self) -> None:
+        target = evaluate_by_learner(
+            ["a"],
+            [0],
+            [0.2],
+            planned_learner_ids=["a"],
+            planned_row_count=1,
+        )
+        control = evaluate_by_learner(
+            ["a"],
+            [0],
+            [0.3],
+            planned_learner_ids=["a"],
+            planned_row_count=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "explicit frozen planned row ids"):
             paired_learner_bootstrap(target, {"history": control})
 
 

--- a/benchmarks/native-evidence-v1/tests/test_predictor_fingerprints.py
+++ b/benchmarks/native-evidence-v1/tests/test_predictor_fingerprints.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.predictor import (  # noqa: E402
+    PredictorSpec,
+    fingerprint_predictor_spec,
+    fit_common_logistic_predictor,
+)
+
+
+CATEGORIES = {
+    "previous_outcome": ("missing", "success", "failure", "unknown"),
+    "current_task_family": ("free-recall", "near-transfer", "unknown"),
+}
+
+
+class PredictorFingerprintTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rows = [
+            {
+                "prior_eligible_attempt_count": 0,
+                "prior_success_rate": None,
+                "previous_outcome": "missing",
+                "current_task_family": "free-recall",
+            },
+            {
+                "prior_eligible_attempt_count": 1,
+                "prior_success_rate": 1.0,
+                "previous_outcome": "success",
+                "current_task_family": "free-recall",
+            },
+            {
+                "prior_eligible_attempt_count": 2,
+                "prior_success_rate": 0.5,
+                "previous_outcome": "failure",
+                "current_task_family": "near-transfer",
+            },
+            {
+                "prior_eligible_attempt_count": 3,
+                "prior_success_rate": 1 / 3,
+                "previous_outcome": "failure",
+                "current_task_family": "near-transfer",
+            },
+        ]
+        self.labels = [0, 0, 1, 1]
+
+    def test_reviewed_predictor_spec_has_stable_content_fingerprint(self) -> None:
+        spec = PredictorSpec()
+        fingerprint = fingerprint_predictor_spec(spec)
+        self.assertRegex(fingerprint, r"^sha256:[0-9a-f]{64}$")
+        self.assertEqual(fingerprint, fingerprint_predictor_spec(PredictorSpec()))
+        self.assertNotEqual(
+            fingerprint,
+            fingerprint_predictor_spec(PredictorSpec(C=2.0)),
+        )
+
+    def test_same_train_rows_reproduce_transform_fit_and_prediction_artifact(self) -> None:
+        first = fit_common_logistic_predictor(
+            self.rows,
+            self.labels,
+            categorical_domains=CATEGORIES,
+        )
+        second = fit_common_logistic_predictor(
+            self.rows,
+            self.labels,
+            categorical_domains=CATEGORIES,
+        )
+
+        self.assertEqual(first.spec_fingerprint, second.spec_fingerprint)
+        self.assertEqual(first.transform_fingerprint, second.transform_fingerprint)
+        self.assertEqual(first.fitted_artifact_fingerprint, second.fitted_artifact_fingerprint)
+        np.testing.assert_allclose(
+            first.predict_error_probability(self.rows),
+            second.predict_error_probability(self.rows),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_eval_only_rows_cannot_refit_or_change_frozen_transform_fingerprint(self) -> None:
+        predictor = fit_common_logistic_predictor(
+            self.rows,
+            self.labels,
+            categorical_domains=CATEGORIES,
+        )
+        before = predictor.transform_fingerprint
+        evaluation_rows = [
+            {
+                "prior_eligible_attempt_count": 100,
+                "prior_success_rate": None,
+                "previous_outcome": "future-unseen-value",
+                "current_task_family": "free-recall",
+            }
+        ]
+
+        probabilities = predictor.predict_error_probability(evaluation_rows)
+        self.assertTrue(np.all(np.isfinite(probabilities)))
+        self.assertEqual(before, predictor.transform_fingerprint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_predictor_nonconvergence.py
+++ b/benchmarks/native-evidence-v1/tests/test_predictor_nonconvergence.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.predictor import PredictorSpec, fit_common_logistic_predictor  # noqa: E402
+
+
+class PredictorNonconvergenceTests(unittest.TestCase):
+    def test_iteration_limited_fit_is_not_estimable_and_has_no_prediction_surface(self) -> None:
+        rows = [
+            {
+                "prior_eligible_attempt_count": index,
+                "prior_success_rate": (index % 7) / 6,
+                "previous_outcome": "success" if index % 3 else "failure",
+            }
+            for index in range(80)
+        ]
+        labels = [0 if index < 40 else 1 for index in range(80)]
+        predictor = fit_common_logistic_predictor(
+            rows,
+            labels,
+            categorical_domains={
+                "previous_outcome": ("success", "failure", "unknown"),
+            },
+            spec=PredictorSpec(max_iter=1, tol=1e-15),
+        )
+
+        self.assertEqual(predictor.availability, "not-estimable")
+        self.assertEqual(predictor.unavailable_reason, "nonconvergence")
+        self.assertIsNone(predictor.model)
+        with self.assertRaisesRegex(RuntimeError, "nonconvergence"):
+            predictor.predict_error_probability(rows[:1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
+++ b/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
@@ -51,7 +51,7 @@ def contrast(
 
 
 class FrozenPreprocessingTests(unittest.TestCase):
-    def test_transform_is_train_frozen_and_unseen_category_maps_to_unknown(self) -> None:
+    def test_transform_is_train_frozen_and_unseen_category_maps_to_declared_unknown(self) -> None:
         train = [
             {
                 "prior_eligible_attempt_count": 0,
@@ -74,21 +74,23 @@ class FrozenPreprocessingTests(unittest.TestCase):
         ]
         transform = fit_feature_transform(train, categorical_domains=CATEGORIES)
         before = transform
-        matrix = transform.transform(
-            [
-                {
-                    "prior_eligible_attempt_count": 8,
-                    "prior_success_rate": None,
-                    "previous_outcome": "future-new-category",
-                    "current_task_family": "free-recall",
-                }
-            ]
-        )
+        unseen = {
+            "prior_eligible_attempt_count": 8,
+            "prior_success_rate": None,
+            "previous_outcome": "future-new-category",
+            "current_task_family": "free-recall",
+        }
+        explicit_unknown = {**unseen, "previous_outcome": "unknown"}
+        unseen_matrix = transform.transform([unseen])
+        unknown_matrix = transform.transform([explicit_unknown])
+
         self.assertIs(transform, before)
-        self.assertEqual(matrix.shape[0], 1)
-        unknown_name = "cat:previous_outcome=unknown"
-        self.assertIn(unknown_name, transform.retained_columns)
-        self.assertEqual(matrix[0, transform.retained_columns.index(unknown_name)], 1.0)
+        self.assertEqual(unseen_matrix.shape[0], 1)
+        previous_transform = next(
+            item for item in transform.categorical if item.source_name == "previous_outcome"
+        )
+        self.assertIn("unknown", previous_transform.categories)
+        np.testing.assert_array_equal(unseen_matrix, unknown_matrix)
 
     def test_missing_numeric_is_explicit_and_not_serialized_as_zero_observation(self) -> None:
         train = [
@@ -183,11 +185,12 @@ class MetricTests(unittest.TestCase):
 
 class DecisionTests(unittest.TestCase):
     def setUp(self) -> None:
+        # Fixture-only approved margins exercise the gate; these are not Spec #005 real utility values.
         self.utility = UtilityMargins(
             delta_history=0.01,
             delta_basis=0.005,
             approved=True,
-            justification_artifact="utility-review.json",
+            justification_artifact="synthetic-fixture-utility-review.json",
         )
 
     def test_unresolved_utility_disables_keep_and_simplify(self) -> None:
@@ -210,15 +213,27 @@ class DecisionTests(unittest.TestCase):
         )
         self.assertEqual(result.decision, RealityDecision.KEEP)
 
-    def test_history_win_without_basis_win_is_representation_only(self) -> None:
+    def test_history_win_with_exact_basis_prediction_equivalence_is_representation_only(self) -> None:
         result = decide_native_representation(
             DecisionInput(
                 history=contrast(-0.08, -0.03, -0.03, -0.001),
-                basis=contrast(-0.01, 0.01, -0.01, 0.01),
+                basis=contrast(0.0, 0.0, 0.0, 0.0),
                 utility=self.utility,
+                basis_prediction_equivalent=True,
             )
         )
         self.assertEqual(result.decision, RealityDecision.KEEP_REPRESENTATION_ONLY)
+
+    def test_unresolved_basis_attribution_never_becomes_representation_only(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.03, -0.001),
+                basis=contrast(None, None, None, None),
+                utility=self.utility,
+                basis_prediction_equivalent=False,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
 
     def test_simplify_requires_material_benefit_excluded_against_both_controls(self) -> None:
         result = decide_native_representation(

--- a/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
+++ b/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
@@ -173,9 +173,31 @@ class MetricTests(unittest.TestCase):
     def test_paired_bootstrap_uses_shared_learner_units_and_is_reproducible(self) -> None:
         ids = ["a", "b", "c", "d"]
         labels = [0, 1, 0, 1]
-        target = evaluate_by_learner(ids, labels, [0.1, 0.8, 0.2, 0.7])
-        history = evaluate_by_learner(ids, labels, [0.2, 0.7, 0.3, 0.6])
-        basis = evaluate_by_learner(ids, labels, [0.15, 0.75, 0.25, 0.65])
+        row_ids = ["a:r1", "b:r1", "c:r1", "d:r1"]
+        target = evaluate_by_learner(
+            ids,
+            labels,
+            [0.1, 0.8, 0.2, 0.7],
+            row_ids=row_ids,
+            planned_learner_ids=ids,
+            planned_row_ids=row_ids,
+        )
+        history = evaluate_by_learner(
+            ids,
+            labels,
+            [0.2, 0.7, 0.3, 0.6],
+            row_ids=row_ids,
+            planned_learner_ids=ids,
+            planned_row_ids=row_ids,
+        )
+        basis = evaluate_by_learner(
+            ids,
+            labels,
+            [0.15, 0.75, 0.25, 0.65],
+            row_ids=row_ids,
+            planned_learner_ids=ids,
+            planned_row_ids=row_ids,
+        )
         first = paired_learner_bootstrap(target, {"history": history, "basis": basis})
         second = paired_learner_bootstrap(target, {"history": history, "basis": basis})
         self.assertEqual(first, second)

--- a/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
+++ b/benchmarks/native-evidence-v1/tests/test_predictor_plumbing.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.decision import (  # noqa: E402
+    DecisionInput,
+    RealityDecision,
+    UtilityMargins,
+    decide_native_representation,
+)
+from scripts.metrics import (  # noqa: E402
+    Interval,
+    PairedContrastInterval,
+    evaluate_binary_probabilities,
+    evaluate_by_learner,
+    paired_learner_bootstrap,
+)
+from scripts.predictor import fit_common_logistic_predictor, fit_prevalence_baseline  # noqa: E402
+from scripts.preprocessing import fit_feature_transform  # noqa: E402
+
+
+CATEGORIES = {
+    "previous_outcome": ("missing", "success", "failure", "unknown"),
+    "current_task_family": ("free-recall", "near-transfer", "unknown"),
+}
+
+
+def contrast(
+    log_lower: float | None,
+    log_upper: float | None,
+    brier_lower: float | None,
+    brier_upper: float | None,
+) -> PairedContrastInterval:
+    return PairedContrastInterval(
+        learner_count=20,
+        log_loss=None if log_lower is None or log_upper is None else Interval(log_lower, log_upper),
+        brier=None
+        if brier_lower is None or brier_upper is None
+        else Interval(brier_lower, brier_upper),
+        descriptive_log_loss_difference=None,
+        descriptive_brier_difference=None,
+    )
+
+
+class FrozenPreprocessingTests(unittest.TestCase):
+    def test_transform_is_train_frozen_and_unseen_category_maps_to_unknown(self) -> None:
+        train = [
+            {
+                "prior_eligible_attempt_count": 0,
+                "prior_success_rate": None,
+                "previous_outcome": "missing",
+                "current_task_family": "free-recall",
+            },
+            {
+                "prior_eligible_attempt_count": 1,
+                "prior_success_rate": 1.0,
+                "previous_outcome": "success",
+                "current_task_family": "near-transfer",
+            },
+            {
+                "prior_eligible_attempt_count": 2,
+                "prior_success_rate": 0.5,
+                "previous_outcome": "failure",
+                "current_task_family": "free-recall",
+            },
+        ]
+        transform = fit_feature_transform(train, categorical_domains=CATEGORIES)
+        before = transform
+        matrix = transform.transform(
+            [
+                {
+                    "prior_eligible_attempt_count": 8,
+                    "prior_success_rate": None,
+                    "previous_outcome": "future-new-category",
+                    "current_task_family": "free-recall",
+                }
+            ]
+        )
+        self.assertIs(transform, before)
+        self.assertEqual(matrix.shape[0], 1)
+        unknown_name = "cat:previous_outcome=unknown"
+        self.assertIn(unknown_name, transform.retained_columns)
+        self.assertEqual(matrix[0, transform.retained_columns.index(unknown_name)], 1.0)
+
+    def test_missing_numeric_is_explicit_and_not_serialized_as_zero_observation(self) -> None:
+        train = [
+            {"prior_success_rate": None, "previous_outcome": "missing", "current_task_family": "free-recall"},
+            {"prior_success_rate": 0.25, "previous_outcome": "failure", "current_task_family": "near-transfer"},
+            {"prior_success_rate": 0.75, "previous_outcome": "success", "current_task_family": "free-recall"},
+        ]
+        transform = fit_feature_transform(train, categorical_domains=CATEGORIES)
+        matrix = transform.transform([train[0]])
+        missing_name = "missing:prior_success_rate"
+        self.assertIn(missing_name, transform.retained_columns)
+        self.assertEqual(matrix[0, transform.retained_columns.index(missing_name)], 1.0)
+
+    def test_b2_named_column_wins_exact_duplicate_pruning(self) -> None:
+        train = [
+            {"prior_positive_count": 0, "nep_positive_count": 0},
+            {"prior_positive_count": 1, "nep_positive_count": 1},
+            {"prior_positive_count": 3, "nep_positive_count": 3},
+        ]
+        transform = fit_feature_transform(train, categorical_domains={})
+        dropped = dict(transform.dropped_duplicate_columns)
+        self.assertEqual(dropped.get("num:nep_positive_count"), "num:prior_positive_count")
+
+
+class PredictorTests(unittest.TestCase):
+    def test_one_class_train_is_not_estimable_but_prevalence_stays_available(self) -> None:
+        rows = [
+            {"prior_eligible_attempt_count": 0},
+            {"prior_eligible_attempt_count": 1},
+            {"prior_eligible_attempt_count": 2},
+        ]
+        predictor = fit_common_logistic_predictor(rows, [0, 0, 0], categorical_domains={})
+        self.assertEqual(predictor.availability, "not-estimable")
+        self.assertEqual(predictor.unavailable_reason, "one-class-train")
+
+        baseline = fit_prevalence_baseline([0, 0, 0])
+        self.assertAlmostEqual(baseline.error_probability, 1 / 5)
+        np.testing.assert_allclose(baseline.predict(2), np.asarray([0.2, 0.2]))
+
+    def test_common_logistic_fit_returns_finite_probabilities(self) -> None:
+        rows = [
+            {"prior_eligible_attempt_count": 0, "previous_outcome": "missing", "current_task_family": "free-recall"},
+            {"prior_eligible_attempt_count": 1, "previous_outcome": "success", "current_task_family": "free-recall"},
+            {"prior_eligible_attempt_count": 2, "previous_outcome": "failure", "current_task_family": "near-transfer"},
+            {"prior_eligible_attempt_count": 3, "previous_outcome": "failure", "current_task_family": "near-transfer"},
+        ]
+        predictor = fit_common_logistic_predictor(rows, [0, 0, 1, 1], categorical_domains=CATEGORIES)
+        self.assertEqual(predictor.availability, "available")
+        probabilities = predictor.predict_error_probability(rows)
+        self.assertTrue(np.all(np.isfinite(probabilities)))
+        self.assertTrue(np.all((probabilities >= 0) & (probabilities <= 1)))
+
+
+class MetricTests(unittest.TestCase):
+    def test_one_class_subset_keeps_log_loss_and_brier_and_nulls_auc(self) -> None:
+        metrics = evaluate_binary_probabilities([1, 1], [0.8, 0.6])
+        self.assertIsNone(metrics.auc)
+        self.assertEqual(metrics.auc_unavailable_reason, "one-class-subset")
+        self.assertGreater(metrics.log_loss, 0)
+        self.assertGreaterEqual(metrics.brier, 0)
+        self.assertEqual(len(metrics.calibration_bins), 5)
+
+    def test_clipping_is_evaluation_only_and_audited(self) -> None:
+        metrics = evaluate_binary_probabilities([0, 1], [0.0, 1.0])
+        self.assertEqual(metrics.clipped_probability_count, 2)
+        self.assertGreaterEqual(metrics.log_loss, 0)
+        self.assertEqual(metrics.brier, 0.0)
+
+    def test_learner_weighting_differs_from_attempt_weighting_when_rows_are_unbalanced(self) -> None:
+        learners = ["a", "a", "a", "b"]
+        labels = [0, 0, 0, 1]
+        probabilities = [0.1, 0.1, 0.1, 0.1]
+        bundle = evaluate_by_learner(learners, labels, probabilities, planned_learner_ids=["a", "b", "c"])
+        self.assertEqual(bundle.learner_count, 3)
+        self.assertEqual(bundle.learner_with_outcome_count, 2)
+        self.assertIsNotNone(bundle.attempt_weighted)
+        assert bundle.attempt_weighted is not None
+        self.assertNotAlmostEqual(bundle.mean_per_learner_log_loss, bundle.attempt_weighted.log_loss)
+
+    def test_paired_bootstrap_uses_shared_learner_units_and_is_reproducible(self) -> None:
+        ids = ["a", "b", "c", "d"]
+        labels = [0, 1, 0, 1]
+        target = evaluate_by_learner(ids, labels, [0.1, 0.8, 0.2, 0.7])
+        history = evaluate_by_learner(ids, labels, [0.2, 0.7, 0.3, 0.6])
+        basis = evaluate_by_learner(ids, labels, [0.15, 0.75, 0.25, 0.65])
+        first = paired_learner_bootstrap(target, {"history": history, "basis": basis})
+        second = paired_learner_bootstrap(target, {"history": history, "basis": basis})
+        self.assertEqual(first, second)
+        self.assertEqual(first["history"].learner_count, 4)
+        self.assertIsNotNone(first["history"].log_loss)
+
+
+class DecisionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.utility = UtilityMargins(
+            delta_history=0.01,
+            delta_basis=0.005,
+            approved=True,
+            justification_artifact="utility-review.json",
+        )
+
+    def test_unresolved_utility_disables_keep_and_simplify(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.1, -0.08, -0.03, -0.01),
+                basis=contrast(-0.1, -0.08, -0.03, -0.01),
+                utility=UtilityMargins(None, None, False, None),
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.GATHER_MORE_EVIDENCE)
+
+    def test_keep_requires_winning_both_controls(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.03, -0.001),
+                basis=contrast(-0.05, -0.02, -0.02, 0.0),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.KEEP)
+
+    def test_history_win_without_basis_win_is_representation_only(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.08, -0.03, -0.03, -0.001),
+                basis=contrast(-0.01, 0.01, -0.01, 0.01),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.KEEP_REPRESENTATION_ONLY)
+
+    def test_simplify_requires_material_benefit_excluded_against_both_controls(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(0.001, 0.03, -0.01, 0.01),
+                basis=contrast(0.002, 0.04, -0.01, 0.02),
+                utility=self.utility,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.SIMPLIFY)
+
+    def test_instrumentation_failure_redesigns_before_predictive_decision(self) -> None:
+        result = decide_native_representation(
+            DecisionInput(
+                history=contrast(-0.1, -0.08, -0.03, -0.01),
+                basis=contrast(-0.1, -0.08, -0.03, -0.01),
+                utility=self.utility,
+                instrumentation_valid=False,
+            )
+        )
+        self.assertEqual(result.decision, RealityDecision.REDESIGN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_preprocessing_availability.py
+++ b/benchmarks/native-evidence-v1/tests/test_preprocessing_availability.py
@@ -48,6 +48,32 @@ class AvailabilityMaskTests(unittest.TestCase):
         self.assertNotIn("missing:feature_a", dropped)
         self.assertNotIn("missing:feature_b", dropped)
 
+    def test_train_seen_only_category_still_retains_explicit_unknown_channel(self) -> None:
+        train = [
+            {"current_task_family": "free-recall"},
+            {"current_task_family": "free-recall"},
+        ]
+        transform = fit_feature_transform(
+            train,
+            categorical_domains={
+                "current_task_family": ("free-recall", "near-transfer", "unknown"),
+            },
+        )
+
+        unknown_name = "cat:current_task_family=unknown"
+        self.assertIn(unknown_name, transform.retained_columns)
+        self.assertNotIn(unknown_name, transform.dropped_constant_columns)
+
+        known = transform.transform([{"current_task_family": "free-recall"}])
+        unseen = transform.transform([{"current_task_family": "future-new-family"}])
+        explicit_unknown = transform.transform([{"current_task_family": "unknown"}])
+        unknown_index = transform.retained_columns.index(unknown_name)
+
+        self.assertEqual(known[0, unknown_index], 0.0)
+        self.assertEqual(unseen[0, unknown_index], 1.0)
+        np.testing.assert_array_equal(unseen, explicit_unknown)
+        self.assertFalse(np.array_equal(known, unseen))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_preprocessing_availability.py
+++ b/benchmarks/native-evidence-v1/tests/test_preprocessing_availability.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.preprocessing import fit_feature_transform  # noqa: E402
+
+
+class AvailabilityMaskTests(unittest.TestCase):
+    def test_train_complete_numeric_still_retains_missing_indicator_for_future_unknown(self) -> None:
+        train = [
+            {"prior_success_rate": 0.0},
+            {"prior_success_rate": 0.5},
+            {"prior_success_rate": 1.0},
+        ]
+        transform = fit_feature_transform(train, categorical_domains={})
+
+        missing_name = "missing:prior_success_rate"
+        self.assertIn(missing_name, transform.retained_columns)
+        self.assertNotIn(missing_name, transform.dropped_constant_columns)
+
+        mean_observation = transform.transform([{"prior_success_rate": 0.5}])
+        missing_observation = transform.transform([{"prior_success_rate": None}])
+        missing_index = transform.retained_columns.index(missing_name)
+
+        self.assertEqual(mean_observation[0, missing_index], 0.0)
+        self.assertEqual(missing_observation[0, missing_index], 1.0)
+        self.assertFalse(np.array_equal(mean_observation, missing_observation))
+
+    def test_availability_masks_are_not_pruned_as_exact_duplicates(self) -> None:
+        train = [
+            {"feature_a": 0.0, "feature_b": 1.0},
+            {"feature_a": 1.0, "feature_b": 2.0},
+            {"feature_a": 2.0, "feature_b": 3.0},
+        ]
+        transform = fit_feature_transform(train, categorical_domains={})
+
+        self.assertIn("missing:feature_a", transform.retained_columns)
+        self.assertIn("missing:feature_b", transform.retained_columns)
+        dropped = dict(transform.dropped_duplicate_columns)
+        self.assertNotIn("missing:feature_a", dropped)
+        self.assertNotIn("missing:feature_b", dropped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/tests/test_preprocessing_counts.py
+++ b/benchmarks/native-evidence-v1/tests/test_preprocessing_counts.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.preprocessing import fit_feature_transform  # noqa: E402
+
+
+class CountTransformTests(unittest.TestCase):
+    def test_positive_and_negative_count_suffixes_use_log1p(self) -> None:
+        rows = [
+            {
+                "prior_family_free-recall_positive": 0,
+                "prior_role_free-recall_negative": 1,
+                "prior_success_rate": 0.0,
+            },
+            {
+                "prior_family_free-recall_positive": 3,
+                "prior_role_free-recall_negative": 2,
+                "prior_success_rate": 0.5,
+            },
+            {
+                "prior_family_free-recall_positive": 7,
+                "prior_role_free-recall_negative": 4,
+                "prior_success_rate": 1.0,
+            },
+        ]
+        transform = fit_feature_transform(rows, categorical_domains={})
+        by_source = {item.source_name: item for item in transform.numeric}
+
+        self.assertTrue(by_source["prior_family_free-recall_positive"].log1p)
+        self.assertTrue(by_source["prior_role_free-recall_negative"].log1p)
+        self.assertFalse(by_source["prior_success_rate"].log1p)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/native-evidence-v1/types.ts
+++ b/benchmarks/native-evidence-v1/types.ts
@@ -1,0 +1,60 @@
+import type { ReferenceCoreEvidence } from "@/lib/core/certified-evidence";
+import type { CoreTaskSpec } from "@/lib/core/task";
+
+export const NATIVE_PILOT_CONTRACT_ID = "nep.native-evidence-pilot.v1" as const;
+export const NATIVE_PREDICTOR_CONTRACT_ID = "nep.native-predictor.v1" as const;
+export const NATIVE_PILOT_SCORING_CONTRACT_ID = "nep.native-pilot.binary-v1" as const;
+export const NATIVE_PILOT_TARGET_ID = "nep.en.v1.language-system.syntax-grammar" as const;
+export const NATIVE_PILOT_CONTENT_SLICE = "pilot-slice:present-subject-verb-agreement" as const;
+export const SYNTHETIC_ONLY_STATUS = "synthetic-plumbing-only" as const;
+
+export const PILOT_TASK_FAMILIES = [
+  "recognition-independent",
+  "recognition-supported",
+  "free-recall",
+  "delayed-free-recall",
+  "near-transfer",
+] as const;
+
+export type PilotTaskFamily = (typeof PILOT_TASK_FAMILIES)[number];
+
+export type PilotTaskDefinition = {
+  readonly pilotContractId: typeof NATIVE_PILOT_CONTRACT_ID;
+  readonly family: PilotTaskFamily;
+  readonly task: CoreTaskSpec;
+  readonly contentFingerprint: `sha256:${string}`;
+  readonly contextId: string;
+  readonly stimulusFormGroup: string;
+  readonly scoringContractId: typeof NATIVE_PILOT_SCORING_CONTRACT_ID;
+};
+
+export type SyntheticPilotEvent = {
+  readonly participantId: string;
+  readonly taskDefinition: PilotTaskDefinition;
+  readonly evidence: ReferenceCoreEvidence;
+  readonly availableAt: string;
+};
+
+export type FeatureValue = number | string | null;
+export type FeatureVector = Readonly<Record<string, FeatureValue>>;
+
+export type PredictionFeatureRow = {
+  readonly participantId: string;
+  readonly targetEventId: string;
+  readonly predictionTimestamp: string;
+  readonly label: 0 | 1 | null;
+  readonly acceptedHistoryEventIds: readonly string[];
+  readonly b2: FeatureVector;
+  readonly b2Basis: FeatureVector;
+  readonly b3: FeatureVector;
+};
+
+export type SyntheticArtifactKind = "feature" | "model" | "prediction" | "result";
+
+export type SyntheticArtifactRecord = {
+  readonly artifactId: string;
+  readonly kind: SyntheticArtifactKind;
+  readonly participantIds: readonly string[];
+  readonly valid: boolean;
+  readonly invalidatedReason: string | null;
+};

--- a/benchmarks/native-evidence-v1/types.ts
+++ b/benchmarks/native-evidence-v1/types.ts
@@ -55,6 +55,7 @@ export type SyntheticArtifactRecord = {
   readonly artifactId: string;
   readonly kind: SyntheticArtifactKind;
   readonly participantIds: readonly string[];
+  readonly dependsOnArtifactIds: readonly string[];
   readonly valid: boolean;
   readonly invalidatedReason: string | null;
 };

--- a/specs/005-native-evidence-pilot-v1/tasks.md
+++ b/specs/005-native-evidence-pilot-v1/tasks.md
@@ -11,7 +11,7 @@
 - [x] N007 Define delayed-retrieval and changed-context causal rules; primary prediction targets are free-recall/delayed-free-recall/near-transfer.
 - [x] N008 Draft privacy/consent/retention requirements; human collection remains disabled.
 - [x] N009 Require `nep.native-predictor.v1` estimator/hyperparameter freeze before any human N3 outcomes; comparative proposal specifies the configuration for N2 verification.
-- [ ] N010 Independent review PASS for Spec #005 exact head.
+- [x] N010 Independent review PASS for Spec #005 exact head `34013121cb9ab6850d15fa09a06ed3a46da44486` (PR #146 review `5120984278`).
 
 ## Comparative amendment — CODEX-CORE-FRONTIER-001
 
@@ -19,27 +19,27 @@
 - [x] N012 Propose baseline ladder, common estimator and conditional classical comparator in `contracts/native-pilot-contract.md`.
 - [x] N013 Map B3 columns to canonical code and expose duplicate/count-derived transforms; specify B2-basis attribution control.
 - [x] N014 Propose causal split/availability, metrics/coverage, uncertainty, sizing and removal criteria before N3.
-- [ ] N015 Independently approve amended Spec #005 and its statistical choices; N010 remains required.
+- [x] N015 Independently approve amended Spec #005 and its statistical choices on exact head `34013121cb9ab6850d15fa09a06ed3a46da44486`; N010 recorded above.
 
 ## N2 — synthetic plumbing only
 
-- [ ] N020 Create `benchmarks/native-evidence-v1/` from reviewed Spec #005.
-- [ ] N021 Implement versioned task definitions using existing `CoreTaskSpec`.
-- [ ] N022 Implement synthetic observations/candidates and issue evidence only through `validateReferenceCoreEvidence()`.
-- [ ] N023 Add cold-start, support/reveal, free-recall, delayed-recall, valid/invalid transfer scenarios.
-- [ ] N024 Add duplicate and out-of-order reducer adversarial scenarios.
-- [ ] N025 Add detached/cloned evidence rejection scenario.
-- [ ] N026 Implement strong B2/B3 pre-attempt feature extraction with explicit prediction timestamp and no future/current label feedback.
+- [x] N020 Create `benchmarks/native-evidence-v1/` from reviewed Spec #005.
+- [x] N021 Implement versioned task definitions using existing `CoreTaskSpec`.
+- [x] N022 Implement synthetic observations/candidates and issue evidence only through `validateReferenceCoreEvidence()`.
+- [x] N023 Add cold-start, support/reveal, free-recall, delayed-recall, valid/invalid transfer scenarios.
+- [x] N024 Add duplicate and out-of-order reducer adversarial scenarios.
+- [x] N025 Add detached/cloned evidence rejection scenario.
+- [x] N026 Implement strong B2/B3 pre-attempt feature extraction with explicit prediction timestamp and no future/current label feedback.
 - [ ] N027 Verify and fingerprint the reviewed `nep.native-predictor.v1` configuration using synthetic stability checks only; same estimator/preprocessing for B2/B2-basis/B3.
-- [ ] N028 Implement synthetic participant export/delete and prove participant-scoped artifacts are removed.
-- [ ] N029 Reuse benchmark manifest/integrity conventions; clearly mark every artifact `synthetic-plumbing-only`.
+- [x] N028 Implement synthetic participant export/delete and prove participant-scoped artifacts are removed.
+- [x] N029 Reuse benchmark manifest/integrity conventions; clearly mark every artifact `synthetic-plumbing-only`.
 - [ ] N030 Exact-head Verify + focused native harness CI green.
 - [ ] N031 Opposite-agent independent review PASS of N2 implementation.
-- [ ] N032 Implement B0 and B2-basis controls, algebraic duplicate audit and stable TRAIN-only preprocessing per predictor contract.
+- [x] N032 Implement B0 and B2-basis controls, algebraic duplicate audit and stable TRAIN-only preprocessing per predictor contract.
 - [ ] N033 Add late-label/equal-time, blind-block, participant-isolation and future-label mutation adversarial tests.
 - [ ] N034 Adapt metric/manifest donor for one-class Brier/log loss, nullable AUC, complete coverage and paired learner resampling.
 - [ ] N035 Verify installed pinned pyBKT backend and supported seeded multi-fit; parity-test a diagnostic observer, record per-start stopping/likelihoods, and review TRAIN-only near-best/stability tolerances. Missing diagnostics or one poor start must not exclude working BKT; retain unresolved assurance explicitly.
-- [ ] N036 Verify deletion invalidates dependent model/prediction/result artifacts; no participant survives through a stale fitted artifact.
+- [x] N036 Verify deletion invalidates dependent model/prediction/result artifacts; no participant survives through a stale fitted artifact.
 - [ ] N037 Test the two-contrast attribution decision table, exact versus unproven equivalence, missing utility margins, Brier conflicts and equality boundaries; no synthetic validity claims.
 
 ## N3 — human pilot

--- a/specs/005-native-evidence-pilot-v1/tasks.md
+++ b/specs/005-native-evidence-pilot-v1/tasks.md
@@ -30,17 +30,17 @@
 - [x] N024 Add duplicate and out-of-order reducer adversarial scenarios.
 - [x] N025 Add detached/cloned evidence rejection scenario.
 - [x] N026 Implement strong B2/B3 pre-attempt feature extraction with explicit prediction timestamp and no future/current label feedback.
-- [ ] N027 Verify and fingerprint the reviewed `nep.native-predictor.v1` configuration using synthetic stability checks only; same estimator/preprocessing for B2/B2-basis/B3.
+- [x] N027 Verify and fingerprint the reviewed `nep.native-predictor.v1` configuration using synthetic stability checks only; same estimator/preprocessing for B2/B2-basis/B3.
 - [x] N028 Implement synthetic participant export/delete and prove participant-scoped artifacts are removed.
 - [x] N029 Reuse benchmark manifest/integrity conventions; clearly mark every artifact `synthetic-plumbing-only`.
-- [ ] N030 Exact-head Verify + focused native harness CI green.
+- [ ] N030 Exact-head Verify + focused native harness CI green. Focused Native Evidence N2 run `33965408898` is green at `cadcc0bc2b50936f5f90e6f55d7a533e5eee94a8`; standard exact-head Verify remains required.
 - [ ] N031 Opposite-agent independent review PASS of N2 implementation.
 - [x] N032 Implement B0 and B2-basis controls, algebraic duplicate audit and stable TRAIN-only preprocessing per predictor contract.
-- [ ] N033 Add late-label/equal-time, blind-block, participant-isolation and future-label mutation adversarial tests.
-- [ ] N034 Adapt metric/manifest donor for one-class Brier/log loss, nullable AUC, complete coverage and paired learner resampling.
-- [ ] N035 Verify installed pinned pyBKT backend and supported seeded multi-fit; parity-test a diagnostic observer, record per-start stopping/likelihoods, and review TRAIN-only near-best/stability tolerances. Missing diagnostics or one poor start must not exclude working BKT; retain unresolved assurance explicitly.
+- [x] N033 Add late-label/equal-time, blind-block, participant-isolation and future-label mutation adversarial tests.
+- [x] N034 Adapt metric/manifest donor for one-class Brier/log loss, nullable AUC, explicit missing-outcome coverage and paired learner resampling.
+- [ ] N035 Verify installed pinned pyBKT backend and supported seeded multi-fit; parity-test a diagnostic observer, record per-start stopping/likelihoods, and review TRAIN-only near-best/stability tolerances. Backend/observer/parity/convergence telemetry is implemented and emitted as a `synthetic-plumbing-only` CI artifact; TRAIN-only near-best/predictive-stability tolerances remain deliberately unresolved pending independent review.
 - [x] N036 Verify deletion invalidates dependent model/prediction/result artifacts; no participant survives through a stale fitted artifact.
-- [ ] N037 Test the two-contrast attribution decision table, exact versus unproven equivalence, missing utility margins, Brier conflicts and equality boundaries; no synthetic validity claims.
+- [x] N037 Test the two-contrast attribution decision table, exact versus unproven equivalence, missing utility margins, Brier conflicts and equality boundaries; no synthetic validity claims.
 
 ## N3 — human pilot
 

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -8,6 +8,7 @@ export default defineProject({
     globals: true,
     include: [
       "scripts/lib/**/*.test.ts",
+      "benchmarks/native-evidence-v1/**/*.test.ts",
       "src/lib/dashboard/word-of-day.test.ts",
       "src/__tests__/architecture-boundaries.test.ts",
       "src/__tests__/curriculum-quality.test.ts",


### PR DESCRIPTION
## Scope

Stage N2 synthetic-only implementation for reviewed Spec #005 on top of PR #146 exact approved head `34013121cb9ab6850d15fa09a06ed3a46da44486`.

Current exact implementation head: `aedaa72b3689671ac8f1dd4906a168ce345aa382`.

Implemented:
- prospective five-family `CoreTaskSpec` matrix and reference-only issuance through `validateReferenceCoreEvidence()`;
- one shared accepted-history ledger for B2/B2-basis/B3, strict `occurredAt` + `availableAt` cutoffs, unknown-vs-zero handling and future/current-label mutation invariance;
- exact accepted-history parity with the canonical core projector: duplicate event IDs are rebound one-to-one, core `occurredAt/eventId` ordering is preserved rather than host availability ordering, and wrapper task metadata must match validated evidence or fail closed;
- frozen split/fit-cutoff protocol that prevents blind TEST-block feedback and forces held-out participants to cold start;
- frozen TRAIN-prefix selectors reject ambiguous duplicate prefix IDs rather than using last-write-wins semantics;
- every blind target is now prospectively bound to exactly one participant, prediction timestamp and current-task feature semantics (family, task id/version, content fingerprint, support/reveal, transfer distance, context, stimulus-form group and scoring contract); cross-participant target swaps, timestamp drift and task-semantic drift fail closed;
- B0, strong B2, algebraic B2-basis, and actual projector B3 feature lanes;
- TRAIN-only preprocessing with preserved numeric missingness masks and categorical unknown channels, count `log1p` transforms, reviewed scikit-learn logistic configuration, deterministic fingerprints, one-class/nonconverged `not-estimable` behavior;
- learner-weighted log loss/Brier, nullable one-class AUC, fixed calibration bins and explicit missing-outcome coverage;
- paired learner bootstrap requires the same frozen row IDs and exact observed `(rowId, participantId, label)` bindings across lanes, so equal row counts or equal per-learner positive counts cannot conceal complete-case or row-swap drift;
- two-control KEEP/SIMPLIFY attribution gate including exact-vs-unproven equivalence, utility-unresolved, Brier-conflict and equality-boundary cases;
- transitive synthetic artifact lineage and deletion invalidation across feature -> model -> prediction -> result;
- pinned pyBKT 1.4.3 comparator at source revision `06fc180ae72c117458acc527f8ec90cc8e0581c1`, source-faithful 5-start fit, blind predict-before-update path, installed-backend inspection, non-invasive EM observer parity tests, selected-parameter and per-start diagnostic artifact;
- full synthetic run manifest binds frozen split/cutoff, participant allocation, per-target frozen schedule/task semantics, model/prediction fingerprints, artifact lineage, coverage, source/license pins, BKT diagnostics, utility-gate status and decision-rule version;
- every generated research artifact remains `synthetic-plumbing-only` and explicitly forbids learner-validity/mastery/calibration claims.

## Latest self-audit corrections

The self-audit has now found and corrected four fail-closed integrity gaps after the earlier implementation checkpoint:
1. paired metric alignment previously compared counts/label totals rather than exact frozen row identity;
2. frozen TRAIN-prefix selection previously had a `Map(eventId -> event)` last-write-wins ambiguity on duplicate supplied IDs;
3. blind target IDs and participant IDs were individually valid but not frozen together, allowing a cross-participant target swap in principle;
4. blind prediction timestamp/current-task semantics were caller-supplied at evaluation time rather than frozen into the prospective target schedule, allowing recency/current-task features to drift after protocol freeze.

All four now have adversarial regression coverage. Target schedule bindings are also persisted inside the split manifest digest so the run artifact records the exact participant/time/task semantics being evaluated.

## Exact-head CI evidence

Focused Native Evidence N2:
- run `33973826674` / #76 — SUCCESS on exact head `aedaa72b3689671ac8f1dd4906a168ce345aa382`;
- TypeScript documentation governance/lint/typecheck/all focused N2 tests — SUCCESS;
- Python predictor/metric/pyBKT tests and diagnostics emission — SUCCESS;
- pyBKT artifact: `native-bkt-diagnostics-aedaa72b3689671ac8f1dd4906a168ce345aa382`, artifact id `9971717978`, digest `sha256:81010f7058895213a087ff8a5333c759a945ff42d70ca45646f1f96bf4e2fa56`.

Standard Verify exact-head:
- run `33973892834` / Verify #724 — SUCCESS on the exact same SHA, launched through verification-only branch `gemini/verify-native-evidence-n2-aedaa7`;
- documentation governance, lint, TypeScript, full unit tests and content standards — SUCCESS;
- fresh Supabase migrations, DB lint and pgTAP/RLS tests — SUCCESS.

N030 is satisfied for this exact implementation SHA. Any later code/doc commit that changes the PR head invalidates this exact-head evidence and requires a fresh Verify.

The observed CI pyBKT backend remains pure-Python E-step with effective EM `tol=0.005`, `maxiter=100`, `<=`; observer/public parity matches, selected predictions are finite, and convergence assurance is observed. This is plumbing evidence only. The backend stopping tolerance is not a between-start stability/equivalence threshold.

## Remaining gates before N2 PASS

- N031 — independent opposite-agent adversarial review of exact head `aedaa72b3689671ac8f1dd4906a168ce345aa382`;
- N035 — independent review/freeze or explicit rejection of TRAIN-only pyBKT near-best-likelihood and predictive-stability tolerances. Current stability assurance intentionally remains unresolved; absent an independently defensible threshold, the correct disposition remains `TOLERANCES_UNJUSTIFIED` rather than inventing a cutoff from synthetic ranges or backend EM tolerance.

All earlier N031/N035 handoffs are stale because the implementation head moved during self-audit. A fresh exact-head handoff is required against `aedaa72...`.

## Boundary

No human N3 collection, learner-model validity claim, predictive-superiority claim, calibration/mastery/CEFR promotion, production write, UI, merge, deploy, or Ready-for-review transition is authorized. Keep Draft.