### PR TITLE
fix(learning): route legacy attempts through canonical RPC

### DIFF
--- a/src/app/actions/learning-attempts.ts
+++ b/src/app/actions/learning-attempts.ts
@@ -1,8 +1,14 @@
 "use server";
 
 import { headers } from "next/headers";
-import { createClient } from "@/lib/supabase/server";
-import { createRateLimiter } from "@/lib/security/rate-limit";
+import { z } from "zod";
+
+import { seedUnitVocabToSRS } from "@/app/actions/cards";
+import { completeUnit } from "@/app/actions/unit";
+import {
+  compileLegacyAttemptRpcArgs,
+  type LegacyAttemptRpcArgs,
+} from "@/lib/learning/legacy-attempt-adapter";
 import {
   LearningAttemptBatchSchema,
   type LearningAttemptBatchInput,
@@ -12,16 +18,31 @@ import {
   scoreTrialCheckpoint,
 } from "@/lib/lessons/trial-checkpoint";
 import { GOLD_MISSION_01 } from "@/lib/missions/gold-mission-01";
-import { seedUnitVocabToSRS } from "@/app/actions/cards";
-import { completeUnit } from "@/app/actions/unit";
-import { z } from "zod";
+import { createRateLimiter } from "@/lib/security/rate-limit";
+import { createClient } from "@/lib/supabase/server";
 
 const attemptLimiter = createRateLimiter(60, 60_000, "learning-attempts");
 
+type RpcError = { message: string } | null;
+type RpcClient = {
+  rpc: (
+    fn: "record_learning_attempt",
+    args: LegacyAttemptRpcArgs,
+  ) => Promise<{ data: unknown; error: RpcError }>;
+};
+
+/**
+ * Compatibility boundary for legacy mission/checkpoint callers.
+ *
+ * The September learning-core migration replaced the old lesson/activity/score table shape with
+ * the canonical Attempt → Evidence → LearnerSkillState model and revoked direct authenticated
+ * inserts. Legacy callers do not carry enough canonical semantic identity to create trustworthy
+ * mastery evidence, so we preserve them as attempt-only history through the canonical RPC.
+ */
 export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
   const parsed = LearningAttemptBatchSchema.safeParse(input);
   if (!parsed.success) {
-    return { success: false as const, error: "Dữ liệu lần học không hợp lệ." };
+    return { success: false as const, error: "Dữ liệu lần học không hợp lệ.", inserted: 0 };
   }
 
   const requestHeaders = await headers();
@@ -33,6 +54,7 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     return {
       success: false as const,
       error: "Quá nhiều lần ghi nhận. Vui lòng thử lại sau.",
+      inserted: 0,
     };
   }
 
@@ -42,30 +64,32 @@ export async function recordLearningAttempts(input: LearningAttemptBatchInput) {
     error: authError,
   } = await supabase.auth.getUser();
   if (authError || !user) {
-    return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ." };
+    return { success: false as const, error: "Bạn cần đăng nhập để lưu tiến độ.", inserted: 0 };
   }
 
-  const { error } = await supabase.from("learning_attempts").insert(
-    parsed.data.attempts.map((attempt) => ({
-      user_id: user.id,
-      session_id: parsed.data.sessionId,
-      lesson_id: parsed.data.lessonId,
-      activity_id: attempt.activityId,
-      modality: attempt.modality,
-      status: attempt.status,
-      score: attempt.score,
-      error_tags: attempt.errorTags,
-      evaluator: attempt.evaluator,
-      evaluator_version: attempt.evaluatorVersion,
-      latency_ms: attempt.latencyMs,
-    })),
-  );
+  const rpcClient = supabase as unknown as RpcClient;
+  let inserted = 0;
 
-  if (error) {
-    return { success: false as const, error: "Không thể lưu bằng chứng học tập." };
+  // Compatibility attempts are intentionally evidence-free. Sequential writes make any partial
+  // failure explicit to the caller; a partial failure cannot mutate canonical learner state.
+  for (const attempt of parsed.data.attempts) {
+    const args = compileLegacyAttemptRpcArgs({
+      sessionId: parsed.data.sessionId,
+      lessonId: parsed.data.lessonId,
+      attempt,
+    });
+    const { error } = await rpcClient.rpc("record_learning_attempt", args);
+    if (error) {
+      return {
+        success: false as const,
+        error: `Không thể lưu attempt tương thích (${inserted}/${parsed.data.attempts.length}): ${error.message}`,
+        inserted,
+      };
+    }
+    inserted += 1;
   }
 
-  return { success: true as const, inserted: parsed.data.attempts.length };
+  return { success: true as const, inserted };
 }
 
 const trialCheckpointClaimSchema = z
@@ -132,8 +156,8 @@ export async function claimTrialCheckpoint(input: unknown) {
     };
   }
 
-  // Reuse the existing FSRS deck for communicative chunks after mastery is verified.
-  // Raw audio and transcripts are not persisted here.
+  // Reuse the existing FSRS deck for communicative chunks after the legacy checkpoint gate passes.
+  // This remains separate from canonical capability mastery evidence.
   const reviewSeed = await seedUnitVocabToSRS({
     vocab: GOLD_MISSION_01.targetChunks.map((chunk) => ({
       word: chunk.english,

--- a/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
+++ b/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { compileLegacyAttemptRpcArgs } from "@/lib/learning/legacy-attempt-adapter";
+
+const baseAttempt = {
+  activityId: "unit-a0-1:checkpoint:q1",
+  modality: "checkpoint" as const,
+  status: "scored" as const,
+  score: 100,
+  errorTags: [],
+  evaluator: "deterministic-answer-key",
+  evaluatorVersion: "2.0.0",
+  latencyMs: 1200,
+};
+
+describe("compileLegacyAttemptRpcArgs", () => {
+  it("preserves a legacy checkpoint as attempt-only canonical history", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: { ...baseAttempt, modality: "checkpoint" },
+    });
+
+    expect(result.p_knowledge_item_id).toBe("legacy:unit-a0-1:checkpoint:q1");
+    expect(result.p_response_modality).toBe("choice");
+    expect(result.p_correct).toBe(true);
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_evidence_target_id).toBeNull();
+    expect(result.p_capability_id).toBeNull();
+  });
+
+  it("does not turn a partial mission score into binary correctness or mastery evidence", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: {
+        ...baseAttempt,
+        activityId: "unit-a0-1:mission:mission-meet-new-colleague",
+        modality: "speaking",
+        score: 75,
+        errorTags: ["missing_intent:ask_name"],
+        evaluator: "deterministic-intent-match",
+      },
+    });
+
+    expect(result.p_response_modality).toBe("speech");
+    expect(result.p_correct).toBeNull();
+    expect(result.p_response_text).toBeNull();
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_metadata.legacyErrorTags).toEqual(["missing_intent:ask_name"]);
+  });
+
+  it("maps failed checkpoint to false while keeping evidence null", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: { ...baseAttempt, score: 0, errorTags: ["answer_mismatch"] },
+    });
+
+    expect(result.p_correct).toBe(false);
+    expect(result.p_response_modality).toBe("choice");
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_response_text).toBeNull();
+  });
+
+  it("maps modalities conservatively without creating evidence", () => {
+    const expected = {
+      speaking: "speech",
+      shadowing: "speech",
+      writing: "text",
+      quiz: "choice",
+      checkpoint: "choice",
+      listening: "none",
+      reading: "none",
+      vocabulary: "none",
+      grammar: "none",
+    } as const;
+
+    for (const [modality, responseModality] of Object.entries(expected)) {
+      const result = compileLegacyAttemptRpcArgs({
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        lessonId: "unit-a0-1",
+        attempt: { ...baseAttempt, modality: modality as typeof baseAttempt.modality },
+      });
+      expect(result.p_response_modality).toBe(responseModality);
+      expect(result.p_evidence_type).toBeNull();
+    }
+  });
+
+  it("keeps correctness null for unscored attempts", () => {
+    for (const status of ["unscored", "skipped", "unavailable"] as const) {
+      const result = compileLegacyAttemptRpcArgs({
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        lessonId: "unit-a0-1",
+        attempt: { ...baseAttempt, status },
+      });
+      expect(result.p_correct).toBeNull();
+    }
+  });
+
+  it("guarantees null evidence and canonical-state authority fields", () => {
+    const result = compileLegacyAttemptRpcArgs({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      lessonId: "unit-a0-1",
+      attempt: baseAttempt,
+    });
+
+    expect(result.p_capability_id).toBeNull();
+    expect(result.p_evidence_type).toBeNull();
+    expect(result.p_evidence_target_id).toBeNull();
+    expect(result.p_evidence_success).toBeNull();
+    expect(result.p_evidence_confidence).toBeNull();
+    expect(result.p_evidence_context_id).toBeNull();
+    expect(result.p_evaluator).toBeNull();
+    expect(result.p_evidence_metadata).toEqual({});
+    expect(result.p_response_text).toBeNull();
+    expect(result.p_context_id).toBeNull();
+    expect(result.p_hint_count).toBe(0);
+    expect(result.p_reveal_used).toBe(false);
+    expect(result.p_support_level).toBe(0);
+  });
+});

--- a/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
+++ b/src/lib/learning/__tests__/legacy-attempt-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { compileLegacyAttemptRpcArgs } from "@/lib/learning/legacy-attempt-adapter";
+import type { LearningAttemptItem } from "@/lib/lessons/learning-attempt";
 
 const baseAttempt = {
   activityId: "unit-a0-1:checkpoint:q1",
@@ -64,23 +65,25 @@ describe("compileLegacyAttemptRpcArgs", () => {
   });
 
   it("maps modalities conservatively without creating evidence", () => {
-    const expected = {
-      speaking: "speech",
-      shadowing: "speech",
-      writing: "text",
-      quiz: "choice",
-      checkpoint: "choice",
-      listening: "none",
-      reading: "none",
-      vocabulary: "none",
-      grammar: "none",
-    } as const;
+    const modalityCases: Array<
+      [LearningAttemptItem["modality"], "choice" | "text" | "speech" | "none"]
+    > = [
+      ["speaking", "speech"],
+      ["shadowing", "speech"],
+      ["writing", "text"],
+      ["quiz", "choice"],
+      ["checkpoint", "choice"],
+      ["listening", "none"],
+      ["reading", "none"],
+      ["vocabulary", "none"],
+      ["grammar", "none"],
+    ];
 
-    for (const [modality, responseModality] of Object.entries(expected)) {
+    for (const [modality, responseModality] of modalityCases) {
       const result = compileLegacyAttemptRpcArgs({
         sessionId: "11111111-1111-4111-8111-111111111111",
         lessonId: "unit-a0-1",
-        attempt: { ...baseAttempt, modality: modality as typeof baseAttempt.modality },
+        attempt: { ...baseAttempt, modality },
       });
       expect(result.p_response_modality).toBe(responseModality);
       expect(result.p_evidence_type).toBeNull();

--- a/src/lib/learning/legacy-attempt-adapter.ts
+++ b/src/lib/learning/legacy-attempt-adapter.ts
@@ -1,0 +1,117 @@
+import type { LearningAttemptItem } from "@/lib/lessons/learning-attempt";
+
+export type CanonicalResponseModality =
+  | "choice"
+  | "text"
+  | "speech"
+  | "gesture"
+  | "none";
+
+export type LegacyAttemptRpcArgs = {
+  p_knowledge_item_id: string;
+  p_capability_id: null;
+  p_session_id: string;
+  p_exercise_type: string;
+  p_response_modality: CanonicalResponseModality;
+  p_prompt_id: string;
+  p_context_id: null;
+  p_response_text: null;
+  p_correct: boolean | null;
+  p_latency_ms: number | null;
+  p_hint_count: 0;
+  p_reveal_used: false;
+  p_support_level: 0;
+  p_metadata: {
+    compatibilitySource: "legacy-learning-attempt-v1";
+    lessonId: string;
+    activityId: string;
+    legacyModality: LearningAttemptItem["modality"];
+    legacyStatus: LearningAttemptItem["status"];
+    legacyScore: number | null;
+    legacyErrorTags: string[];
+    legacyEvaluator: string;
+    legacyEvaluatorVersion: string;
+  };
+  p_evidence_type: null;
+  p_evidence_target_id: null;
+  p_evidence_success: null;
+  p_evidence_confidence: null;
+  p_evidence_context_id: null;
+  p_evaluator: null;
+  p_evidence_metadata: Record<string, never>;
+};
+
+function responseModalityForLegacyAttempt(
+  modality: LearningAttemptItem["modality"],
+): CanonicalResponseModality {
+  switch (modality) {
+    case "speaking":
+    case "shadowing":
+      return "speech";
+    case "writing":
+      return "text";
+    case "quiz":
+    case "checkpoint":
+      return "choice";
+    case "vocabulary":
+    case "grammar":
+    case "listening":
+    case "reading":
+      return "none";
+  }
+}
+
+function binaryCorrectness(score: number | null): boolean | null {
+  if (score === 100) return true;
+  if (score === 0) return false;
+  return null;
+}
+
+/**
+ * Compatibility bridge for legacy lesson/mission callers.
+ *
+ * These callers do not carry enough canonical semantic identity to create trustworthy mastery
+ * evidence. Preserve their observations as immutable attempts through the canonical RPC, but do
+ * not fabricate capability/evidence events or mutate learner_skill_states.
+ */
+export function compileLegacyAttemptRpcArgs(input: {
+  sessionId: string;
+  lessonId: string;
+  attempt: LearningAttemptItem;
+}): LegacyAttemptRpcArgs {
+  const { sessionId, lessonId, attempt } = input;
+
+  return {
+    p_knowledge_item_id: `legacy:${attempt.activityId}`,
+    p_capability_id: null,
+    p_session_id: sessionId,
+    p_exercise_type: `legacy:${attempt.modality}`,
+    p_response_modality: responseModalityForLegacyAttempt(attempt.modality),
+    p_prompt_id: attempt.activityId,
+    p_context_id: null,
+    p_response_text: null,
+    p_correct: attempt.status === "scored" ? binaryCorrectness(attempt.score) : null,
+    p_latency_ms: attempt.latencyMs,
+    p_hint_count: 0,
+    p_reveal_used: false,
+    p_support_level: 0,
+    p_metadata: {
+      compatibilitySource: "legacy-learning-attempt-v1",
+      lessonId,
+      activityId: attempt.activityId,
+      legacyModality: attempt.modality,
+      legacyStatus: attempt.status,
+      legacyScore: attempt.score,
+      legacyErrorTags: attempt.errorTags,
+      legacyEvaluator: attempt.evaluator,
+      legacyEvaluatorVersion: attempt.evaluatorVersion,
+    },
+    p_evidence_type: null,
+    p_evidence_target_id: null,
+    p_evidence_success: null,
+    p_evidence_confidence: null,
+    p_evidence_context_id: null,
+    p_evaluator: null,
+    p_evidence_metadata: {},
+  };
+}


### PR DESCRIPTION
## P0 release-consistency fix

Supersedes closed PR #87 with a clean port from current reset-normalized `main@2b85d1c835b3590c4093b14e79a612c1fd30c574`.

### Verified production problem

Read-only production checks on 2026-09-06 confirm:

- authenticated users cannot directly INSERT/UPDATE/DELETE canonical `learning_attempts`, `learning_evidence_events`, or `learner_skill_states`;
- `public.record_learning_attempt(...)` exists and authenticated callers have EXECUTE;
- the production RPC delegates to `private.record_learning_attempt_core(...)`;
- when `p_evidence_type IS NULL`, the core persists the attempt and returns before creating an evidence event or updating learner skill state.

Current main's legacy `recordLearningAttempts()` still attempts the retired direct table shape, so authenticated legacy checkpoint/mission logging is incompatible with production.

### Change

- route legacy attempts through `record_learning_attempt`;
- add a small adapter that maps legacy modalities/status/scores to the canonical attempt contract;
- preserve raw response text as null;
- set every canonical evidence/mastery field to null;
- add focused unit tests for modality, correctness and evidence-free semantics.

### Evidence boundary

This is attempt-history compatibility only. It does not create canonical learning evidence, learner skill-state mutations, mastery, CEFR claims, Nếp authority, curriculum changes, or product-roadmap changes.

### Bounded tradeoff

The legacy API accepts a batch, while the production canonical RPC records one attempt per call. This bridge therefore writes sequentially and returns an explicit `inserted` count if a later call fails. A partial failure may leave partial attempt-only history and a retry may duplicate that history. It cannot partially mutate canonical evidence/mastery because evidence fields are always null. Introducing a new batch DB RPC solely to preserve legacy atomicity is intentionally out of scope for this compatibility fix.

### Diff

Exactly three files relative to current main:

- `src/app/actions/learning-attempts.ts`
- `src/lib/learning/legacy-attempt-adapter.ts`
- `src/lib/learning/__tests__/legacy-attempt-adapter.test.ts`

No migration, dependency, UI, curriculum, deployment or product-direction change.

### Required gate

Run current Verify on the exact PR head, including lint, TypeScript, unit/content tests and fresh migration/database/RLS checks. Merge only on exact-head green state.