### PR TITLE
refactor(scope): remove dashboard gamification data

### DIFF
--- a/src/app/(main)/dashboard/components/TodayMission.tsx
+++ b/src/app/(main)/dashboard/components/TodayMission.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import {
-  ArrowRight,
-  Zap,
-  BookOpen,
-  Star,
-  CheckCircle2,
-  Circle,
-} from "lucide-react";
+import { ArrowRight, BookOpen, CheckCircle2, Circle } from "lucide-react";
 
 import {
   countCompletedMissions,
@@ -21,27 +14,27 @@ interface TodayMissionProps {
 }
 
 /**
- * Unified daily mission hub — all completion flags synced from server.
+ * Focused daily learning hub. Completion comes from server-side learning evidence.
  */
 export default function TodayMission({ missions }: TodayMissionProps) {
-  const primary = missions.find((m) => m.kind === "primary");
-  const tasks = missions.filter((m) => m.kind !== "primary");
+  const primary = missions.find((mission) => mission.kind === "primary");
+  const tasks = missions.filter((mission) => mission.kind !== "primary");
   const completedCount = countCompletedMissions(missions);
   const progressPct = missions.length
     ? Math.round((completedCount / missions.length) * 100)
     : 0;
-  const allDone = completedCount === missions.length;
+  const allDone = missions.length > 0 && completedCount === missions.length;
 
   return (
     <div className="rounded-2xl border border-zinc-200/60 dark:border-zinc-800/60 bg-white/60 dark:bg-zinc-900/30 backdrop-blur-sm overflow-hidden">
       <div className="px-4 sm:px-5 pt-4 sm:pt-5 pb-3">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <span className="flex size-7 items-center justify-center rounded-lg bg-amber-500/10">
-              <Zap className="size-4 text-amber-500 fill-amber-500" />
+            <span className="flex size-7 items-center justify-center rounded-lg bg-emerald-500/10">
+              <BookOpen className="size-4 text-emerald-600 dark:text-emerald-400" />
             </span>
             <p className="text-xs font-black text-zinc-900 dark:text-zinc-50 uppercase tracking-wider">
-              Nhiệm vụ hôm nay
+              Kế hoạch học hôm nay
             </p>
           </div>
           <span className="text-xs font-bold text-zinc-500 dark:text-zinc-400">
@@ -50,7 +43,7 @@ export default function TodayMission({ missions }: TodayMissionProps) {
         </div>
         <div className="h-1.5 w-full bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
           <div
-            className="h-full bg-gradient-to-r from-amber-500 to-emerald-500 rounded-full transition-all duration-700"
+            className="h-full bg-emerald-500 rounded-full transition-all duration-500"
             style={{ width: `${progressPct}%` }}
           />
         </div>
@@ -66,7 +59,7 @@ export default function TodayMission({ missions }: TodayMissionProps) {
               href={primary.href}
               id="today-mission-primary"
               className={cn(
-                "flex items-center gap-3 p-3 rounded-xl border transition-all duration-150 group",
+                "flex items-center gap-3 p-3 rounded-xl border transition-colors duration-150 group",
                 primary.completed
                   ? "border-emerald-500/30 bg-emerald-500/5"
                   : "border-emerald-500/20 bg-emerald-500/5 hover:bg-emerald-500/10 hover:border-emerald-500/30",
@@ -74,7 +67,7 @@ export default function TodayMission({ missions }: TodayMissionProps) {
             >
               <div
                 className={cn(
-                  "size-8 rounded-full border-2 flex items-center justify-center shrink-0 transition-all",
+                  "size-8 rounded-full border-2 flex items-center justify-center shrink-0",
                   primary.completed
                     ? "border-emerald-500 bg-emerald-500"
                     : "border-emerald-400 dark:border-emerald-600",
@@ -103,22 +96,16 @@ export default function TodayMission({ missions }: TodayMissionProps) {
                   </p>
                 )}
               </div>
-              <div className="flex items-center gap-1.5 shrink-0">
-                <span className="flex items-center gap-0.5 text-[10px] font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-                  <Star className="size-2.5 fill-current" />
-                  +{primary.xp} XP
-                </span>
-                {!primary.completed && (
-                  <ArrowRight className="size-3.5 text-zinc-400 group-hover:text-emerald-500 transition-colors" />
-                )}
-              </div>
+              {!primary.completed && (
+                <ArrowRight className="size-3.5 shrink-0 text-zinc-400 group-hover:text-emerald-500 transition-colors" />
+              )}
             </Link>
           </div>
         )}
 
         <div>
           <p className="text-[10px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest mb-1.5">
-            Danh sách — tự động cập nhật từ tiến độ
+            Các bước còn lại
           </p>
           <div className="space-y-1">
             {tasks.map((mission) => (
@@ -127,12 +114,10 @@ export default function TodayMission({ missions }: TodayMissionProps) {
                 href={mission.href}
                 id={`today-mission-${mission.id}`}
                 className={cn(
-                  "flex items-center gap-3 py-2.5 px-3 rounded-xl border transition-all duration-150",
+                  "flex items-center gap-3 py-2.5 px-3 rounded-xl border transition-colors duration-150",
                   mission.completed
                     ? "border-zinc-200/40 dark:border-zinc-800/40 bg-zinc-50/50 dark:bg-zinc-900/20 opacity-80"
-                    : mission.kind === "bonus"
-                      ? "border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/8 hover:border-amber-500/30"
-                      : "border-zinc-200/50 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/40",
+                    : "border-zinc-200/50 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/40",
                 )}
               >
                 <span className="shrink-0 text-emerald-600 dark:text-emerald-400">
@@ -159,9 +144,6 @@ export default function TodayMission({ missions }: TodayMissionProps) {
                     </p>
                   )}
                 </div>
-                <span className="text-[10px] font-bold bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 px-2 py-0.5 rounded-lg border border-emerald-500/15 font-mono shrink-0">
-                  +{mission.xp} XP
-                </span>
               </Link>
             ))}
           </div>
@@ -169,7 +151,7 @@ export default function TodayMission({ missions }: TodayMissionProps) {
 
         {allDone && (
           <p className="text-center text-xs font-bold text-emerald-600 dark:text-emerald-400 pt-1">
-            Tuyệt vời! Đã hoàn thành mọi nhiệm vụ hôm nay.
+            Đã hoàn thành kế hoạch học hôm nay.
           </p>
         )}
       </div>

--- a/src/app/(main)/dashboard/components/UnitCard.tsx
+++ b/src/app/(main)/dashboard/components/UnitCard.tsx
@@ -12,7 +12,6 @@ interface UnitCardProps {
     completed: boolean;
     route: string;
     tags: string[];
-    xp: number;
   };
 }
 
@@ -21,14 +20,12 @@ export default function UnitCard({ currentUnitData }: UnitCardProps) {
 
   return (
     <div className="relative rounded-2xl border border-zinc-200/60 dark:border-zinc-800/60 bg-white/60 dark:bg-zinc-900/25 backdrop-blur-sm p-6 sm:p-8 flex flex-col justify-between overflow-hidden group hover:border-emerald-500/30 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-emerald-500/5 transition-all duration-300">
-      {/* Background decorative */}
       <div className="absolute inset-0 bg-gradient-to-tr from-emerald-500/5 via-transparent to-teal-500/5 -z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
       <div className="absolute -top-8 -right-8 opacity-[0.04] dark:opacity-[0.06] text-emerald-600 group-hover:scale-105 transition-transform duration-500">
         <BookOpen className="size-48" />
       </div>
 
       <div className="space-y-5 relative z-10">
-        {/* Header */}
         <div className="flex items-center justify-between flex-wrap gap-2">
           <span className="text-[10px] font-extrabold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800/60 px-3 py-1 rounded-full">
             Bài học đang học
@@ -38,7 +35,6 @@ export default function UnitCard({ currentUnitData }: UnitCardProps) {
           </span>
         </div>
 
-        {/* Title + description */}
         <div className="space-y-2">
           <h3 className="text-xl sm:text-2xl font-black text-zinc-900 dark:text-zinc-50 leading-tight tracking-tight group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors duration-200">
             {currentUnitData.title}
@@ -48,7 +44,6 @@ export default function UnitCard({ currentUnitData }: UnitCardProps) {
           </p>
         </div>
 
-        {/* Skill tags */}
         <div className="flex flex-wrap gap-2">
           {tags.map((tag) => (
             <span
@@ -61,45 +56,27 @@ export default function UnitCard({ currentUnitData }: UnitCardProps) {
         </div>
       </div>
 
-      {/* Progress + CTA */}
       <div className="mt-6 pt-5 border-t border-zinc-200/50 dark:border-zinc-800/50 relative z-10 space-y-5">
         <div className="space-y-1.5">
           <div className="flex justify-between items-center text-xs">
             <span className="text-zinc-500 dark:text-zinc-400 font-semibold flex items-center gap-1.5">
               <TrendingUp className="size-3.5 text-emerald-500" />
-              Tiến trình
+              Tiến trình bài học
             </span>
             <span className="text-zinc-900 dark:text-zinc-50 font-black font-mono">{currentUnitData.progress}%</span>
           </div>
           <div className="h-2.5 w-full bg-zinc-100 dark:bg-zinc-800/80 rounded-full overflow-hidden">
             <div
-              className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-teal-500 transition-all duration-700 ease-out relative overflow-hidden"
+              className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-teal-500 transition-all duration-700 ease-out"
               style={{ width: `${currentUnitData.progress}%` }}
-            >
-              <div className="absolute inset-0 bg-white/20 animate-pulse" />
-            </div>
+            />
           </div>
         </div>
 
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div className="flex flex-col gap-0.5">
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">
-              Hoàn thành để nhận <strong className="text-zinc-700 dark:text-zinc-300 font-bold">{currentUnitData.xp} XP</strong>
-            </p>
-            {/* FutureStateHint — forward-looking progress nudge */}
-            {currentUnitData.progress < 100 && (() => {
-              const next = currentUnitData.progress >= 75
-                ? "sắp hoàn thành unit này! 🎉"
-                : currentUnitData.progress >= 50
-                  ? `${Math.min(currentUnitData.progress + 25, 100)}% qua bài này sau hôm nay ✨`
-                  : `${currentUnitData.progress + 20}% sau bài học hôm nay 🚀`;
-              return (
-                <p className="text-[10px] text-emerald-600 dark:text-emerald-400 font-bold">
-                  Tiếp tục → {next}
-                </p>
-              );
-            })()}
-          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            Tiếp tục từ phần đang học và hoàn thành nhiệm vụ giao tiếp của bài.
+          </p>
           <div className="flex flex-col sm:flex-row gap-2 shrink-0 w-full sm:w-auto">
             <Link href={`${currentUnitData.route}?mini=1`} className="w-full sm:w-auto">
               <Button
@@ -112,7 +89,7 @@ export default function UnitCard({ currentUnitData }: UnitCardProps) {
             </Link>
             <Link href={currentUnitData.route} className="w-full sm:w-auto">
               <Button className="w-full sm:w-auto h-11 px-7 bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-400 hover:to-teal-400 text-white font-extrabold rounded-xl flex items-center justify-center gap-2 transition-all duration-200 shadow-lg shadow-emerald-600/20 hover:shadow-emerald-500/30 active:scale-[0.97]">
-                <span>Tiếp tục học ngay</span>
+                <span>Tiếp tục học</span>
                 <ArrowRight className="size-4" />
               </Button>
             </Link>

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -125,18 +125,28 @@ export default async function DashboardPage() {
   return (
     <DashboardClient
       userName={userName}
+      currentStreak={0}
+      bestStreak={0}
+      lastActiveDate={null}
+      totalXp={0}
       userLevel={userLevel}
       completedUnits={completedUnits}
       dueCardsCount={dueCardsCount}
       currentUnitData={currentUnitData}
+      initialXpCurrent={0}
       dailyMissions={dailyMissions}
+      dailyXpGoal={0}
       wordOfDay={wordOfDay}
       completedUnitIds={completedUnitIds}
+      streakFreezeCount={0}
+      weeklyData={[]}
+      calendarData={[]}
       allUnits={UNITS.map((unit) => ({
         id: unit.id,
         title: unit.title,
         level: unit.level,
         route: unit.route,
+        xp: unit.xp,
       }))}
       recentSpeakingSessions={recentSpeakingSessions}
     />

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next";
 import { getDueCards } from "@/app/actions/cards";
-import {
-  getUserProgress,
-  getWeeklyXpData,
-  getDailyActivity,
-  getTodayMissionFlags,
-} from "@/app/actions/stats";
+import { getUserProgress, getTodayMissionFlags } from "@/app/actions/stats";
 import { buildDailyMissions } from "@/lib/dashboard/daily-missions";
 import { alignWordOfDayTopic } from "@/lib/dashboard/word-of-day";
 import {
@@ -19,62 +14,41 @@ import DashboardClient from "./components/DashboardClient";
 
 export const metadata: Metadata = {
   title: "Dashboard | AtoEnglish",
-  description: "Xem tiến độ học, streak, XP và tiếp tục bài học tiếng Anh của bạn.",
+  description: "Tiếp tục bài học, luyện tập, ôn tập và theo dõi tiến độ tiếng Anh.",
 };
 
-// P1-1 Fix: ISR 30s — fresh enough for daily dashboard use.
-// Eliminates full SSR on every navigation (was causing 200-400ms server latency per visit).
-// For real-time streak/XP after lesson completion, UnitTemplate calls router.refresh() directly.
 export const revalidate = 30;
 
 export default async function DashboardPage() {
-  // Fetch all data in parallel — single round-trip batch
-  const [progressRes, cardsRes, unitRes, speakingRes, bulkRes, weeklyRes, activityRes] =
-    await Promise.all([
-      getUserProgress(),
-      getDueCards(),
-      getCurrentUnit(),
-      getRecentSpeakingSessions(5),
-      getAllUnitCompletionStatuses(),
-      getWeeklyXpData(),
-      getDailyActivity(),
-    ]);
+  const [progressRes, cardsRes, unitRes, speakingRes, bulkRes] = await Promise.all([
+    getUserProgress(),
+    getDueCards(),
+    getCurrentUnit(),
+    getRecentSpeakingSessions(5),
+    getAllUnitCompletionStatuses(),
+  ]);
 
-  // Extract speaking sessions for the dashboard feed (narrow practice_type string → union literal)
   const VALID_TYPES = ["shadowing", "roleplay", "journal"] as const;
-  type SpeakingPracticeType = typeof VALID_TYPES[number];
+  type SpeakingPracticeType = (typeof VALID_TYPES)[number];
   const recentSpeakingSessions = (
     speakingRes.success && speakingRes.sessions ? speakingRes.sessions : []
   )
-    .filter((s) => VALID_TYPES.includes(s.practice_type as SpeakingPracticeType))
-    .map((s) => ({
-      id: s.id,
-      practice_type: s.practice_type as SpeakingPracticeType,
-      duration: s.duration,
-      accuracy_score: s.accuracy_score,
-      scenario_id: s.scenario_id,
-      created_at: s.created_at,
+    .filter((session) => VALID_TYPES.includes(session.practice_type as SpeakingPracticeType))
+    .map((session) => ({
+      id: session.id,
+      practice_type: session.practice_type as SpeakingPracticeType,
+      duration: session.duration,
+      accuracy_score: session.accuracy_score,
+      scenario_id: session.scenario_id,
+      created_at: session.created_at,
     }));
 
   let userName = "Học viên";
-  let totalXp = 0;
-  let currentStreak = 0;
-  let bestStreak = 0;
-  let lastActiveDate: string | null = null;
   let userLevel = "A0 Learner";
-  let dailyXpGoal = 50;
-  let streakFreezeCount = 0;
-  const isGuest = !progressRes.success || !progressRes.progress;
 
   if (progressRes.success && progressRes.progress) {
-    const p = progressRes.progress;
-    userName = p.display_name || "Học viên";
-    totalXp = p.total_xp || 0;
-    currentStreak = p.streak || 0;
-    bestStreak = (p as unknown as { best_streak?: number }).best_streak ?? 0;
-    lastActiveDate = (p as unknown as { last_active_date?: string | null }).last_active_date ?? null;
-    dailyXpGoal = p.daily_xp_goal || 50;
-    streakFreezeCount = (p as unknown as { streak_freeze_count?: number }).streak_freeze_count ?? 0;
+    const progress = progressRes.progress;
+    userName = progress.display_name || "Học viên";
 
     const levelNames: Record<string, string> = {
       A0: "A0 Nền tảng",
@@ -84,7 +58,7 @@ export default async function DashboardPage() {
       B2: "B2 Upper-Intermediate",
       C1: "C1 Advanced",
     };
-    userLevel = levelNames[p.current_level] || `${p.current_level} Learner`;
+    userLevel = levelNames[progress.current_level] || `${progress.current_level} Learner`;
   }
 
   const dueCardsCount = cardsRes.success && cardsRes.cards ? cardsRes.cards.length : 0;
@@ -97,8 +71,8 @@ export default async function DashboardPage() {
     progress: 0,
     completed: false,
     route: "/learn/unit-1",
-    tags: UNITS.find(u => u.id === "unit-1")?.tags ?? [],
-    xp: UNITS.find(u => u.id === "unit-1")?.xp ?? 80,
+    tags: UNITS.find((unit) => unit.id === "unit-1")?.tags ?? [],
+    xp: UNITS.find((unit) => unit.id === "unit-1")?.xp ?? 80,
   };
 
   if (unitRes.success && unitRes.unitId) {
@@ -109,27 +83,12 @@ export default async function DashboardPage() {
     currentUnitData.progress = unitRes.progress || 0;
     currentUnitData.completed = !!unitRes.completed;
     currentUnitData.route = unitRes.route || "/learn/unit-1";
-    currentUnitData.tags = UNITS.find(u => u.id === unitRes.unitId)?.tags ?? [];
-    currentUnitData.xp = UNITS.find(u => u.id === unitRes.unitId)?.xp ?? 80;
+    currentUnitData.tags = UNITS.find((unit) => unit.id === unitRes.unitId)?.tags ?? [];
+    currentUnitData.xp = UNITS.find((unit) => unit.id === unitRes.unitId)?.xp ?? 80;
   }
 
-  // Bulk unit completion data — already fetched in parallel above
   const completedMap = bulkRes.completedMap;
-  // Derive count from the map — no extra getCompletedUnitsCount() call needed
   const completedUnits = completedMap.size;
-
-  const todayStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Ho_Chi_Minh" });
-  let todayXp = 0;
-
-  for (const unit of UNITS) {
-    const entry = completedMap.get(unit.id);
-    if (entry?.completedAt) {
-      const completedDateStr = new Date(entry.completedAt).toLocaleDateString("sv-SE", { timeZone: "Asia/Ho_Chi_Minh" });
-      if (completedDateStr === todayStr) todayXp += (entry.xpEarned || 80);
-    }
-  }
-
-  const initialXpCurrent = Math.min(todayXp, dailyXpGoal);
 
   const missionFlagsRes = await getTodayMissionFlags(currentUnitData.unitId);
   const flags = missionFlagsRes.flags;
@@ -148,52 +107,37 @@ export default async function DashboardPage() {
     speakingDoneToday: flags.speakingDoneToday,
   });
 
-  // Completed unit IDs — for the unit progress grid on dashboard
-  const completedUnitIds = UNITS
-    .filter(u => completedMap.has(u.id))
-    .map(u => u.id);
+  const completedUnitIds = UNITS.filter((unit) => completedMap.has(unit.id)).map(
+    (unit) => unit.id,
+  );
 
-  // ── Word of the Day: deterministic by VN date, from current unit vocab ──────
-  const allVocab = UNITS.flatMap(u => UNIT_VOCABULARY[u.id] ?? []);
+  const allVocab = UNITS.flatMap((unit) => UNIT_VOCABULARY[unit.id] ?? []);
   const currentUnitVocab = UNIT_VOCABULARY[currentUnitData.unitId] ?? [];
   const vocabPool = currentUnitVocab.length > 0 ? currentUnitVocab : allVocab;
-  // P3-6 Fix: Use VN timezone date so word rotates at VN midnight (not UTC midnight = 07:00 VN)
-  const vnDateStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Ho_Chi_Minh" });
+  const vnDateStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "Asia/Ho_Chi_Minh",
+  });
   const [vyear, vmonth, vday] = vnDateStr.split("-").map(Number);
   const dayIndex = vyear * 10000 + vmonth * 100 + (vday ?? 0);
-  const selectedWord = vocabPool.length > 0
-    ? vocabPool[dayIndex % vocabPool.length]
-    : null;
+  const selectedWord = vocabPool.length > 0 ? vocabPool[dayIndex % vocabPool.length] : null;
   const wordOfDay = alignWordOfDayTopic(currentUnitData.unitId, selectedWord);
-
-  const weeklyData = weeklyRes.success && weeklyRes.data ? weeklyRes.data : [];
-
-  // 49-day calendar data (last 7 weeks) from getDailyActivity
-  const calendarData = (activityRes.success && activityRes.days
-    ? activityRes.days
-    : []
-  ).slice(-49).map(d => ({ date: d.date, xp: d.xp }));
 
   return (
     <DashboardClient
       userName={userName}
-      currentStreak={currentStreak}
-      bestStreak={bestStreak}
-      lastActiveDate={lastActiveDate}
-      totalXp={totalXp}
       userLevel={userLevel}
       completedUnits={completedUnits}
       dueCardsCount={dueCardsCount}
       currentUnitData={currentUnitData}
-      initialXpCurrent={initialXpCurrent}
       dailyMissions={dailyMissions}
-      dailyXpGoal={dailyXpGoal}
       wordOfDay={wordOfDay}
       completedUnitIds={completedUnitIds}
-      streakFreezeCount={streakFreezeCount}
-      weeklyData={weeklyData}
-      calendarData={calendarData}
-      allUnits={UNITS.map(u => ({ id: u.id, title: u.title, level: u.level, route: u.route, xp: u.xp }))}
+      allUnits={UNITS.map((unit) => ({
+        id: unit.id,
+        title: unit.title,
+        level: unit.level,
+        route: unit.route,
+      }))}
       recentSpeakingSessions={recentSpeakingSessions}
     />
   );


### PR DESCRIPTION
## Cleanup
- stops fetching weekly XP activity and daily activity solely for retired gamification dashboard surfaces
- stops deriving current streak, best streak, freeze counts, daily XP goal, and today's XP for dashboard rendering
- removes XP reward messaging from the current-unit card
- removes XP rewards from the daily learning mission UI
- keeps compatibility props temporarily as zero/empty values so the focused dashboard contract can be narrowed in a later safe slice

## Preserved intentionally
- user identity and current level
- current lesson
- daily learning evidence flags
- SRS due cards
- speaking sessions
- placement/checkpoint assessment
- curriculum completion progress

Exact-head Verify must pass before merge.