### PR TITLE
refactor(scope): reduce non-core learning maintenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ If there is no active task or owner decision, do not invent maintenance, refacto
 
 ## Single-direction gate
 
-`docs/project/PROJECT_STATE.md` defines exactly one active product direction.
+`docs/project/PROJECT_STATE.md` defines exactly one active product direction and its minimum active product surface.
 
-Before doing any product work, verify that the requested change directly advances that direction. If it does not, stop.
+Before doing any product work, verify that the requested change directly advances that direction and minimum surface. If it does not, stop.
 
 Agents must not create, suggest, activate or maintain:
 
@@ -38,6 +38,19 @@ Do not treat ambiguity as permission to branch product strategy. Do not infer a 
 Only an explicit current owner statement that clearly replaces the existing direction may change product direction.
 
 Security, privacy, data-integrity, release and correctness fixes may interrupt execution when necessary, but they do not redefine the product direction.
+
+## Reduced-scope gate
+
+Features explicitly listed as closed/non-core in `docs/project/PROJECT_STATE.md` are frozen compatibility surface, not backlog.
+
+Agents must not create work to improve, redesign, expand, benchmark or revive those surfaces. In particular, do not create product work around XP, streak celebrations, leagues/leaderboards, badges/achievements, confetti/reward effects, mandatory Job/Career overlays, social competition or speculative engagement systems.
+
+When touching code that contains a closed/non-core surface:
+
+1. preserve it only when removal would create disproportionate compatibility, migration or correctness risk;
+2. do not add new dependencies or product behavior for it;
+3. prefer safe deletion or simplification when that reduces maintenance burden;
+4. never use legacy code existence as justification for new roadmap work.
 
 ## Scope discipline
 

--- a/docs/project/PROJECT_STATE.md
+++ b/docs/project/PROJECT_STATE.md
@@ -5,7 +5,7 @@
 
 ## Current state
 
-AtoEnglish now has exactly **one active product direction**. All previous, parallel, experimental, inherited or alternative product directions are closed as sources of authority.
+AtoEnglish has exactly **one active product direction**. All previous, parallel, experimental, inherited or alternative product directions are closed as sources of authority.
 
 Existing features, curriculum, branches, historical plans, experiments and R&D remain evidence of what exists or what was tried. They do **not** authorize continuing those directions.
 
@@ -21,7 +21,33 @@ The current reference foundation is:
 - British Council — lesson planning and course-planning guidance;
 - official technical standards only where implementation requires them, such as W3C accessibility guidance and browser/platform documentation.
 
-This direction means the product must be shaped from real learner outcomes and official language-learning guidance first. Existing implementation is a substrate to inspect, keep, change or remove according to that direction; it is not a competing roadmap.
+This direction means the product is shaped from real learner outcomes and official language-learning guidance first. Existing implementation is a substrate to inspect, keep, change or remove according to that direction; it is not a competing roadmap.
+
+## Minimum active product surface
+
+Only the following areas are active product scope:
+
+1. curriculum and CEFR/action-oriented learning outcomes;
+2. lesson delivery for reading, listening, speaking, writing and interaction as required by those outcomes;
+3. practice and assessment that produce honest evidence of learner performance;
+4. progression/review needed to retain and reuse learned language, including SRS where it directly serves retention;
+5. authentication, learner-data integrity, accessibility, security and release reliability required to operate the learning product.
+
+Everything else must justify itself against one of these five areas. Existing code is not sufficient justification.
+
+## Explicitly closed / non-core scope
+
+The following are **not active product directions and must not create maintenance obligations or roadmap work** unless the owner explicitly reactivates them:
+
+- XP optimization, live XP effects and XP milestone systems;
+- streak celebrations, streak milestone overlays and streak-focused engagement work;
+- leagues, leaderboards, social competition and competitive ranking;
+- badges, achievement collections, confetti and decorative reward systems;
+- mandatory Job/Career lesson overlays or a separate career-English track;
+- feature work whose main purpose is engagement, retention mechanics or visual novelty rather than language learning;
+- speculative AI tutors/coaches, community/social systems or parallel learning modes not required by a validated learning outcome.
+
+Legacy database fields, migrations or code for these areas may remain temporarily when deletion would create unnecessary migration or compatibility risk. They are **frozen compatibility surface**, not active scope: do not extend them, redesign them or use their existence as a reason to create work. Remove them opportunistically when doing so is safe and reduces complexity.
 
 ## Direction lock
 
@@ -37,7 +63,7 @@ Do not create:
 - replacement product identities;
 - exploratory branches/issues whose purpose is to invent another direction.
 
-A task is valid only when it directly advances the single active direction above or fixes a concrete security, privacy, data-integrity, release or correctness blocker that prevents it.
+A task is valid only when it directly advances the minimum active product surface above or fixes a concrete security, privacy, data-integrity, release or correctness blocker that prevents it.
 
 If a proposed task does not clearly satisfy that rule, stop. Do not reinterpret ambiguity as permission to invent a new direction.
 
@@ -76,11 +102,12 @@ Do not silently re-enable the old GitHub Actions Vercel deployment experiment. T
 - The single active direction in this file is the only product-direction authority.
 - No historical roadmap/spec/agent backlog in Git history automatically becomes active work.
 - `main` code/migrations/tests are implementation truth; verified production facts are production truth.
-- New work requires an explicit current task and must remain inside the single active direction.
+- New work requires an explicit current task and must remain inside the minimum active product surface.
 - Security/privacy/data-integrity/release blockers may interrupt execution but may not redefine product direction.
+- Closed/non-core surfaces must default to deletion, freezing or non-extension rather than refinement.
 
 ## Active work
 
-There is no inherited product roadmap or parallel workstream. Work selection must stay inside the single active direction above.
+There is no inherited product roadmap or parallel workstream. Work selection must stay inside the single active direction and minimum active product surface above.
 
 When no explicit bounded task exists inside that direction, stop rather than manufacture one.

--- a/src/components/learn/sections/WarmupSection.tsx
+++ b/src/components/learn/sections/WarmupSection.tsx
@@ -64,37 +64,6 @@ export default function WarmupSection({
         />
       )}
 
-      {unit.jobScenarios && unit.jobScenarios.length > 0 && (
-        <div className="mb-8">
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-lg">💼</span>
-            <p className="text-sm font-bold text-primary">Job / Career Focus — Ứng dụng thực tế công việc</p>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {unit.jobScenarios.map((js, idx) => (
-              <div
-                key={idx}
-                className="rounded-2xl border border-border/60 bg-card p-4 shadow-md hover:border-primary/40 transition-colors"
-              >
-                <div className="font-bold text-foreground text-sm mb-1">{js.title}</div>
-                <div className="text-xs text-muted-foreground mb-1">🎯 {js.focus}</div>
-                <div className="text-xs text-muted-foreground/80 mb-2">{js.context}</div>
-                {js.l1Note && (
-                  <div className="mt-2 rounded-xl bg-amber-950/30 border border-amber-900/50 p-2 text-[11px] text-amber-300">
-                    {js.l1Note}
-                  </div>
-                )}
-                {js.example && (
-                  <div className="mt-2 text-[11px] font-mono bg-black/30 rounded-lg px-2 py-1 text-emerald-300/90">
-                    {js.example}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       <div className="grid grid-cols-2 gap-4 mb-8">
         {unit.warmupGreetings.map((g, i) => (
           <motion.button
@@ -175,8 +144,9 @@ export default function WarmupSection({
         {Object.keys(warmupRated).length === Math.min(5, unit.vocab.length) && (
           <p className="text-xs text-muted-foreground mt-3 text-center italic">
             {Object.values(warmupRated).filter((v) => v === "known").length >= 3
-              ? "🎉 Bạn đã biết nhiều rồi — bài học này giúp bạn dùng thành thạo hơn!"
-              : "💪 Bình thường thôi! Sau bài học bạn sẽ nhớ hết."}
+              ? "Bạn đã biết nhiều rồi — bài học này giúp bạn dùng thành thạo hơn."
+              : "Tiếp tục học và kiểm tra lại ở phần thực hành."
+            }
           </p>
         )}
       </div>
@@ -257,7 +227,7 @@ export default function WarmupSection({
               }}
               className="mt-3 w-full bg-primary/10 hover:bg-primary/20 text-primary font-bold rounded-xl py-2 text-sm transition-colors border border-primary/30"
             >
-              ✅ Đã ôn xong ({warmupCards.length} thẻ)
+              Đã ôn xong ({warmupCards.length} thẻ)
             </button>
           )}
         </div>
@@ -266,8 +236,8 @@ export default function WarmupSection({
       {unit.culturalNote && (
         <div className="border-l-4 border-primary bg-muted/30 rounded-r-2xl p-5 mb-8">
           <div className="flex items-center gap-2 mb-2">
-            <span className="text-lg">🇻🇳</span>
-            <p className="text-sm font-bold text-primary">Ghi chú văn hóa</p>
+            <span className="text-lg">🌐</span>
+            <p className="text-sm font-bold text-primary">Ghi chú sử dụng ngôn ngữ</p>
           </div>
           <p
             className="text-muted-foreground text-sm leading-relaxed"

--- a/src/lib/lessons/content-standard.ts
+++ b/src/lib/lessons/content-standard.ts
@@ -7,10 +7,12 @@ import {
 /**
  * Chuẩn nội dung bài học hiện tại.
  *
- * Các ngưỡng số lượng bên dưới là legacy content-health checks; chúng KHÔNG tự chứng minh
- * một bài học đạt CEFR. CEFR alignment được khóa riêng bằng action contract truy vết về
- * Council of Europe và chỉ được mở rộng sang unit khác khi nội dung unit đó thực sự được
- * đối chiếu, không sinh descriptor hàng loạt bằng suy đoán.
+ * Các ngưỡng số lượng bên dưới chỉ là legacy content-health checks còn cần thiết để
+ * tránh bài học rỗng. Chúng KHÔNG tự chứng minh một bài học đạt CEFR.
+ *
+ * Chỉ giữ các gate trực tiếp phục vụ học ngôn ngữ. Các product-focus cũ như
+ * Job/Career, gamification hay engagement mechanics không được biến thành chuẩn
+ * bắt buộc của curriculum.
  */
 export const LESSON_CONTENT_STANDARD = {
   situationMinChars: 30,
@@ -18,9 +20,6 @@ export const LESSON_CONTENT_STANDARD = {
   learningOutcomesMax: 5,
   culturalNoteMinChars: 40,
   warmupGreetingsMin: 3,
-
-  vocabMin: 8,
-  vocabMax: 20,
 
   l1MinRatioByLevel: {
     A0: 0.5,
@@ -32,9 +31,7 @@ export const LESSON_CONTENT_STANDARD = {
 
   l1NoteMinChars: 15,
   fluencyDrillItemsMin: 5,
-  shadowingMin: 5,
   dialoguesMin: 2,
-  jobScenariosMin: 1,
   cumulativeReviewMin: 3,
   practiceTranslateMin: 3,
   listenAndChooseMin: 5,
@@ -60,7 +57,6 @@ export interface UnitLike {
   practiceTranslate?: unknown[];
   listenAndChoose?: unknown[];
   quiz?: unknown[];
-  jobScenarios?: unknown[];
 }
 
 export function l1CoverageRatio(unit: UnitLike): number {
@@ -125,11 +121,6 @@ export function validateLessonContentStandard(
   const dialoguesLen = unit.dialogues?.length ?? 0;
   if (dialoguesLen < s.dialoguesMin) {
     tag("dialogues", `dialogues phải ≥ ${s.dialoguesMin}`);
-  }
-
-  const jobLen = unit.jobScenarios?.length ?? 0;
-  if (jobLen < s.jobScenariosMin) {
-    tag("jobScenarios", `jobScenarios phải ≥ ${s.jobScenariosMin}`);
   }
 
   const minL1 = s.l1MinRatioByLevel[unit.level] ?? 0.5;


### PR DESCRIPTION
## What this removes from active scope
- mandatory Job/Career lesson overlays and the curriculum gate that forced every unit to carry job scenarios
- dead content-standard constants that were not actually validated
- product authority for XP/streak/league/badge/confetti/social-competition engagement work

## What remains active
- CEFR/action-oriented curriculum outcomes
- reading/listening/speaking/writing/interaction lesson delivery
- honest practice/assessment evidence
- retention/review such as SRS where it directly supports language learning
- auth, learner-data integrity, accessibility, security and release reliability

## Compatibility boundary
Legacy gamification/database fields may remain temporarily when deletion would create disproportionate migration or correctness risk, but they are frozen: no expansion, redesign or roadmap work. Safe deletion is preferred when those files are touched.

## Code cleanup in this PR
- removes the visible Job / Career Focus block from lesson warmup
- removes jobScenarios as a required lesson-content standard
- locks the reduced scope into PROJECT_STATE.md and AGENTS.md

Exact-head Verify must pass before merge.