### PR TITLE
feat(learning): evaluate Unit 1 speaking by task accomplishment

### DIFF
--- a/src/__tests__/speaking-task-evaluation.test.ts
+++ b/src/__tests__/speaking-task-evaluation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { evaluateSpeakingTask } from "@/lib/lessons/speaking-task-evaluation";
+
+describe("CEFR-aligned speaking task feedback", () => {
+  it("accepts a successful Unit 1 interaction even when it does not copy the lesson hint", () => {
+    const result = evaluateSpeakingTask(
+      "unit-1",
+      "Hi Alex. I'm Hoang. I work in Ho Chi Minh City. How are you? See you later."
+    );
+
+    expect(result).toMatchObject({
+      unitId: "unit-1",
+      accomplished: true,
+      metCount: 5,
+      total: 5,
+      evidenceKind: "practice-task-feedback",
+    });
+  });
+
+  it("does not pass a fluent-looking sentence that misses the interaction task", () => {
+    const result = evaluateSpeakingTask(
+      "unit-1",
+      "Hello. My name is Hoang. I'm from Vietnam."
+    );
+
+    expect(result?.accomplished).toBe(false);
+    expect(result?.criteria.find((criterion) => criterion.id === "interaction")?.met).toBe(false);
+    expect(result?.criteria.find((criterion) => criterion.id === "closing")?.met).toBe(false);
+  });
+
+  it("does not pretend unsupported units have a task rubric", () => {
+    expect(evaluateSpeakingTask("unit-2", "Hello there")).toBeUndefined();
+  });
+});

--- a/src/components/learn/sections/SpeakingSection.tsx
+++ b/src/components/learn/sections/SpeakingSection.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { Mic, MicOff, CheckCircle, Lightbulb, Volume2 } from "lucide-react";
-import { MinimalButton } from "@/components/design-system";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { CheckCircle, Lightbulb, Mic, MicOff, Volume2, XCircle } from "lucide-react";
 import LessonSectionHeader from "../lesson-ui/LessonSectionHeader";
 import LessonContinueButton from "../lesson-ui/LessonContinueButton";
 import { lessonSectionMotion } from "../lesson-ui/motion";
@@ -12,6 +11,10 @@ import { calcSpeechScore } from "@/lib/utils/speech";
 import { SpeechRecognitionFallback } from "@/lib/utils/speech-fallback";
 import type { UnitData } from "../UnitTemplate";
 import { trackPilotEventPersistentlyOnce } from "@/lib/pilot/pilot-analytics-client";
+import {
+  evaluateSpeakingTask,
+  type SpeakingTaskEvaluation,
+} from "@/lib/lessons/speaking-task-evaluation";
 
 interface SpeechRecognitionEvent {
   results: {
@@ -51,32 +54,34 @@ interface SpeakingSectionProps {
   goNext: () => void;
 }
 
-// Helper: detect specific missing English final consonants (codas) commonly deleted by Vietnamese learners
 function detectMissingCodas(expected: string, actual: string): string[] {
   const missingWarnings: string[] = [];
   const cleanExpected = expected.toLowerCase().replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "").trim();
   const cleanActual = actual.toLowerCase().replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "").trim();
-
   const expectedWords = cleanExpected.split(/\s+/);
   const actualWords = cleanActual.split(/\s+/);
 
   expectedWords.forEach((word) => {
-    // Check if the expected word ends in a target coda sound
-    if (word.endsWith("k") || word.endsWith("t") || word.endsWith("s") || word.endsWith("d") || word.endsWith("ce") || word.endsWith("se")) {
-      // Find matching word base in actual spoken phrase
+    if (
+      word.endsWith("k") ||
+      word.endsWith("t") ||
+      word.endsWith("s") ||
+      word.endsWith("d") ||
+      word.endsWith("ce") ||
+      word.endsWith("se")
+    ) {
       const baseWordWithoutCoda = word.replace(/(k|t|s|d|ce|se)$/, "");
-      
-      // If user pronounced the base but omitted the ending
       const foundOmission = actualWords.some(
-        (aWord) => aWord === baseWordWithoutCoda && aWord !== word
+        (actualWord) => actualWord === baseWordWithoutCoda && actualWord !== word
       );
 
       if (foundOmission) {
         let soundExplanation = "";
         if (word.endsWith("k")) soundExplanation = "âm /k/ (ví dụ: 'like' -> 'lai-kờ')";
         else if (word.endsWith("t")) soundExplanation = "âm /t/ (ví dụ: 'cat' -> 'ca-tờ')";
-        else if (word.endsWith("s") || word.endsWith("ce") || word.endsWith("se")) soundExplanation = "âm /s/ (ví dụ: 'face' -> 'fây-sờ')";
-        else if (word.endsWith("d")) soundExplanation = "âm /d/ (ví dụ: 'red' -> 're-dờ')";
+        else if (word.endsWith("s") || word.endsWith("ce") || word.endsWith("se")) {
+          soundExplanation = "âm /s/ (ví dụ: 'face' -> 'fây-sờ')";
+        } else if (word.endsWith("d")) soundExplanation = "âm /d/ (ví dụ: 'red' -> 're-dờ')";
 
         missingWarnings.push(`Từ "${word}" phát âm thiếu ${soundExplanation}`);
       }
@@ -102,94 +107,125 @@ export default function SpeakingSection({
   const [level2Transcript, setLevel2Transcript] = useState("");
   const [level2Recording, setLevel2Recording] = useState(false);
   const [level2Score, setLevel2Score] = useState<number | null>(null);
+  const [level2TaskEvaluation, setLevel2TaskEvaluation] =
+    useState<SpeakingTaskEvaluation | null>(null);
   const [level2Done, setLevel2Done] = useState(false);
   const [showHint, setShowHint] = useState(false);
 
   const [isRecognizing, setIsRecognizing] = useState(false);
   const recognitionRef = useRef<SpeechRecognitionObj | null>(null);
 
-  // Clean up speech recognition on unmount
   useEffect(() => {
     return () => {
       if (recognitionRef.current) {
         try {
           recognitionRef.current.abort();
-        } catch { /* ignore */ }
+        } catch {
+          // ignore browser cleanup errors
+        }
       }
     };
   }, []);
 
   const getSpeechRecognition = () => {
     if (typeof window === "undefined") return null;
-    const w = window as unknown as Record<string, unknown>;
-    return (w.SpeechRecognition ?? w.webkitSpeechRecognition ?? SpeechRecognitionFallback) as unknown as new () => SpeechRecognitionObj;
+    const windowWithSpeech = window as unknown as Record<string, unknown>;
+    return (
+      windowWithSpeech.SpeechRecognition ??
+      windowWithSpeech.webkitSpeechRecognition ??
+      SpeechRecognitionFallback
+    ) as unknown as new () => SpeechRecognitionObj;
   };
 
-  const formattedL1Prompt = unit.speaking.level1Prompt.replace("{input}", nameInput || "______");
+  const formattedL1Prompt = unit.speaking.level1Prompt.replace(
+    "{input}",
+    nameInput || "______"
+  );
 
-  const startRecognition = (expectedTranscript: string, onResult: (text: string) => void) => {
+  const startRecognition = (
+    expectedTranscript: string,
+    onResult: (text: string) => void
+  ) => {
     const SpeechRecognitionAPI = getSpeechRecognition();
     if (!SpeechRecognitionAPI) {
       toast.error("Trình duyệt không hỗ trợ nhận diện giọng nói");
       return;
     }
 
-    // Set fallback active transcript if using fallback
     if (SpeechRecognitionAPI === SpeechRecognitionFallback) {
       SpeechRecognitionFallback.activeTranscript = expectedTranscript;
     }
 
-    const rec = new SpeechRecognitionAPI();
-    rec.lang = "en-US";
-    rec.interimResults = false;
-    rec.maxAlternatives = 1;
+    const recognition = new SpeechRecognitionAPI();
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.maxAlternatives = 1;
 
-    rec.onresult = (e: SpeechRecognitionEvent) => {
-      const text = e.results[0][0].transcript;
-      onResult(text);
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      onResult(event.results[0][0].transcript);
     };
 
-    rec.onerror = (e: SpeechRecognitionErrorEvent) => {
-      if (e.error !== "aborted") {
-        toast.error(`Lỗi nhận diện: ${e.error}`);
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error !== "aborted") {
+        toast.error(`Lỗi nhận diện: ${event.error}`);
       }
       setIsLevel1Recording(false);
       setLevel2Recording(false);
       setIsRecognizing(false);
     };
 
-    rec.onend = () => {
+    recognition.onend = () => {
       setIsLevel1Recording(false);
       setLevel2Recording(false);
       setIsRecognizing(false);
     };
 
-    rec.onstart = () => setIsRecognizing(true);
-    recognitionRef.current = rec;
+    recognition.onstart = () => setIsRecognizing(true);
+    recognitionRef.current = recognition;
+
     if (unit.unitId === "unit-a0-1") {
       trackPilotEventPersistentlyOnce("first_speaking_started", unit.unitId, {
         source: "lesson",
         unitId: unit.unitId,
       });
     }
-    rec.start();
+
+    recognition.start();
   };
 
   const handleLevel2Record = () => {
     setLevel2Recording(true);
     setLevel2Transcript("");
     setLevel2Score(null);
-    // Score against the hint text (strips HTML tags)
+    setLevel2TaskEvaluation(null);
+    setLevel2Done(false);
+
     const hintText = unit.speaking.level2Hint
       .replace(/<[^>]*>/g, "")
-      .replace(/\[.*?\]/g, "") // strip [tên bạn] and similar placeholders
+      .replace(/\[.*?\]/g, "")
       .trim();
 
     startRecognition(hintText, (text) => {
       setLevel2Transcript(text);
       setLevel2Recording(false);
+
+      const taskEvaluation = evaluateSpeakingTask(unit.unitId, text);
+      if (taskEvaluation) {
+        setLevel2TaskEvaluation(taskEvaluation);
+        setLevel2Done(taskEvaluation.accomplished);
+        if (taskEvaluation.accomplished) {
+          toast.success(`Hoàn thành nhiệm vụ: ${taskEvaluation.metCount}/${taskEvaluation.total} tiêu chí`);
+        } else {
+          toast.info(
+            `Đã làm được ${taskEvaluation.metCount}/${taskEvaluation.total} tiêu chí — xem phần còn thiếu rồi thử lại.`
+          );
+        }
+        return;
+      }
+
       const score = calcSpeechScore(hintText, text);
       setLevel2Score(score);
+
       if (unit.unitId === "unit-a0-1") {
         trackPilotEventPersistentlyOnce("first_speaking_completed", unit.unitId, {
           source: "lesson",
@@ -198,6 +234,7 @@ export default function SpeakingSection({
           passed: score >= 60,
         });
       }
+
       if (score >= 60) {
         setLevel2Done(true);
         toast.success(`Tốt lắm! ${score}%`);
@@ -221,7 +258,6 @@ export default function SpeakingSection({
         totalSections={TOTAL_SECTIONS}
       />
 
-      {/* Level 1 */}
       <div className="border border-border/60 bg-card rounded-2xl p-4 sm:p-6 mb-4 sm:mb-5 shadow-md">
         <div className="flex items-center gap-2 mb-4">
           <span className="px-2 py-0.5 text-xs font-bold bg-emerald-600/20 text-emerald-400 rounded-full">
@@ -245,7 +281,7 @@ export default function SpeakingSection({
           type="text"
           placeholder={unit.speaking.level1Placeholder}
           value={nameInput}
-          onChange={(e) => setNameInput(e.target.value)}
+          onChange={(event) => setNameInput(event.target.value)}
           className="w-full bg-muted/40 border border-border/60 rounded-xl px-4 py-3 text-foreground placeholder:text-muted-foreground/60 mb-3 focus:outline-none focus:border-emerald-500 transition-colors"
         />
 
@@ -276,14 +312,10 @@ export default function SpeakingSection({
                       } else {
                         toast.success(`Tốt lắm! ${score}%`);
                       }
+                    } else if (missingCodas.length > 0) {
+                      toast.error(`Chưa đạt (${score}%). Lỗi: ${missingCodas.join(", ")}`);
                     } else {
-                      if (missingCodas.length > 0) {
-                        toast.error(
-                          `Chưa đạt (${score}%). Lỗi: ${missingCodas.join(", ")}`
-                        );
-                      } else {
-                        toast.info(`${score}% — Không sao, thử lại nhé!`);
-                      }
+                      toast.info(`${score}% — Không sao, thử lại nhé!`);
                     }
                   });
                 }}
@@ -305,6 +337,7 @@ export default function SpeakingSection({
                 )}
               </button>
             </div>
+
             {level1Transcript && (
               <div className="bg-muted/30 rounded-xl px-4 py-3 text-sm">
                 <p className="text-muted-foreground text-[10px] mb-1 font-bold">BẠN VỪA NÓI:</p>
@@ -318,7 +351,7 @@ export default function SpeakingSection({
                           : "bg-amber-500/20 text-amber-400"
                       }`}
                     >
-                      {level1Score}% chính xác
+                      {level1Score}% khớp transcript mẫu
                     </span>
                     {level1Score < 60 && (
                       <button
@@ -335,11 +368,13 @@ export default function SpeakingSection({
                 )}
               </div>
             )}
+
             {level1Done && (
               <div className="flex items-center gap-2 text-emerald-400 text-sm font-bold">
                 <CheckCircle size={14} /> Hoàn thành cấp độ 1!
               </div>
             )}
+
             {!level1Done && level1Score !== null && level1Score < 60 && (
               <button
                 onClick={() => setLevel1Done(true)}
@@ -352,7 +387,6 @@ export default function SpeakingSection({
         )}
       </div>
 
-      {/* Level 2 */}
       <div
         className={`border border-border/60 bg-card rounded-2xl p-6 mb-6 transition-all shadow-md ${
           level1Done ? "border-border/60" : "border-border/40 opacity-40 pointer-events-none"
@@ -362,7 +396,7 @@ export default function SpeakingSection({
           <span className="px-2 py-0.5 text-xs font-bold bg-teal-600/20 text-teal-400 rounded-full">
             Cấp độ 2
           </span>
-          <p className="text-foreground font-semibold">Tự giới thiệu / Diễn đạt tự do</p>
+          <p className="text-foreground font-semibold">Thực hiện nhiệm vụ giao tiếp</p>
           {level2Done && <CheckCircle size={16} className="text-emerald-400 ml-auto" />}
         </div>
 
@@ -375,7 +409,7 @@ export default function SpeakingSection({
 
         <div className="flex gap-2 mb-4">
           <button
-            onClick={() => setShowHint((p) => !p)}
+            onClick={() => setShowHint((previous) => !previous)}
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
           >
             <Lightbulb size={12} />
@@ -403,7 +437,39 @@ export default function SpeakingSection({
           <div className="bg-muted/30 rounded-xl p-3 mb-3">
             <p className="text-xs text-muted-foreground mb-1">Bạn vừa nói:</p>
             <p className="text-foreground text-sm">&ldquo;{level2Transcript}&rdquo;</p>
-            {level2Score !== null && (
+
+            {level2TaskEvaluation ? (
+              <div className="mt-3 space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs font-bold text-foreground">Hoàn thành nhiệm vụ</p>
+                  <span
+                    className={`text-xs font-black px-2.5 py-1 rounded-full ${
+                      level2TaskEvaluation.accomplished
+                        ? "bg-emerald-500/15 text-emerald-400"
+                        : "bg-amber-500/15 text-amber-400"
+                    }`}
+                  >
+                    {level2TaskEvaluation.metCount}/{level2TaskEvaluation.total}
+                  </span>
+                </div>
+                {level2TaskEvaluation.criteria.map((criterion) => (
+                  <div
+                    key={criterion.id}
+                    className="flex items-start gap-2 rounded-lg border border-border/50 bg-background/30 px-3 py-2"
+                  >
+                    {criterion.met ? (
+                      <CheckCircle size={14} className="mt-0.5 shrink-0 text-emerald-400" />
+                    ) : (
+                      <XCircle size={14} className="mt-0.5 shrink-0 text-amber-400" />
+                    )}
+                    <span className="text-xs text-muted-foreground">{criterion.labelVi}</span>
+                  </div>
+                ))}
+                <p className="text-[11px] leading-relaxed text-muted-foreground/70">
+                  Đây là phản hồi luyện tập theo nhiệm vụ giao tiếp, không phải chứng nhận bạn đã đạt CEFR A1.
+                </p>
+              </div>
+            ) : level2Score !== null ? (
               <div className="mt-2 flex items-center gap-2">
                 <div
                   className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold border ${
@@ -412,13 +478,13 @@ export default function SpeakingSection({
                       : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                   }`}
                 >
-                  Độ chính xác: {level2Score}%
+                  Khớp transcript mẫu: {level2Score}%
                 </div>
                 <span className="text-xs text-muted-foreground">
                   {level2Score >= 70 ? "Tốt lắm! 🎉" : "Thử lại sẽ tốt hơn 💪"}
                 </span>
               </div>
-            )}
+            ) : null}
           </div>
         )}
 
@@ -434,11 +500,13 @@ export default function SpeakingSection({
             }
             aria-label={level2Recording ? "Dừng ghi âm" : "Bắt đầu ghi âm"}
             className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-bold text-sm transition-colors ${
-              level2Recording ? "bg-red-600 text-white animate-pulse" : "bg-emerald-600 hover:bg-emerald-500 text-white"
+              level2Recording
+                ? "bg-red-600 text-white animate-pulse"
+                : "bg-emerald-600 hover:bg-emerald-500 text-white"
             }`}
           >
             {level2Recording ? <MicOff size={16} /> : <Mic size={16} />}
-            {level2Recording ? "Dừng" : "Bắt đầu nói"}
+            {level2Recording ? "Dừng" : level2Transcript ? "Thử lại" : "Bắt đầu nói"}
           </button>
           {level2Transcript && (
             <button
@@ -456,7 +524,7 @@ export default function SpeakingSection({
           </p>
         )}
         <p className="text-muted-foreground/60 text-xs mt-2 text-center">
-          Không sao đâu, cứ thử — mình ở đây để luyện cùng bạn! 💪
+          Mục tiêu là truyền đạt đủ ý trong tình huống, không phải đọc giống hệt câu mẫu.
         </p>
       </div>
 
@@ -464,7 +532,9 @@ export default function SpeakingSection({
         <LessonContinueButton onClick={goNext}>Xem kết quả</LessonContinueButton>
       )}
       {level1Done && !level2Done && level2Transcript === "" && (
-        <p className="text-center text-muted-foreground text-sm">Thử nói ở Cấp độ 2 trước khi tiếp tục 🎤</p>
+        <p className="text-center text-muted-foreground text-sm">
+          Thử nói ở Cấp độ 2 trước khi tiếp tục 🎤
+        </p>
       )}
     </motion.div>
   );

--- a/src/lib/lessons/speaking-task-evaluation.ts
+++ b/src/lib/lessons/speaking-task-evaluation.ts
@@ -1,0 +1,83 @@
+export interface SpeakingTaskCriterionResult {
+  id: "greeting" | "identity" | "personal-info" | "interaction" | "closing";
+  labelVi: string;
+  met: boolean;
+}
+
+export interface SpeakingTaskEvaluation {
+  unitId: string;
+  criteria: SpeakingTaskCriterionResult[];
+  metCount: number;
+  total: number;
+  accomplished: boolean;
+  /** Practice feedback only. This must never be promoted to CEFR mastery evidence. */
+  evidenceKind: "practice-task-feedback";
+}
+
+const normalize = (transcript: string) =>
+  transcript
+    .toLowerCase()
+    .replace(/[’]/g, "'")
+    .replace(/[^a-z'?\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+function evaluateUnit1(transcript: string): SpeakingTaskEvaluation {
+  const text = normalize(transcript);
+
+  const criteria: SpeakingTaskCriterionResult[] = [
+    {
+      id: "greeting",
+      labelVi: "Mở đầu bằng lời chào phù hợp.",
+      met: /\b(hi|hello|hey|good morning|good afternoon|good evening)\b/.test(text),
+    },
+    {
+      id: "identity",
+      labelVi: "Tự giới thiệu tên.",
+      met: /\bmy name is\b/.test(text) || /\bi(?:'m| am)\s+(?!from\b)[a-z]+\b/.test(text),
+    },
+    {
+      id: "personal-info",
+      labelVi: "Nói ít nhất một thông tin cá nhân đơn giản.",
+      met:
+        /\bi(?:'m| am) from\b/.test(text) ||
+        /\bi (?:live|work|study) (?:in|at)\b/.test(text) ||
+        /\bi(?:'m| am) (?:a|an)\s+[a-z]+\b/.test(text),
+    },
+    {
+      id: "interaction",
+      labelVi: "Hỏi người đối thoại ít nhất một câu đơn giản.",
+      met:
+        /\b(where are you from|what(?:'s| is) your name|how are you|and you|how about you|what about you)\b/.test(text) ||
+        /\b(?:where|what|how|do|are|can)\b[^?]{0,50}\b(?:you|your)\b\??/.test(text),
+    },
+    {
+      id: "closing",
+      labelVi: "Kết thúc cuộc gặp lịch sự.",
+      met: /\b(goodbye|bye|see you|see you later|have a nice day|nice meeting you)\b/.test(text),
+    },
+  ];
+
+  const metCount = criteria.filter((criterion) => criterion.met).length;
+
+  return {
+    unitId: "unit-1",
+    criteria,
+    metCount,
+    total: criteria.length,
+    accomplished: metCount === criteria.length,
+    evidenceKind: "practice-task-feedback",
+  };
+}
+
+/**
+ * Returns task-accomplishment feedback only for units with an explicitly designed evaluator.
+ * Undefined means the unit must continue using its existing practice feedback until a rubric is authored.
+ */
+export function evaluateSpeakingTask(
+  unitId: string,
+  transcript: string
+): SpeakingTaskEvaluation | undefined {
+  if (unitId === "unit-1") return evaluateUnit1(transcript);
+  return undefined;
+}


### PR DESCRIPTION
## What this changes
- adds a Unit 1 speaking-task evaluator aligned with the CEFR action contract merged in #172
- scores observable task completion (greeting, identity, personal info, interaction, closing) instead of sentence-template similarity
- keeps template-match feedback for units that do not yet have an authored task rubric
- relabels template practice as transcript matching rather than pronunciation/accuracy
- shows criterion-by-criterion feedback in Speaking UI
- explicitly states task feedback is practice evidence, not CEFR mastery certification

## Regression coverage
- a valid alternative utterance that does not copy the hint passes the Unit 1 task
- a fluent utterance that misses interaction/closing does not pass
- unsupported units do not silently receive a fabricated rubric

## Scope
This continues the single CEFR/action-oriented migration begun in #172. It does not add another curriculum direction and does not claim CEFR mastery.

## Verification
Exact-head GitHub Verify must pass before merge.