### PR TITLE
fix(release): restore deliberate main production deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,9 @@
   "buildCommand": "npm run build",
   "git": {
     "deploymentEnabled": {
-      "**": false,
-      "preview/**": true
+      "main": true,
+      "preview/**": true,
+      "**": false
     }
   },
   "crons": [


### PR DESCRIPTION
Closes the Vercel half of #152.

Root cause: `vercel.json` currently disables automatic Git deployments for every branch via `"**": false`, except `preview/**`. That means reviewed pushes to `main` never create a production deployment, leaving production pinned to the old `1e462367…` deployment.

This change explicitly enables `main` while preserving the existing preview-only allowance and default deny for every other branch:

- `main`: production Git deployment enabled
- `preview/**`: preview deployment enabled
- all other branches: disabled

Release discipline for this PR:
1. Verify exact PR head in GitHub Actions.
2. Confirm Vercel preview deployment for this `preview/**` branch is READY.
3. Smoke the preview.
4. Merge with exact-head guard.
5. Confirm Vercel creates a production deployment from the resulting `main` commit and production aliases move to it.
6. Smoke production and scan runtime errors before closing #152.