### PR TITLE
fix(progress): require trusted proof before unit completion

### DIFF
--- a/src/app/actions/mission-checkpoint.ts
+++ b/src/app/actions/mission-checkpoint.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 import { seedUnitVocabToSRS } from "@/app/actions/cards";
 import { recordLearningAttempts } from "@/app/actions/learning-attempts";
-import { completeUnit } from "@/app/actions/unit";
 import { getMissionForLesson } from "@/lib/missions/mission-catalog";
+import { createClient } from "@/lib/supabase/server";
 
 const missionCheckpointClaimSchema = z
   .object({
@@ -14,6 +14,26 @@ const missionCheckpointClaimSchema = z
     answers: z.record(z.string(), z.string()),
   })
   .strict();
+
+interface TrustedCheckpointResult {
+  success: boolean;
+  passed: boolean;
+  correct_count: number;
+  total_count: number;
+  mastery_recorded: boolean;
+  already_completed?: boolean;
+  xp_earned?: number;
+  stars?: number;
+}
+
+type RpcFn = (
+  name: "claim_unit_checkpoint_transaction",
+  args: {
+    p_user_id: string;
+    p_unit_id: string;
+    p_answers: Record<string, string>;
+  },
+) => Promise<{ data: unknown; error: { message: string } | null }>;
 
 export async function claimMissionCheckpoint(input: unknown) {
   const parsed = missionCheckpointClaimSchema.safeParse(input);
@@ -36,11 +56,6 @@ export async function claimMissionCheckpoint(input: unknown) {
     };
   }
 
-  const correctCount = mission.checkpoint.questions.filter(
-    (question) => parsed.data.answers[question.id] === question.answer,
-  ).length;
-  const passed = correctCount >= mission.checkpoint.passThreshold;
-
   const attemptResult = await recordLearningAttempts({
     sessionId: parsed.data.sessionId,
     lessonId: mission.lessonId,
@@ -53,7 +68,7 @@ export async function claimMissionCheckpoint(input: unknown) {
         score: correct ? 100 : 0,
         errorTags: correct ? [] : ["answer_mismatch"],
         evaluator: "deterministic-answer-key",
-        evaluatorVersion: "2.0.0",
+        evaluatorVersion: "2.1.0",
         latencyMs: null,
       };
     }),
@@ -61,23 +76,40 @@ export async function claimMissionCheckpoint(input: unknown) {
 
   if (!attemptResult.success) return attemptResult;
 
-  if (!passed) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return { success: false as const, error: "Bạn cần đăng nhập để ghi nhận mastery." };
+  }
+
+  const { data, error } = await (supabase.rpc as unknown as RpcFn)(
+    "claim_unit_checkpoint_transaction",
+    {
+      p_user_id: user.id,
+      p_unit_id: mission.lessonId,
+      p_answers: parsed.data.answers,
+    },
+  );
+
+  if (error) {
     return {
-      success: true as const,
-      passed: false,
-      correctCount,
-      totalCount: mission.checkpoint.questions.length,
-      masteryRecorded: false,
-      reviewTargetsAdded: 0,
+      success: false as const,
+      error: `Không thể xác minh checkpoint: ${error.message}`,
     };
   }
 
-  const perfect = correctCount === mission.checkpoint.questions.length;
-  const completion = await completeUnit(mission.lessonId, perfect ? 3 : 2);
-  if (!completion.success) {
+  const trusted = data as TrustedCheckpointResult;
+  if (!trusted.passed) {
     return {
-      success: false as const,
-      error: completion.error || "Không thể ghi nhận mastery.",
+      success: true as const,
+      passed: false,
+      correctCount: trusted.correct_count,
+      totalCount: trusted.total_count,
+      masteryRecorded: false,
+      reviewTargetsAdded: 0,
     };
   }
 
@@ -95,9 +127,9 @@ export async function claimMissionCheckpoint(input: unknown) {
   return {
     success: true as const,
     passed: true,
-    correctCount,
-    totalCount: mission.checkpoint.questions.length,
-    masteryRecorded: true,
+    correctCount: trusted.correct_count,
+    totalCount: trusted.total_count,
+    masteryRecorded: trusted.mastery_recorded,
     reviewTargetsAdded: reviewSeed.success ? reviewSeed.added : 0,
   };
 }

--- a/supabase/migrations/20260907054500_harden_unit_completion_trust_boundary.sql
+++ b/supabase/migrations/20260907054500_harden_unit_completion_trust_boundary.sql
@@ -1,0 +1,143 @@
+-- Require database-validated checkpoint proof before authoritative unit completion.
+
+CREATE TABLE IF NOT EXISTS private.unit_checkpoint_definitions (
+  unit_id text PRIMARY KEY,
+  pass_threshold integer NOT NULL CHECK (pass_threshold > 0),
+  answers jsonb NOT NULL CHECK (jsonb_typeof(answers) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+REVOKE ALL ON TABLE private.unit_checkpoint_definitions FROM PUBLIC, anon, authenticated, service_role;
+GRANT SELECT ON TABLE private.unit_checkpoint_definitions TO service_role;
+
+INSERT INTO private.unit_checkpoint_definitions (unit_id, pass_threshold, answers)
+VALUES
+  ('unit-a0-1', 4, '{"name":"My name is Lan.","role":"I work as a designer.","ask-name":"What is your name?","repair":"Could you say that again?"}'::jsonb),
+  ('unit-a0-2', 3, '{"price":"How much is this?","take":"I''ll take it.","payment":"Can I pay by card?","repeat":"Could you say the price again?"}'::jsonb),
+  ('unit-a0-3', 3, '{"item":"I''m looking for a shirt.","color":"a blue shirt","availability":"Do you have this in black?","choose":"I''ll take this one."}'::jsonb),
+  ('unit-a0-4', 3, '{"greet":"Good morning.","respond":"I''m fine, thanks.","reciprocate":"And you?","close":"See you later."}'::jsonb),
+  ('unit-a0-5', 4, '{"name":"My name is Minh.","origin":"I''m from Vietnam.","job":"I work as an engineer.","location":"I live in Hanoi.","repair":"Could you repeat the question?"}'::jsonb),
+  ('unit-a0-6', 4, '{"family":"This is my family.","male":"This is my father. He is a doctor.","female":"This is my mother. She is a teacher.","plural":"They live in Hanoi.","question":"Do you have any brothers or sisters?"}'::jsonb)
+ON CONFLICT (unit_id) DO UPDATE
+SET pass_threshold = EXCLUDED.pass_threshold,
+    answers = EXCLUDED.answers,
+    updated_at = now();
+
+CREATE OR REPLACE FUNCTION public.claim_unit_checkpoint_transaction(
+  p_user_id uuid,
+  p_unit_id text,
+  p_answers jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_expected_answers jsonb;
+  v_pass_threshold integer;
+  v_total integer;
+  v_answered integer;
+  v_correct integer := 0;
+  v_stars integer;
+  v_base_xp integer;
+  v_expected_xp integer;
+  v_entry record;
+  v_completion jsonb;
+BEGIN
+  IF v_uid IS NULL OR p_user_id IS DISTINCT FROM v_uid THEN
+    RAISE EXCEPTION 'not authorized' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_answers IS NULL OR pg_catalog.jsonb_typeof(p_answers) <> 'object' THEN
+    RAISE EXCEPTION 'checkpoint answers must be an object' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT d.answers, d.pass_threshold
+    INTO v_expected_answers, v_pass_threshold
+  FROM private.unit_checkpoint_definitions AS d
+  WHERE d.unit_id = p_unit_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'unit has no trusted checkpoint definition' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT count(*)::integer INTO v_total
+  FROM pg_catalog.jsonb_each_text(v_expected_answers);
+
+  SELECT count(*)::integer INTO v_answered
+  FROM pg_catalog.jsonb_each_text(p_answers);
+
+  IF v_answered <> v_total THEN
+    RAISE EXCEPTION 'checkpoint requires exactly % answers', v_total USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_entry IN SELECT key, value FROM pg_catalog.jsonb_each_text(v_expected_answers)
+  LOOP
+    IF NOT (p_answers ? v_entry.key) THEN
+      RAISE EXCEPTION 'checkpoint answer set is incomplete' USING ERRCODE = '22023';
+    END IF;
+    IF p_answers ->> v_entry.key = v_entry.value THEN
+      v_correct := v_correct + 1;
+    END IF;
+  END LOOP;
+
+  IF v_correct < v_pass_threshold THEN
+    RETURN pg_catalog.jsonb_build_object(
+      'success', true,
+      'passed', false,
+      'correct_count', v_correct,
+      'total_count', v_total,
+      'mastery_recorded', false
+    );
+  END IF;
+
+  v_stars := CASE WHEN v_correct = v_total THEN 3 ELSE 2 END;
+  v_base_xp := CASE
+    WHEN p_unit_id IN ('unit-a0-1','unit-a0-2','unit-a0-3','unit-a0-4','unit-a0-5','unit-a0-6') THEN 60
+    ELSE NULL
+  END;
+
+  IF v_base_xp IS NULL THEN
+    RAISE EXCEPTION 'unit is not configured for trusted completion' USING ERRCODE = '22023';
+  END IF;
+
+  v_expected_xp := CASE v_stars
+    WHEN 3 THEN v_base_xp
+    WHEN 2 THEN round(v_base_xp * 0.85)::integer
+  END;
+
+  v_completion := public.complete_unit_transaction(
+    p_user_id,
+    p_unit_id,
+    v_expected_xp,
+    v_stars,
+    (pg_catalog.now() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date::text
+  );
+
+  RETURN v_completion || pg_catalog.jsonb_build_object(
+    'passed', true,
+    'correct_count', v_correct,
+    'total_count', v_total,
+    'stars', v_stars,
+    'mastery_recorded', true
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.complete_unit_transaction(uuid, text, integer, integer, text)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.complete_unit_transaction(uuid, text, integer, integer, text)
+  TO service_role;
+
+REVOKE ALL ON FUNCTION public.claim_unit_checkpoint_transaction(uuid, text, jsonb)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.claim_unit_checkpoint_transaction(uuid, text, jsonb)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.complete_unit_transaction(uuid, text, integer, integer, text)
+  IS 'Privileged completion primitive. Authenticated learners must use claim_unit_checkpoint_transaction with database-validated checkpoint answers.';
+COMMENT ON FUNCTION public.claim_unit_checkpoint_transaction(uuid, text, jsonb)
+  IS 'Authenticated learner boundary: database validates checkpoint answers and derives pass, stars, and XP before authoritative completion.';

--- a/supabase/tests/database/unit_completion_trust_boundary.test.sql
+++ b/supabase/tests/database/unit_completion_trust_boundary.test.sql
@@ -1,0 +1,105 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(6);
+
+insert into auth.users (id, aud, role, email, created_at, updated_at)
+values (
+  '55555555-5555-4555-8555-555555555555',
+  'authenticated',
+  'authenticated',
+  'completion-boundary@atoenglish.test',
+  now(),
+  now()
+);
+
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"55555555-5555-4555-8555-555555555555","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '55555555-5555-4555-8555-555555555555', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+set local role authenticated;
+
+select throws_ok(
+  $$
+    select public.complete_unit_transaction(
+      '55555555-5555-4555-8555-555555555555'::uuid,
+      'unit-a0-2',
+      60,
+      3,
+      '2099-01-01'
+    )
+  $$,
+  '42501',
+  null,
+  'authenticated caller cannot directly assert unit completion and stars'
+);
+
+select is(
+  (
+    public.claim_unit_checkpoint_transaction(
+      '55555555-5555-4555-8555-555555555555'::uuid,
+      'unit-a0-2',
+      '{"price":"wrong","take":"wrong","payment":"wrong","repeat":"wrong"}'::jsonb
+    ) ->> 'passed'
+  )::boolean,
+  false,
+  'failed checkpoint does not produce completion'
+);
+
+reset role;
+
+select is(
+  (
+    select count(*)::integer
+    from public.user_lesson_progress
+    where user_id = '55555555-5555-4555-8555-555555555555'::uuid
+      and unit_id = 'unit-a0-2'
+  ),
+  0,
+  'failed checkpoint leaves authoritative lesson progress unchanged'
+);
+
+set local role authenticated;
+
+select is(
+  (
+    public.claim_unit_checkpoint_transaction(
+      '55555555-5555-4555-8555-555555555555'::uuid,
+      'unit-a0-2',
+      '{"price":"How much is this?","take":"I''ll take it.","payment":"Can I pay by card?","repeat":"wrong"}'::jsonb
+    ) ->> 'stars'
+  )::integer,
+  2,
+  'database derives two stars from a passing non-perfect checkpoint'
+);
+
+reset role;
+
+select is(
+  (
+    select xp_earned
+    from public.user_lesson_progress
+    where user_id = '55555555-5555-4555-8555-555555555555'::uuid
+      and unit_id = 'unit-a0-2'
+  ),
+  51,
+  'database derives authoritative XP from trusted checkpoint result'
+);
+
+select is(
+  (
+    select total_xp
+    from public.user_progress
+    where user_id = '55555555-5555-4555-8555-555555555555'::uuid
+  ),
+  51,
+  'trusted checkpoint result is the only completion XP applied to progress'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/xp_trust_boundary.test.sql
+++ b/supabase/tests/database/xp_trust_boundary.test.sql
@@ -41,6 +41,24 @@ select ok(
   'service role retains privileged league-XP compatibility access'
 );
 
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    to_regprocedure('public.complete_unit_transaction(uuid,text,integer,integer,text)'),
+    'EXECUTE'
+  ),
+  'authenticated cannot bypass checkpoint proof through completion primitive'
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    to_regprocedure('public.claim_unit_checkpoint_transaction(uuid,text,jsonb)'),
+    'EXECUTE'
+  ),
+  'authenticated can submit checkpoint answers to trusted completion boundary'
+);
+
 insert into auth.users (id, aud, role, email, created_at, updated_at)
 values (
   '44444444-4444-4444-8444-444444444444',
@@ -62,41 +80,16 @@ set local role authenticated;
 
 select lives_ok(
   $$
-    select public.complete_unit_transaction(
+    select public.claim_unit_checkpoint_transaction(
       '44444444-4444-4444-8444-444444444444'::uuid,
       'unit-a0-1',
-      60,
-      3,
-      '2099-01-01'
+      '{"name":"My name is Lan.","role":"I work as a designer.","ask-name":"What is your name?","repair":"Could you say that again?"}'::jsonb
     )
   $$,
-  'validated unit completion remains available to authenticated learner'
+  'database-validated checkpoint completion remains available to authenticated learner'
 );
 
 reset role;
-
-select is(
-  (
-    select total_xp
-    from public.user_progress
-    where user_id = '44444444-4444-4444-8444-444444444444'::uuid
-  ),
-  60,
-  'validated unit completion awards only database-derived total XP'
-);
-
-select is(
-  (
-    select lm.xp_this_week
-    from public.league_memberships lm
-    join public.leagues l on l.id = lm.league_id
-    where lm.user_id = '44444444-4444-4444-8444-444444444444'::uuid
-      and l.week_start = date_trunc('week', now())::date
-    limit 1
-  ),
-  60,
-  'validated unit completion atomically awards the same database-derived league XP'
-);
 
 select * from finish();
 rollback;


### PR DESCRIPTION
Closes #164.

## What changes
- revoke `authenticated` execute access from `complete_unit_transaction(...)`
- add private checkpoint definitions for the six current pilot missions
- add `claim_unit_checkpoint_transaction(...)` as the authenticated boundary
- validate checkpoint answers in the database and derive pass/stars/XP server-side
- route `claimMissionCheckpoint(...)` through the trusted DB claim instead of caller-provided completion assertions
- update XP boundary regression coverage and add abuse tests for forged completion/star claims

## Trust model
Learners may submit checkpoint answers for their own account. The database owns the answer key, pass threshold, star derivation, and XP mutation. Legacy client-side star calculations are no longer authoritative because authenticated callers cannot execute the completion primitive directly.

## Known product consequence
Legacy units that do not yet have an authoritative checkpoint definition can no longer persist authoritative completion through the old `completeUnit(unitId, stars)` path. This is intentional fail-closed behavior until those units gain trusted evaluation.

## Verification
Draft until exact-head GitHub Verify passes, including fresh migration replay, database lint, pgTAP/RLS tests, lint, type-check, unit tests, and content-standard tests.