### PR TITLE
feat(learning): ground unit 1 in a traceable CEFR action contract

### DIFF
--- a/src/components/learn/lesson-ui/SituationCard.tsx
+++ b/src/components/learn/lesson-ui/SituationCard.tsx
@@ -1,11 +1,15 @@
+import { getCefrActionContract } from "@/lib/lessons/cefr-action-contracts";
 import LessonCard from "./LessonCard";
 
 interface SituationCardProps {
+  unitId: string;
   situation: string;
   outcomes?: string[];
 }
 
-export default function SituationCard({ situation, outcomes }: SituationCardProps) {
+export default function SituationCard({ unitId, situation, outcomes }: SituationCardProps) {
+  const cefrAction = getCefrActionContract(unitId);
+
   return (
     <LessonCard variant="highlight" className="mb-6 overflow-hidden relative">
       <div className="absolute inset-0 bg-gradient-to-br from-teal-500/5 via-transparent to-emerald-500/5 pointer-events-none" />
@@ -21,6 +25,37 @@ export default function SituationCard({ situation, outcomes }: SituationCardProp
         <p className="text-white text-lg sm:text-xl leading-relaxed font-semibold mb-4">
           {situation}
         </p>
+
+        {cefrAction && (
+          <div className="mb-4 rounded-2xl border border-emerald-500/25 bg-emerald-500/5 p-4">
+            <div className="flex flex-wrap items-center gap-2 mb-2">
+              <span className="rounded-full bg-emerald-500/15 px-2.5 py-1 text-[10px] font-black uppercase tracking-wider text-emerald-300">
+                CEFR {cefrAction.level}
+              </span>
+              <span className="rounded-full bg-sky-500/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-sky-300">
+                {cefrAction.mode}
+              </span>
+            </div>
+            <p className="text-[11px] font-black uppercase tracking-widest text-emerald-400 mb-1">
+              Nhiệm vụ giao tiếp đích
+            </p>
+            <p className="text-sm font-semibold leading-relaxed text-zinc-100">
+              {cefrAction.actionTaskVi}
+            </p>
+            <ul className="mt-3 space-y-1.5">
+              {cefrAction.successCriteriaVi.map((criterion) => (
+                <li key={criterion} className="flex items-start gap-2 text-xs leading-relaxed text-zinc-400">
+                  <span className="mt-0.5 text-emerald-400">✓</span>
+                  <span>{criterion}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 text-[10px] leading-relaxed text-zinc-500">
+              Tham chiếu: {cefrAction.source.title}. Điểm quiz/XP của bài chưa được coi là bằng chứng CEFR mastery.
+            </p>
+          </div>
+        )}
+
         {outcomes && outcomes.length > 0 && (
           <ul className="space-y-2">
             {outcomes.map((o, i) => (

--- a/src/components/learn/sections/WarmupSection.tsx
+++ b/src/components/learn/sections/WarmupSection.tsx
@@ -57,10 +57,13 @@ export default function WarmupSection({
       <HowToLearnCard />
 
       {unit.situation && (
-        <SituationCard situation={unit.situation} outcomes={unit.learningOutcomes} />
+        <SituationCard
+          unitId={unit.unitId}
+          situation={unit.situation}
+          outcomes={unit.learningOutcomes}
+        />
       )}
 
-      {/* ── Job / Career Focus (TASK-153 world-class VN adult job content) ── */}
       {unit.jobScenarios && unit.jobScenarios.length > 0 && (
         <div className="mb-8">
           <div className="flex items-center gap-2 mb-3">
@@ -74,9 +77,7 @@ export default function WarmupSection({
                 className="rounded-2xl border border-border/60 bg-card p-4 shadow-md hover:border-primary/40 transition-colors"
               >
                 <div className="font-bold text-foreground text-sm mb-1">{js.title}</div>
-                <div className="text-xs text-muted-foreground mb-1">
-                  🎯 {js.focus}
-                </div>
+                <div className="text-xs text-muted-foreground mb-1">🎯 {js.focus}</div>
                 <div className="text-xs text-muted-foreground/80 mb-2">{js.context}</div>
                 {js.l1Note && (
                   <div className="mt-2 rounded-xl bg-amber-950/30 border border-amber-900/50 p-2 text-[11px] text-amber-300">
@@ -94,7 +95,6 @@ export default function WarmupSection({
         </div>
       )}
 
-      {/* Interaction Row */}
       <div className="grid grid-cols-2 gap-4 mb-8">
         {unit.warmupGreetings.map((g, i) => (
           <motion.button
@@ -105,21 +105,16 @@ export default function WarmupSection({
             transition={{ type: "spring", stiffness: 450, damping: 15 }}
             className="flex flex-col items-center text-center gap-3 p-5 border border-border/60 bg-card rounded-2xl transition-all duration-200 group hover:shadow-lg"
           >
-            <span className="text-4xl group-hover:scale-110 transition-transform duration-200">
-              {g.emoji}
-            </span>
+            <span className="text-4xl group-hover:scale-110 transition-transform duration-200">{g.emoji}</span>
             <div>
               <p className="font-bold text-foreground text-sm leading-tight">{g.en}</p>
               <p className="text-[11px] text-muted-foreground mt-0.5">{g.vn}</p>
             </div>
-            <span className="text-[9px] text-emerald-600 font-bold opacity-0 group-hover:opacity-100 transition-opacity">
-              ▶ Nghe
-            </span>
+            <span className="text-[9px] text-emerald-600 font-bold opacity-0 group-hover:opacity-100 transition-opacity">▶ Nghe</span>
           </motion.button>
         ))}
       </div>
 
-      {/* ── Vocab Self-Check ── */}
       <div className="mb-6 rounded-2xl border border-border/60 bg-card p-4 shadow-md">
         <div className="flex items-center justify-between mb-3">
           <div>
@@ -127,8 +122,7 @@ export default function WarmupSection({
             <p className="text-xs text-muted-foreground mt-0.5">Tự đánh giá trước khi học — không ảnh hưởng điểm số</p>
           </div>
           <span className="text-xs font-bold text-emerald-400">
-            {Object.values(warmupRated).filter((v) => v === "known").length}/
-            {Math.min(5, unit.vocab.length)}
+            {Object.values(warmupRated).filter((v) => v === "known").length}/{Math.min(5, unit.vocab.length)}
           </span>
         </div>
         <div className="space-y-2">
@@ -187,12 +181,9 @@ export default function WarmupSection({
         )}
       </div>
 
-      {/* ── Vietnamese Learner Alert ── */}
       {unit.grammar?.vnNote && (
         <div className="mb-6 rounded-2xl bg-red-500/10 border border-red-500/40 p-4">
-          <p className="text-[10px] font-black text-red-400 uppercase tracking-widest mb-2">
-            ⚠️ Bẫy ngữ pháp của người Việt trong bài này
-          </p>
+          <p className="text-[10px] font-black text-red-400 uppercase tracking-widest mb-2">⚠️ Bẫy ngữ pháp của người Việt trong bài này</p>
           <p className="text-muted-foreground text-sm leading-relaxed">
             {unit.grammar.vnNote.length > 150
               ? unit.grammar.vnNote.slice(0, 150) + "... (chi tiết ở phần Ngữ pháp)"
@@ -201,7 +192,6 @@ export default function WarmupSection({
         </div>
       )}
 
-      {/* SRS Warm-up — due cards from previous lessons */}
       {warmupCards.length > 0 && !warmupDone && (
         <div className="bg-amber-950/20 border border-amber-900/50 rounded-2xl p-6 mb-8">
           <div className="flex items-center justify-between mb-4">
@@ -257,7 +247,6 @@ export default function WarmupSection({
             <button
               onClick={() => {
                 setWarmupDone(true);
-                // Silently mark flipped cards as "Good" in SRS (fire-and-forget)
                 warmupCards.forEach((card, wi) => {
                   if (warmupFlipped.has(wi)) {
                     reviewCard(card.id, "Good").catch(() => {
@@ -274,7 +263,6 @@ export default function WarmupSection({
         </div>
       )}
 
-      {/* Cultural Note */}
       {unit.culturalNote && (
         <div className="border-l-4 border-primary bg-muted/30 rounded-r-2xl p-5 mb-8">
           <div className="flex items-center gap-2 mb-2">

--- a/src/lib/lessons/cefr-action-contracts.ts
+++ b/src/lib/lessons/cefr-action-contracts.ts
@@ -1,0 +1,76 @@
+export const CEFR_DESCRIPTOR_SOURCE = {
+  title: "Council of Europe — CEFR Companion Volume (2020)",
+  descriptorIndexUrl:
+    "https://www.coe.int/en/web/common-european-framework-reference-languages/cefr-descriptors",
+} as const;
+
+export type CefrMode =
+  | "reception"
+  | "production"
+  | "interaction"
+  | "mediation"
+  | "online-interaction";
+
+export interface CefrActionContract {
+  unitId: string;
+  level: "Pre-A1" | "A1" | "A2" | "B1" | "B2" | "C1" | "C2";
+  mode: CefrMode;
+  /**
+   * Product-facing Vietnamese paraphrase of the official descriptor.
+   * Keep the official Council of Europe source URL beside it for traceability.
+   */
+  descriptorVi: string;
+  actionTaskVi: string;
+  successCriteriaVi: string[];
+  source: typeof CEFR_DESCRIPTOR_SOURCE;
+  /**
+   * A lesson-completion score is not automatically CEFR mastery evidence.
+   * This field makes that boundary explicit until a matching assessment exists.
+   */
+  masteryEvidence: "not-yet-validated";
+}
+
+const contracts: Record<string, CefrActionContract> = {
+  "unit-1": {
+    unitId: "unit-1",
+    level: "A1",
+    mode: "interaction",
+    descriptorVi:
+      "Có thể hỏi và trả lời các câu hỏi đơn giản về chủ đề rất quen thuộc hoặc nhu cầu trực tiếp.",
+    actionTaskVi:
+      "Trong ngày đầu đi làm, hãy chào một đồng nghiệp mới, tự giới thiệu, trao đổi ít nhất một thông tin cá nhân đơn giản và kết thúc cuộc gặp lịch sự.",
+    successCriteriaVi: [
+      "Mở đầu bằng một lời chào phù hợp với tình huống.",
+      "Nói được tên và ít nhất một thông tin cá nhân đơn giản như nơi mình đến từ.",
+      "Hỏi hoặc trả lời được ít nhất một câu hỏi đơn giản với người đối thoại.",
+      "Kết thúc cuộc gặp bằng một câu lịch sự phù hợp.",
+    ],
+    source: CEFR_DESCRIPTOR_SOURCE,
+    masteryEvidence: "not-yet-validated",
+  },
+};
+
+export const CEFR_ACTION_CONTRACT_REQUIRED_UNIT_IDS = ["unit-1"] as const;
+
+export function getCefrActionContract(unitId: string): CefrActionContract | undefined {
+  return contracts[unitId];
+}
+
+export function validateCefrActionContract(contract: CefrActionContract | undefined): string[] {
+  if (!contract) return ["thiếu CEFR action contract"];
+
+  const violations: string[] = [];
+  if (!contract.level) violations.push("thiếu CEFR level");
+  if (!contract.mode) violations.push("thiếu communicative mode");
+  if (contract.descriptorVi.trim().length < 30) violations.push("descriptor quá ngắn");
+  if (contract.actionTaskVi.trim().length < 50) violations.push("action task quá ngắn");
+  if (contract.successCriteriaVi.length < 3) violations.push("cần ít nhất 3 success criteria");
+  if (!contract.source.descriptorIndexUrl.startsWith("https://www.coe.int/")) {
+    violations.push("descriptor phải truy vết về nguồn chính thức Council of Europe");
+  }
+  if (contract.masteryEvidence !== "not-yet-validated") {
+    violations.push("không được tự tuyên bố CEFR mastery khi chưa có assessment evidence hợp lệ");
+  }
+
+  return violations;
+}

--- a/src/lib/lessons/content-standard.ts
+++ b/src/lib/lessons/content-standard.ts
@@ -1,45 +1,41 @@
-/**
- * Chuẩn nội dung bài học (SDL — Self-Directed Learning).
- * Mọi unit phải đạt trước khi ship. Kiểm tra: curriculum-quality.test.ts + audit-lesson-content.sh
- *
- * Tham chiếu mẫu: src/lib/data/units/unit1.ts
- * Blueprint (nội dung + cách học): src/lib/lessons/lesson-blueprint.ts
- */
+import {
+  CEFR_ACTION_CONTRACT_REQUIRED_UNIT_IDS,
+  getCefrActionContract,
+  validateCefrActionContract,
+} from "@/lib/lessons/cefr-action-contracts";
 
+/**
+ * Chuẩn nội dung bài học hiện tại.
+ *
+ * Các ngưỡng số lượng bên dưới là legacy content-health checks; chúng KHÔNG tự chứng minh
+ * một bài học đạt CEFR. CEFR alignment được khóa riêng bằng action contract truy vết về
+ * Council of Europe và chỉ được mở rộng sang unit khác khi nội dung unit đó thực sự được
+ * đối chiếu, không sinh descriptor hàng loạt bằng suy đoán.
+ */
 export const LESSON_CONTENT_STANDARD = {
-  /** Hook đầu bài — bắt buộc mọi unit */
   situationMinChars: 30,
   learningOutcomesMin: 2,
   learningOutcomesMax: 5,
   culturalNoteMinChars: 40,
   warmupGreetingsMin: 3,
 
-  /** Vocab — cognitive load Nation & Webb */
   vocabMin: 8,
   vocabMax: 20,
 
-  /** L1 interference (người Việt) — % từ có ghi chú lỗi thường gặp */
   l1MinRatioByLevel: {
     A0: 0.5,
     A1: 1,
     A2: 1,
     B1: 0.5,
-    /** Mục tiêu 0.5 — TASK-058 (B2 L1 >=50% per center-ref VN CLT + §7) */
     B2: 0.5,
   } as Record<string, number>,
 
   l1NoteMinChars: 15,
-
-  /** Output & review — TASK-153 raise for world-class (Babbel real convos + VN job) */
   fluencyDrillItemsMin: 5,
-  /** shadowing via fluency/activate drill target 5+ */
   shadowingMin: 5,
   dialoguesMin: 2,
-  /** job focused scenarios target ≥1 per unit (adult VN career needs) */
   jobScenariosMin: 1,
-  /** Mục tiêu đạt 3 — TASK-059 (spiral review, Nation + center ref) */
   cumulativeReviewMin: 3,
-  /** Mục tiêu 3 — TASK-057 đã nâng: mọi unit ≥3 practiceTranslate */
   practiceTranslateMin: 3,
   listenAndChooseMin: 5,
   finalQuizMin: 5,
@@ -51,6 +47,7 @@ export interface ContentStandardViolation {
 }
 
 export interface UnitLike {
+  unitId?: string;
   level: string;
   situation?: string;
   learningOutcomes?: string[];
@@ -125,14 +122,14 @@ export function validateLessonContentStandard(
     tag("quiz", `quiz phải ≥ ${s.finalQuizMin} câu`);
   }
 
-  const dialoguesLen = (unit.dialogues?.length ?? 0);
+  const dialoguesLen = unit.dialogues?.length ?? 0;
   if (dialoguesLen < s.dialoguesMin) {
-    tag("dialogues", `dialogues phải ≥ ${s.dialoguesMin} (Babbel-like real convos + job)`);
+    tag("dialogues", `dialogues phải ≥ ${s.dialoguesMin}`);
   }
 
-  const jobLen = (unit.jobScenarios?.length ?? 0);
+  const jobLen = unit.jobScenarios?.length ?? 0;
   if (jobLen < s.jobScenariosMin) {
-    tag("jobScenarios", `jobScenarios phải ≥ ${s.jobScenariosMin} (VN adult career/job contexts)`);
+    tag("jobScenarios", `jobScenarios phải ≥ ${s.jobScenariosMin}`);
   }
 
   const minL1 = s.l1MinRatioByLevel[unit.level] ?? 0.5;
@@ -142,6 +139,16 @@ export function validateLessonContentStandard(
       "l1_interference_vn",
       `L1 notes ${Math.round(ratio * 100)}% < ${Math.round(minL1 * 100)}% yêu cầu level ${unit.level}`
     );
+  }
+
+  if (
+    unit.unitId &&
+    (CEFR_ACTION_CONTRACT_REQUIRED_UNIT_IDS as readonly string[]).includes(unit.unitId)
+  ) {
+    const contractViolations = validateCefrActionContract(getCefrActionContract(unit.unitId));
+    for (const violation of contractViolations) {
+      tag("cefrActionContract", `${unit.unitId}: ${violation}`);
+    }
   }
 
   return violations;


### PR DESCRIPTION
## What this changes
- adds a traceable Council of Europe CEFR action contract for Unit 1
- binds Unit 1 to A1 spoken interaction rather than treating activity counts/XP as CEFR evidence
- exposes the real-world target task and observable success criteria at the start of the lesson
- adds a content-standard gate so Unit 1 cannot silently lose its CEFR action contract
- explicitly marks CEFR mastery evidence as not yet validated; quiz/XP completion is not promoted to CEFR mastery

## Source basis
- Council of Europe — CEFR Companion Volume (2020)
- Council of Europe official CEFR descriptor index

## Scope
This is the first bounded migration of the existing curriculum toward the repository's single active direction. It does not invent descriptors for the remaining units and does not create a parallel roadmap or curriculum track.

## Verification
Exact-head GitHub Verify is required before merge.