### PR TITLE
fix(security): close private gamification execution bypass

### DIFF
--- a/supabase/migrations/20260907071500_harden_private_gamification_internals.sql
+++ b/supabase/migrations/20260907071500_harden_private_gamification_internals.sql
@@ -1,5 +1,28 @@
--- Close the authenticated execution bypass around privileged gamification helpers.
--- Browser/Data API callers must enter through public wrappers that enforce JWT self scope.
+-- Close authenticated execution bypasses around private implementation helpers.
+-- Browser/Data API callers must enter through explicit public authorization boundaries.
+
+-- Functions grant EXECUTE to PUBLIC by default unless explicitly revoked. Because
+-- authenticated has USAGE on the private schema for controlled wrapper internals,
+-- audit and revoke every existing private-schema function from browser roles here.
+-- Explicit service-role grants are preserved unless a function is deliberately
+-- re-declared below with a narrower privilege set.
+DO $migration$
+DECLARE
+  v_function regprocedure;
+BEGIN
+  FOR v_function IN
+    SELECT p.oid::regprocedure
+    FROM pg_catalog.pg_proc AS p
+    JOIN pg_catalog.pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'private'
+  LOOP
+    EXECUTE pg_catalog.format(
+      'REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, authenticated',
+      v_function
+    );
+  END LOOP;
+END
+$migration$;
 
 REVOKE ALL ON FUNCTION private.assign_league_for_user_internal(uuid)
   FROM PUBLIC, anon, authenticated, service_role;

--- a/supabase/migrations/20260907071500_harden_private_gamification_internals.sql
+++ b/supabase/migrations/20260907071500_harden_private_gamification_internals.sql
@@ -1,0 +1,78 @@
+-- Close the authenticated execution bypass around privileged gamification helpers.
+-- Browser/Data API callers must enter through public wrappers that enforce JWT self scope.
+
+REVOKE ALL ON FUNCTION private.assign_league_for_user_internal(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION private.assign_league_for_user_internal(uuid)
+  TO service_role;
+
+REVOKE ALL ON FUNCTION private.grant_streak_freeze_internal(uuid, integer)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION private.grant_streak_freeze_internal(uuid, integer)
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION public.assign_league_for_user(p_user_id uuid)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_role text := (SELECT auth.role());
+BEGIN
+  IF v_role = 'service_role' THEN
+    NULL;
+  ELSIF v_role = 'authenticated'
+        AND v_uid IS NOT NULL
+        AND p_user_id IS NOT DISTINCT FROM v_uid THEN
+    NULL;
+  ELSE
+    RAISE EXCEPTION 'not authorized' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN private.assign_league_for_user_internal(p_user_id);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.assign_league_for_user(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.assign_league_for_user(uuid)
+  TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.grant_streak_freeze(
+  p_user_id uuid,
+  p_count integer DEFAULT 1
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_role text := (SELECT auth.role());
+BEGIN
+  IF v_role = 'service_role' THEN
+    NULL;
+  ELSIF v_role = 'authenticated'
+        AND v_uid IS NOT NULL
+        AND p_user_id IS NOT DISTINCT FROM v_uid THEN
+    NULL;
+  ELSE
+    RAISE EXCEPTION 'not authorized' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM private.grant_streak_freeze_internal(p_user_id, p_count);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.grant_streak_freeze(uuid, integer)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.grant_streak_freeze(uuid, integer)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION private.assign_league_for_user_internal(uuid)
+  IS 'Privileged league-assignment primitive. Authenticated learners must use the self-scoped public wrapper.';
+COMMENT ON FUNCTION private.grant_streak_freeze_internal(uuid, integer)
+  IS 'Privileged streak-freeze grant primitive. Authenticated learners must use the self-scoped public wrapper.';

--- a/supabase/tests/database/private_gamification_internals.test.sql
+++ b/supabase/tests/database/private_gamification_internals.test.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(8);
+select plan(12);
 
 select ok(
   not has_function_privilege(
@@ -59,6 +59,22 @@ select ok(
   'authenticated retains the public self-scoped streak-freeze wrapper'
 );
 
+-- Private schema functions are implementation details. Browser-authenticated callers
+-- must cross an explicit public authorization boundary instead of executing any
+-- private function directly. This repository-wide invariant prevents a future
+-- private mutator from silently recreating the same USAGE + EXECUTE bypass.
+select is(
+  (
+    select count(*)::bigint
+    from pg_catalog.pg_proc as p
+    join pg_catalog.pg_namespace as n on n.oid = p.pronamespace
+    where n.nspname = 'private'
+      and has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  0::bigint,
+  'authenticated has no direct EXECUTE privilege on any private-schema function'
+);
+
 insert into auth.users (id, aud, role, email, created_at, updated_at)
 values
   (
@@ -77,6 +93,13 @@ values
     now(),
     now()
   );
+
+-- Make the other account eligible for a freeze grant so a missing ownership check
+-- would produce a visible mutation rather than a harmless no-op.
+update public.user_progress
+set streak = 7,
+    streak_freeze_count = 0
+where user_id = '66666666-6666-4666-8666-666666666666'::uuid;
 
 select set_config(
   'request.jwt.claims',
@@ -107,7 +130,39 @@ select throws_ok(
   'authenticated learner cannot assign another user through public wrapper'
 );
 
+select throws_ok(
+  $$
+    select public.grant_streak_freeze(
+      '66666666-6666-4666-8666-666666666666'::uuid,
+      1
+    )
+  $$,
+  '42501',
+  'not authorized',
+  'authenticated learner cannot grant a streak freeze to another user through public wrapper'
+);
+
 reset role;
+
+select is(
+  (
+    select streak_freeze_count
+    from public.user_progress
+    where user_id = '66666666-6666-4666-8666-666666666666'::uuid
+  ),
+  0,
+  'denied cross-account streak-freeze call leaves target freeze count unchanged'
+);
+
+select is(
+  (
+    select count(*)::bigint
+    from private.streak_freeze_grants
+    where user_id = '66666666-6666-4666-8666-666666666666'::uuid
+  ),
+  0::bigint,
+  'denied cross-account streak-freeze call creates no private grant record'
+);
 
 select * from finish();
 rollback;

--- a/supabase/tests/database/private_gamification_internals.test.sql
+++ b/supabase/tests/database/private_gamification_internals.test.sql
@@ -1,0 +1,113 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(8);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    to_regprocedure('private.assign_league_for_user_internal(uuid)'),
+    'EXECUTE'
+  ),
+  'authenticated cannot directly execute private league assignment primitive'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    to_regprocedure('private.grant_streak_freeze_internal(uuid,integer)'),
+    'EXECUTE'
+  ),
+  'authenticated cannot directly execute private streak-freeze primitive'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    to_regprocedure('private.assign_league_for_user_internal(uuid)'),
+    'EXECUTE'
+  ),
+  'service role retains private league assignment access'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    to_regprocedure('private.grant_streak_freeze_internal(uuid,integer)'),
+    'EXECUTE'
+  ),
+  'service role retains private streak-freeze grant access'
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    to_regprocedure('public.assign_league_for_user(uuid)'),
+    'EXECUTE'
+  ),
+  'authenticated retains the public self-scoped league wrapper'
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    to_regprocedure('public.grant_streak_freeze(uuid,integer)'),
+    'EXECUTE'
+  ),
+  'authenticated retains the public self-scoped streak-freeze wrapper'
+);
+
+insert into auth.users (id, aud, role, email, created_at, updated_at)
+values
+  (
+    '55555555-5555-4555-8555-555555555555',
+    'authenticated',
+    'authenticated',
+    'gamification-owner@atoenglish.test',
+    now(),
+    now()
+  ),
+  (
+    '66666666-6666-4666-8666-666666666666',
+    'authenticated',
+    'authenticated',
+    'gamification-other@atoenglish.test',
+    now(),
+    now()
+  );
+
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"55555555-5555-4555-8555-555555555555","role":"authenticated"}',
+  true
+);
+select set_config('request.jwt.claim.sub', '55555555-5555-4555-8555-555555555555', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+set local role authenticated;
+
+select lives_ok(
+  $$
+    select public.assign_league_for_user(
+      '55555555-5555-4555-8555-555555555555'::uuid
+    )
+  $$,
+  'authenticated learner can still assign their own league through public wrapper'
+);
+
+select throws_ok(
+  $$
+    select public.assign_league_for_user(
+      '66666666-6666-4666-8666-666666666666'::uuid
+    )
+  $$,
+  '42501',
+  'not authorized',
+  'authenticated learner cannot assign another user through public wrapper'
+);
+
+reset role;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #170.

## Summary
- revoke authenticated execution on privileged private league/streak-freeze primitives
- keep direct primitive access only for service-role/internal use
- preserve authenticated product APIs through public wrappers with JWT-role + auth.uid() self-scope checks
- add pgTAP regression coverage for function privileges and cross-account denial

## Verification required
- GitHub Verify on the exact PR head
- fresh migration replay
- database lint
- pgTAP/RLS tests

No production database state is assumed or modified by this PR.