### PR TITLE
fix(security): authorize privileged Edge Functions

### DIFF
--- a/src/lib/security/privileged-edge-auth.test.ts
+++ b/src/lib/security/privileged-edge-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { authorizeBearer } from "../../../supabase/functions/_shared/privileged-auth";
+
+describe("privileged edge bearer auth", () => {
+  it("fails closed when the server secret is not configured", () => {
+    const response = authorizeBearer(new Request("https://example.test"), undefined);
+    expect(response?.status).toBe(503);
+  });
+
+  it("rejects missing or ordinary bearer credentials", () => {
+    const response = authorizeBearer(
+      new Request("https://example.test", {
+        headers: { authorization: "Bearer learner-jwt" },
+      }),
+      "server-only-secret",
+    );
+    expect(response?.status).toBe(401);
+  });
+
+  it("accepts only the exact server-only bearer secret", () => {
+    const response = authorizeBearer(
+      new Request("https://example.test", {
+        headers: { authorization: "Bearer server-only-secret" },
+      }),
+      "server-only-secret",
+    );
+    expect(response).toBeNull();
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,7 +1,25 @@
-# Local-only Supabase CLI configuration used by database migration/RLS tests.
+# Local Supabase CLI configuration used by database migration/RLS tests.
 # Remote project linkage is intentionally absent: CI must never depend on production credentials.
 project_id = "atoenglish-local"
 
 [db]
 # Keep local migration behavior aligned with the hosted AtoEnglish database (Postgres 17).
 major_version = 17
+
+# These privileged functions enforce their own server-only bearer secrets in code.
+# `verify_jwt = false` allows those non-JWT scheduler/admin secrets to reach the
+# function; authorization is then mandatory before service-role access is created.
+[functions.list-memories]
+verify_jwt = false
+
+[functions.search-memories]
+verify_jwt = false
+
+[functions.store-memory]
+verify_jwt = false
+
+[functions.manage-memory]
+verify_jwt = false
+
+[functions.streak-reminder]
+verify_jwt = false

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -1,0 +1,21 @@
+# Privileged Edge Function authorization
+
+These functions use `SUPABASE_SERVICE_ROLE_KEY`, so authorization is enforced in function code before privileged database access:
+
+- `list-memories`, `search-memories`, `store-memory`, `manage-memory`
+  - caller: trusted project admin/agent only
+  - required header: `Authorization: Bearer $PROJECT_MEMORY_ADMIN_TOKEN`
+- `streak-reminder`
+  - caller: trusted scheduler only
+  - method: `POST` only
+  - required header: `Authorization: Bearer $STREAK_REMINDER_CRON_SECRET`
+
+The corresponding `supabase/config.toml` entries use `verify_jwt = false` deliberately because these server-only bearer values are not Supabase user JWTs. That setting does **not** make the functions public: requests fail closed in `_shared/privileged-auth.ts` when a secret is missing or does not match.
+
+Deployment requirements:
+
+1. Set `PROJECT_MEMORY_ADMIN_TOKEN` for any deployment that enables the project-memory functions.
+2. Set `STREAK_REMINDER_CRON_SECRET` and configure the scheduler to send it as the Bearer token.
+3. Keep `SUPABASE_SERVICE_ROLE_KEY`, VAPID keys, and both authorization secrets server-only.
+4. Do not configure browser clients or ordinary learner sessions with either privileged secret.
+5. Deploy the checked-in function configuration together with the function source; do not rely on a dashboard-only `verify_jwt` assumption.

--- a/supabase/functions/_shared/privileged-auth.ts
+++ b/supabase/functions/_shared/privileged-auth.ts
@@ -1,0 +1,33 @@
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+export function authorizeBearer(
+  req: Request,
+  expectedSecret: string | null | undefined,
+): Response | null {
+  if (!expectedSecret) {
+    return new Response(
+      JSON.stringify({ error: "Privileged function auth is not configured" }),
+      { status: 503, headers: JSON_HEADERS },
+    );
+  }
+
+  const authorization = req.headers.get("authorization");
+  if (authorization !== `Bearer ${expectedSecret}`) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: JSON_HEADERS },
+    );
+  }
+
+  return null;
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}

--- a/supabase/functions/list-memories/index.ts
+++ b/supabase/functions/list-memories/index.ts
@@ -1,31 +1,21 @@
 /**
- * list-memories — Supabase Edge Function
- * List memories with optional category/project filter — no embedding needed
- *
- * POST body:
- * {
- *   "category": "bug",          // optional — filter by category
- *   "project": "atoenglish",    // optional — filter by project
- *   "limit": 20,                // optional, default 20
- *   "offset": 0                 // optional, default 0 (for pagination)
- * }
+ * list-memories — privileged Supabase Edge Function.
+ * Requires: Authorization: Bearer $PROJECT_MEMORY_ADMIN_TOKEN
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
-};
+import { authorizeBearer, jsonResponse } from "../_shared/privileged-auth.ts";
 
 Deno.serve(async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: CORS });
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
   }
 
-  if (req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
-  }
+  const authError = authorizeBearer(
+    req,
+    Deno.env.get("PROJECT_MEMORY_ADMIN_TOKEN"),
+  );
+  if (authError) return authError;
 
   let body: {
     category?: string;
@@ -37,12 +27,15 @@ Deno.serve(async (req: Request) => {
   try {
     body = await req.json();
   } catch {
-    // Empty body is OK — list all memories
+    // Empty body is valid.
   }
+
+  const limit = Math.min(Math.max(body.limit ?? 20, 1), 100);
+  const offset = Math.max(body.offset ?? 0, 0);
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
   );
 
   try {
@@ -50,39 +43,33 @@ Deno.serve(async (req: Request) => {
       .from("project_memories")
       .select("id, content, category, project, metadata, created_at", { count: "exact" })
       .order("created_at", { ascending: false })
-      .limit(body.limit ?? 20)
-      .range(body.offset ?? 0, (body.offset ?? 0) + (body.limit ?? 20) - 1);
+      .range(offset, offset + limit - 1);
 
     if (body.category) query = query.eq("category", body.category);
     if (body.project) query = query.eq("project", body.project);
 
     const { data, error, count } = await query;
-
     if (error) throw error;
 
-    // Group by category for easy overview
     const byCategory: Record<string, number> = {};
-    (data ?? []).forEach((m) => {
-      byCategory[m.category] = (byCategory[m.category] ?? 0) + 1;
+    (data ?? []).forEach((memory) => {
+      byCategory[memory.category] = (byCategory[memory.category] ?? 0) + 1;
     });
 
-    return new Response(
-      JSON.stringify({
-        memories: data ?? [],
-        count: data?.length ?? 0,
-        total: count ?? 0,
-        by_category: byCategory,
-        filter: {
-          category: body.category ?? null,
-          project: body.project ?? "atoenglish",
-        },
-      }),
-      { headers: { "Content-Type": "application/json", ...CORS } }
-    );
+    return jsonResponse({
+      memories: data ?? [],
+      count: data?.length ?? 0,
+      total: count ?? 0,
+      by_category: byCategory,
+      filter: {
+        category: body.category ?? null,
+        project: body.project ?? "atoenglish",
+      },
+    });
   } catch (err) {
-    return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : String(err) },
+      500,
     );
   }
 });

--- a/supabase/functions/manage-memory/index.ts
+++ b/supabase/functions/manage-memory/index.ts
@@ -1,27 +1,21 @@
 /**
- * manage-memory — Supabase Edge Function
- * Handles DELETE and UPDATE operations on project_memories
- *
- * POST body:
- * { "action": "delete", "id": 5 }
- * { "action": "update", "id": 5, "content": "new content", "category": "bug", "metadata": {} }
+ * manage-memory — privileged Supabase Edge Function.
+ * Requires: Authorization: Bearer $PROJECT_MEMORY_ADMIN_TOKEN
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
-};
+import { authorizeBearer, jsonResponse } from "../_shared/privileged-auth.ts";
 
 Deno.serve(async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: CORS });
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
   }
 
-  if (req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
-  }
+  const authError = authorizeBearer(
+    req,
+    Deno.env.get("PROJECT_MEMORY_ADMIN_TOKEN"),
+  );
+  if (authError) return authError;
 
   let body: {
     action: "delete" | "update";
@@ -34,20 +28,16 @@ Deno.serve(async (req: Request) => {
   try {
     body = await req.json();
   } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400, headers: { "Content-Type": "application/json", ...CORS },
-    });
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
   }
 
   if (!body.id || !body.action) {
-    return new Response(JSON.stringify({ error: "id and action are required" }), {
-      status: 400, headers: { "Content-Type": "application/json", ...CORS },
-    });
+    return jsonResponse({ error: "id and action are required" }, 400);
   }
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
   );
 
   try {
@@ -56,23 +46,15 @@ Deno.serve(async (req: Request) => {
         .from("project_memories")
         .delete()
         .eq("id", body.id);
-
       if (error) throw error;
-
-      return new Response(
-        JSON.stringify({ success: true, deleted_id: body.id }),
-        { headers: { "Content-Type": "application/json", ...CORS } }
-      );
+      return jsonResponse({ success: true, deleted_id: body.id });
     }
 
     if (body.action === "update") {
       if (!body.content?.trim()) {
-        return new Response(JSON.stringify({ error: "content is required for update" }), {
-          status: 400, headers: { "Content-Type": "application/json", ...CORS },
-        });
+        return jsonResponse({ error: "content is required for update" }, 400);
       }
 
-      // Re-embed the updated content
       const model = new Supabase.ai.Session("gte-small");
       const embedding = await model.run(body.content.trim(), {
         mean_pool: true,
@@ -97,23 +79,15 @@ Deno.serve(async (req: Request) => {
         .eq("id", body.id)
         .select("id, content, category, created_at")
         .single();
-
       if (error) throw error;
-
-      return new Response(
-        JSON.stringify({ success: true, memory: data }),
-        { headers: { "Content-Type": "application/json", ...CORS } }
-      );
+      return jsonResponse({ success: true, memory: data });
     }
 
-    return new Response(JSON.stringify({ error: `Unknown action: ${body.action}` }), {
-      status: 400, headers: { "Content-Type": "application/json", ...CORS },
-    });
-
+    return jsonResponse({ error: `Unknown action: ${body.action}` }, 400);
   } catch (err) {
-    return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : String(err) },
+      500,
     );
   }
 });

--- a/supabase/functions/search-memories/index.ts
+++ b/supabase/functions/search-memories/index.ts
@@ -1,32 +1,21 @@
 /**
- * search-memories — Supabase Edge Function
- * Semantic search using Supabase built-in AI (gte-small, 384 dims) — FREE
- *
- * POST body:
- * {
- *   "query": "how does FSRS scheduling work?",
- *   "threshold": 0.70,        // optional, default 0.70
- *   "limit": 8,               // optional, default 8
- *   "project": "atoenglish",  // optional filter
- *   "category": "decision"    // optional filter
- * }
+ * search-memories — privileged Supabase Edge Function.
+ * Requires: Authorization: Bearer $PROJECT_MEMORY_ADMIN_TOKEN
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { authorizeBearer, jsonResponse } from "../_shared/privileged-auth.ts";
 
 Deno.serve(async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "authorization, content-type",
-      },
-    });
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
   }
 
-  if (req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
-  }
+  const authError = authorizeBearer(
+    req,
+    Deno.env.get("PROJECT_MEMORY_ADMIN_TOKEN"),
+  );
+  if (authError) return authError;
 
   let body: {
     query: string;
@@ -39,54 +28,45 @@ Deno.serve(async (req: Request) => {
   try {
     body = await req.json();
   } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400, headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
   }
 
   if (!body.query?.trim()) {
-    return new Response(JSON.stringify({ error: "query is required" }), {
-      status: 400, headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: "query is required" }, 400);
   }
 
   try {
-    // 1. Embed query using built-in gte-small
     const model = new Supabase.ai.Session("gte-small");
     const embedding = await model.run(body.query.trim(), {
       mean_pool: true,
       normalize: true,
     }) as number[];
 
-    // 2. Semantic search via match_memories RPC
     const supabase = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
     );
 
     const { data, error } = await supabase.rpc("match_memories", {
       query_embedding: JSON.stringify(embedding),
       match_threshold: body.threshold ?? 0.70,
-      match_count: body.limit ?? 8,
+      match_count: Math.min(Math.max(body.limit ?? 8, 1), 50),
       filter_project: body.project ?? null,
       filter_category: body.category ?? null,
     });
 
     if (error) throw error;
 
-    return new Response(
-      JSON.stringify({
-        memories: data ?? [],
-        count: data?.length ?? 0,
-        query: body.query,
-      }),
-      { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }
-    );
+    return jsonResponse({
+      memories: data ?? [],
+      count: data?.length ?? 0,
+      query: body.query,
+    });
   } catch (err) {
     console.error("[search-memories]", err);
-    return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : String(err) },
+      500,
     );
   }
 });

--- a/supabase/functions/store-memory/index.ts
+++ b/supabase/functions/store-memory/index.ts
@@ -1,31 +1,21 @@
 /**
- * store-memory — Supabase Edge Function
- * Uses Supabase built-in AI (gte-small, 384 dims) — ZERO cost, no API keys
- *
- * POST body:
- * {
- *   "content": "Decided to use FSRS v6 for spaced repetition",
- *   "category": "decision",       // decision|architecture|context|bug|feature|rule|task
- *   "project": "atoenglish",      // optional
- *   "metadata": {"importance": 8} // optional
- * }
+ * store-memory — privileged Supabase Edge Function.
+ * Requires: Authorization: Bearer $PROJECT_MEMORY_ADMIN_TOKEN
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { authorizeBearer, jsonResponse } from "../_shared/privileged-auth.ts";
 
 Deno.serve(async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "authorization, content-type",
-      },
-    });
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
   }
 
-  if (req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
-  }
+  const authError = authorizeBearer(
+    req,
+    Deno.env.get("PROJECT_MEMORY_ADMIN_TOKEN"),
+  );
+  if (authError) return authError;
 
   let body: {
     content: string;
@@ -37,29 +27,23 @@ Deno.serve(async (req: Request) => {
   try {
     body = await req.json();
   } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400, headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
   }
 
   if (!body.content?.trim()) {
-    return new Response(JSON.stringify({ error: "content is required" }), {
-      status: 400, headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: "content is required" }, 400);
   }
 
   try {
-    // 1. Generate embedding using Supabase built-in AI (free, no API key needed)
     const model = new Supabase.ai.Session("gte-small");
     const embedding = await model.run(body.content.trim(), {
       mean_pool: true,
       normalize: true,
     }) as number[];
 
-    // 2. Insert into DB using service role (bypasses RLS for agent writes)
     const supabase = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
     );
 
     const { data, error } = await supabase
@@ -78,16 +62,12 @@ Deno.serve(async (req: Request) => {
       .single();
 
     if (error) throw error;
-
-    return new Response(
-      JSON.stringify({ success: true, memory: data }),
-      { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }
-    );
+    return jsonResponse({ success: true, memory: data });
   } catch (err) {
     console.error("[store-memory]", err);
-    return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : String(err) },
+      500,
     );
   }
 });

--- a/supabase/functions/streak-reminder/index.ts
+++ b/supabase/functions/streak-reminder/index.ts
@@ -1,30 +1,17 @@
 /**
  * Supabase Edge Function: streak-reminder
- *
- * Runs daily at 13:00 UTC (20:00 Vietnam time via Supabase cron)
- * Sends Web Push notifications to users who haven't studied today
- *
- * Setup in Supabase Dashboard → Edge Functions → Cron:
- *   Schedule: 0 13 * * *
- *   Function: streak-reminder
- *
- * Required secrets (set in Supabase Dashboard → Settings → Edge Functions):
- *   VAPID_PRIVATE_KEY   — generated with: npx web-push generate-vapid-keys
- *   VAPID_PUBLIC_KEY    — same command above
- *   VAPID_SUBJECT       — mailto:your@email.com
+ * Runs from a trusted scheduler using POST only.
+ * Requires: Authorization: Bearer $STREAK_REMINDER_CRON_SECRET
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { authorizeBearer, jsonResponse } from "../_shared/privileged-auth.ts";
 
-// Web Push via built-in crypto (Deno runtime)
 async function sendWebPush(
   subscription: { endpoint: string; keys: { p256dh: string; auth: string } },
-  payload: { title: string; body: string; icon: string }
+  payload: { title: string; body: string; icon: string },
 ): Promise<boolean> {
   const { endpoint, keys } = subscription;
-
-  // Use web-push compatible library (or implement VAPID manually)
-  // For simplicity, using fetch with VAPID Authorization header
   const vapidPublicKey = Deno.env.get("VAPID_PUBLIC_KEY") ?? "";
   const vapidPrivateKey = Deno.env.get("VAPID_PRIVATE_KEY") ?? "";
   const vapidSubject = Deno.env.get("VAPID_SUBJECT") ?? "mailto:admin@atoenglish.app";
@@ -35,16 +22,11 @@ async function sendWebPush(
   }
 
   try {
-    // Import web-push for Deno
     const webpush = await import("npm:web-push@3");
     webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
-
     await webpush.sendNotification(
-      {
-        endpoint,
-        keys: { p256dh: keys.p256dh, auth: keys.auth },
-      },
-      JSON.stringify(payload)
+      { endpoint, keys: { p256dh: keys.p256dh, auth: keys.auth } },
+      JSON.stringify(payload),
     );
     return true;
   } catch (err) {
@@ -53,22 +35,26 @@ async function sendWebPush(
   }
 }
 
-Deno.serve(async (req) => {
-  // Only allow POST (from Supabase cron or manual trigger)
-  if (req.method !== "POST" && req.method !== "GET") {
-    return new Response("Method not allowed", { status: 405 });
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
   }
+
+  const authError = authorizeBearer(
+    req,
+    Deno.env.get("STREAK_REMINDER_CRON_SECRET"),
+  );
+  if (authError) return authError;
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
   );
 
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const todayStr = todayStart.toISOString();
 
-  // Find users with active subscriptions who haven't logged XP today
   const { data: subscriptions, error } = await supabase
     .from("push_subscriptions")
     .select("user_id, endpoint, keys")
@@ -81,13 +67,13 @@ Deno.serve(async (req) => {
         UNION
         SELECT DISTINCT user_id FROM completed_lessons
         WHERE completed_at >= '${todayStr}'
-      )`
+      )`,
     )
-    .limit(500); // safety cap
+    .limit(500);
 
   if (error) {
     console.error("[Reminder] Query failed:", error);
-    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+    return jsonResponse({ error: error.message }, 500);
   }
 
   const payload = {
@@ -98,15 +84,12 @@ Deno.serve(async (req) => {
 
   let sent = 0;
   let failed = 0;
-
   for (const sub of subscriptions ?? []) {
     const ok = await sendWebPush(sub, payload);
-    if (ok) sent++; else failed++;
+    if (ok) sent++;
+    else failed++;
   }
 
   console.log(`[Reminder] Sent: ${sent}, Failed: ${failed}`);
-  return new Response(
-    JSON.stringify({ sent, failed, total: subscriptions?.length ?? 0 }),
-    { headers: { "Content-Type": "application/json" } }
-  );
+  return jsonResponse({ sent, failed, total: subscriptions?.length ?? 0 });
 });


### PR DESCRIPTION
Closes #165.

## What changes
- add shared fail-closed bearer authorization for privileged Supabase Edge Functions
- require `PROJECT_MEMORY_ADMIN_TOKEN` for list/search/store/manage memory functions
- require `STREAK_REMINDER_CRON_SECRET` for streak reminders
- make streak reminder POST-only
- remove browser-wide wildcard CORS from privileged functions
- version `verify_jwt = false` for these custom non-JWT server secrets in `supabase/config.toml`
- document the deployment contract and required server-only secrets
- add unit coverage proving missing/wrong credentials are rejected and only the exact secret is accepted

## Trust model
`verify_jwt = false` is intentional only for these five functions so non-JWT scheduler/admin secrets can reach the handler. Authorization is enforced in code before any service-role client is created or used. Missing configuration fails with 503; missing/wrong credentials fail with 401.

## Verification
Draft until exact-head GitHub Verify passes.