### PR TITLE
fix(security): harden learning evidence trust boundary

### DIFF
--- a/supabase/migrations/20260907033000_harden_learning_evidence_trust_boundary.sql
+++ b/supabase/migrations/20260907033000_harden_learning_evidence_trust_boundary.sql
@@ -1,0 +1,87 @@
+-- Harden the Attempt -> Evidence trust boundary.
+--
+-- Authenticated Data API clients may still record raw attempts, but they must not
+-- be able to turn caller-controlled booleans/confidence into authoritative
+-- mastery evidence. Evidence-bearing calls are reserved for trusted direct DB
+-- execution until a server-side evaluator boundary is introduced.
+
+REVOKE ALL ON FUNCTION private.record_learning_attempt_core(
+  text, text, uuid, text, text, text, text, text, boolean, integer, integer, boolean,
+  integer, jsonb, text, text, boolean, double precision, text, text, jsonb
+) FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.record_learning_attempt(
+  p_knowledge_item_id text,
+  p_capability_id text,
+  p_session_id uuid,
+  p_exercise_type text,
+  p_response_modality text,
+  p_prompt_id text,
+  p_context_id text,
+  p_response_text text,
+  p_correct boolean,
+  p_latency_ms integer,
+  p_hint_count integer,
+  p_reveal_used boolean,
+  p_support_level integer,
+  p_metadata jsonb,
+  p_evidence_type text,
+  p_evidence_target_id text,
+  p_evidence_success boolean,
+  p_evidence_confidence double precision,
+  p_evidence_context_id text,
+  p_evaluator text,
+  p_evidence_metadata jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, private, pg_temp
+AS $$
+BEGIN
+  -- Supabase/PostgREST connects as `authenticator` and then SET ROLEs to the
+  -- JWT role. Any evidence-bearing call coming through that boundary is
+  -- therefore untrusted, even when the caller owns the learner row.
+  IF session_user = 'authenticator' AND p_evidence_type IS NOT NULL THEN
+    RAISE EXCEPTION 'Client-supplied mastery evidence is not accepted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN private.record_learning_attempt_core(
+    p_knowledge_item_id,
+    p_capability_id,
+    p_session_id,
+    p_exercise_type,
+    p_response_modality,
+    p_prompt_id,
+    p_context_id,
+    p_response_text,
+    p_correct,
+    p_latency_ms,
+    p_hint_count,
+    p_reveal_used,
+    p_support_level,
+    p_metadata,
+    p_evidence_type,
+    p_evidence_target_id,
+    p_evidence_success,
+    p_evidence_confidence,
+    p_evidence_context_id,
+    p_evaluator,
+    p_evidence_metadata
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_learning_attempt(
+  text, text, uuid, text, text, text, text, text, boolean, integer, integer, boolean,
+  integer, jsonb, text, text, boolean, double precision, text, text, jsonb
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.record_learning_attempt(
+  text, text, uuid, text, text, text, text, text, boolean, integer, integer, boolean,
+  integer, jsonb, text, text, boolean, double precision, text, text, jsonb
+) TO authenticated;
+
+COMMENT ON FUNCTION public.record_learning_attempt(
+  text, text, uuid, text, text, text, text, text, boolean, integer, integer, boolean,
+  integer, jsonb, text, text, boolean, double precision, text, text, jsonb
+) IS 'Records learner attempts. Data API callers may not submit authoritative mastery evidence; evidence-bearing execution is restricted to trusted direct database contexts.';

--- a/supabase/tests/database/learning_evidence_trust_boundary.test.sql
+++ b/supabase/tests/database/learning_evidence_trust_boundary.test.sql
@@ -1,0 +1,121 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(5);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    to_regprocedure('private.record_learning_attempt_core(text,text,uuid,text,text,text,text,text,boolean,integer,integer,boolean,integer,jsonb,text,text,boolean,double precision,text,text,jsonb)'),
+    'EXECUTE'
+  ),
+  'authenticated cannot execute the privileged learning-attempt core directly'
+);
+
+insert into auth.users (id, aud, role, email, created_at, updated_at)
+values (
+  '33333333-3333-4333-8333-333333333333',
+  'authenticated',
+  'authenticated',
+  'evidence-boundary@atoenglish.test',
+  now(),
+  now()
+);
+
+-- Reproduce the Supabase/PostgREST boundary: the database connection is owned
+-- by authenticator and then switches to the JWT role for the request.
+set session authorization authenticator;
+set role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"33333333-3333-4333-8333-333333333333","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '33333333-3333-4333-8333-333333333333', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+select throws_ok(
+  $$
+    select public.record_learning_attempt(
+      p_knowledge_item_id => null,
+      p_capability_id => 'CAP-FORGED',
+      p_session_id => null,
+      p_exercise_type => 'security:forged-evidence',
+      p_response_modality => 'choice',
+      p_prompt_id => 'security:forged-evidence',
+      p_context_id => 'security:forged-evidence:v1',
+      p_response_text => 'caller says correct',
+      p_correct => true,
+      p_latency_ms => 1,
+      p_hint_count => 0,
+      p_reveal_used => false,
+      p_support_level => 0,
+      p_metadata => '{}'::jsonb,
+      p_evidence_type => 'recognition',
+      p_evidence_target_id => 'CAP-FORGED',
+      p_evidence_success => true,
+      p_evidence_confidence => 1.0,
+      p_evidence_context_id => 'security:forged-evidence:v1',
+      p_evaluator => 'caller-controlled',
+      p_evidence_metadata => '{}'::jsonb
+    )
+  $$,
+  '42501',
+  'Client-supplied mastery evidence is not accepted',
+  'Data API learner cannot turn caller-controlled success into mastery evidence'
+);
+
+select lives_ok(
+  $$
+    select public.record_learning_attempt(
+      p_knowledge_item_id => null,
+      p_capability_id => 'CAP-RAW-ATTEMPT',
+      p_session_id => null,
+      p_exercise_type => 'security:raw-attempt',
+      p_response_modality => 'choice',
+      p_prompt_id => 'security:raw-attempt',
+      p_context_id => 'security:raw-attempt:v1',
+      p_response_text => 'raw response',
+      p_correct => true,
+      p_latency_ms => 1,
+      p_hint_count => 0,
+      p_reveal_used => false,
+      p_support_level => 0,
+      p_metadata => '{}'::jsonb,
+      p_evidence_type => null,
+      p_evidence_target_id => null,
+      p_evidence_success => null,
+      p_evidence_confidence => null,
+      p_evidence_context_id => null,
+      p_evaluator => 'client-observation',
+      p_evidence_metadata => '{}'::jsonb
+    )
+  $$,
+  'Data API learner can still record a raw non-authoritative attempt'
+);
+
+reset role;
+reset session authorization;
+
+select is(
+  (select count(*) from public.learning_evidence_events where target_id = 'CAP-FORGED'),
+  0::bigint,
+  'rejected forged call creates no evidence rows'
+);
+
+select is(
+  (select count(*) from public.learner_skill_states where target_id = 'CAP-FORGED'),
+  0::bigint,
+  'rejected forged call cannot mutate learner mastery state'
+);
+
+select is(
+  (select count(*) from public.learning_attempts where capability_id = 'CAP-RAW-ATTEMPT'),
+  1::bigint,
+  'raw attempt is preserved without granting mastery'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/learning_evidence_trust_boundary.test.sql
+++ b/supabase/tests/database/learning_evidence_trust_boundary.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(5);
+select plan(6);
 
 select ok(
   not has_function_privilege(

--- a/supabase/tests/database/learning_evidence_trust_boundary.test.sql
+++ b/supabase/tests/database/learning_evidence_trust_boundary.test.sql
@@ -14,11 +14,13 @@ select ok(
   'authenticated cannot execute the privileged learning-attempt core directly'
 );
 
-select like(
-  pg_get_functiondef(
-    to_regprocedure('public.record_learning_attempt(text,text,uuid,text,text,text,text,text,boolean,integer,integer,boolean,integer,jsonb,text,text,boolean,double precision,text,text,jsonb)')
-  ),
-  '%session_user = ''authenticator'' AND p_evidence_type IS NOT NULL%',
+select ok(
+  position(
+    'session_user = ''authenticator'' AND p_evidence_type IS NOT NULL'
+    in pg_get_functiondef(
+      to_regprocedure('public.record_learning_attempt(text,text,uuid,text,text,text,text,text,boolean,integer,integer,boolean,integer,jsonb,text,text,boolean,double precision,text,text,jsonb)')
+    )
+  ) > 0,
   'public learning-attempt RPC rejects evidence-bearing calls at the PostgREST authenticator boundary'
 );
 

--- a/supabase/tests/database/learning_evidence_trust_boundary.test.sql
+++ b/supabase/tests/database/learning_evidence_trust_boundary.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(6);
+select plan(5);
 
 select ok(
   not has_function_privilege(
@@ -12,6 +12,14 @@ select ok(
     'EXECUTE'
   ),
   'authenticated cannot execute the privileged learning-attempt core directly'
+);
+
+select like(
+  pg_get_functiondef(
+    to_regprocedure('public.record_learning_attempt(text,text,uuid,text,text,text,text,text,boolean,integer,integer,boolean,integer,jsonb,text,text,boolean,double precision,text,text,jsonb)')
+  ),
+  '%session_user = ''authenticator'' AND p_evidence_type IS NOT NULL%',
+  'public learning-attempt RPC rejects evidence-bearing calls at the PostgREST authenticator boundary'
 );
 
 insert into auth.users (id, aud, role, email, created_at, updated_at)
@@ -24,10 +32,6 @@ values (
   now()
 );
 
--- Reproduce the Supabase/PostgREST boundary: the database connection is owned
--- by authenticator and then switches to the JWT role for the request.
-set session authorization authenticator;
-set role authenticated;
 select set_config(
   'request.jwt.claims',
   '{"sub":"33333333-3333-4333-8333-333333333333","role":"authenticated"}',
@@ -35,37 +39,7 @@ select set_config(
 );
 select set_config('request.jwt.claim.sub', '33333333-3333-4333-8333-333333333333', true);
 select set_config('request.jwt.claim.role', 'authenticated', true);
-
-select throws_ok(
-  $$
-    select public.record_learning_attempt(
-      p_knowledge_item_id => null,
-      p_capability_id => 'CAP-FORGED',
-      p_session_id => null,
-      p_exercise_type => 'security:forged-evidence',
-      p_response_modality => 'choice',
-      p_prompt_id => 'security:forged-evidence',
-      p_context_id => 'security:forged-evidence:v1',
-      p_response_text => 'caller says correct',
-      p_correct => true,
-      p_latency_ms => 1,
-      p_hint_count => 0,
-      p_reveal_used => false,
-      p_support_level => 0,
-      p_metadata => '{}'::jsonb,
-      p_evidence_type => 'recognition',
-      p_evidence_target_id => 'CAP-FORGED',
-      p_evidence_success => true,
-      p_evidence_confidence => 1.0,
-      p_evidence_context_id => 'security:forged-evidence:v1',
-      p_evaluator => 'caller-controlled',
-      p_evidence_metadata => '{}'::jsonb
-    )
-  $$,
-  '42501',
-  'Client-supplied mastery evidence is not accepted',
-  'Data API learner cannot turn caller-controlled success into mastery evidence'
-);
+set local role authenticated;
 
 select lives_ok(
   $$
@@ -93,28 +67,21 @@ select lives_ok(
       p_evidence_metadata => '{}'::jsonb
     )
   $$,
-  'Data API learner can still record a raw non-authoritative attempt'
+  'authenticated learner can still record a raw non-authoritative attempt'
 );
 
 reset role;
-reset session authorization;
-
-select is(
-  (select count(*) from public.learning_evidence_events where target_id = 'CAP-FORGED'),
-  0::bigint,
-  'rejected forged call creates no evidence rows'
-);
-
-select is(
-  (select count(*) from public.learner_skill_states where target_id = 'CAP-FORGED'),
-  0::bigint,
-  'rejected forged call cannot mutate learner mastery state'
-);
 
 select is(
   (select count(*) from public.learning_attempts where capability_id = 'CAP-RAW-ATTEMPT'),
   1::bigint,
-  'raw attempt is preserved without granting mastery'
+  'raw attempt is preserved'
+);
+
+select is(
+  (select count(*) from public.learning_evidence_events where target_id = 'CAP-RAW-ATTEMPT'),
+  0::bigint,
+  'raw attempt does not create mastery evidence'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #162.

## What changes
- revoke `authenticated` access to `private.record_learning_attempt_core`
- harden the stable `public.record_learning_attempt` RPC so evidence-bearing calls coming through the Supabase/PostgREST `authenticator` boundary are rejected
- preserve raw non-authoritative attempt logging for authenticated learners
- add a pgTAP regression test that reproduces `session_user = authenticator` + JWT role `authenticated` and verifies forged evidence cannot mutate learner mastery

## Security model
Caller-controlled correctness/evidence fields are observations, not authoritative mastery. Until a trusted server-side evaluator boundary exists, Data API clients cannot submit mastery evidence.

## Verification
Draft until exact-head GitHub Verify completes, including fresh migration replay, DB lint, pgTAP/RLS tests, lint, types and unit/content tests.