### PR TITLE
refactor(scope): narrow dashboard contract

### DIFF
--- a/src/app/(main)/dashboard/components/DashboardClient.tsx
+++ b/src/app/(main)/dashboard/components/DashboardClient.tsx
@@ -20,10 +20,6 @@ import LevelProgressBar from "./LevelProgressBar";
 
 interface DashboardClientProps {
   userName: string;
-  currentStreak: number;
-  bestStreak: number;
-  lastActiveDate: string | null;
-  totalXp: number;
   userLevel: string;
   completedUnits: number;
   dueCardsCount: number;
@@ -38,9 +34,7 @@ interface DashboardClientProps {
     tags: string[];
     xp: number;
   };
-  initialXpCurrent: number;
   dailyMissions: DailyMission[];
-  dailyXpGoal: number;
   wordOfDay: {
     word: string;
     phonetic: string;
@@ -50,9 +44,6 @@ interface DashboardClientProps {
     level: "A0" | "A1" | "A2" | "B1" | "B2" | "C1";
   } | null;
   completedUnitIds: string[];
-  streakFreezeCount: number;
-  weeklyData: Array<{ day: string; label: string; xp: number; pct: number }>;
-  calendarData: Array<{ date: string; xp: number }>;
   allUnits: Array<{ id: string; title: string; level: string; route: string; xp: number }>;
   recentSpeakingSessions: Array<{
     id: string;

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -125,22 +125,13 @@ export default async function DashboardPage() {
   return (
     <DashboardClient
       userName={userName}
-      currentStreak={0}
-      bestStreak={0}
-      lastActiveDate={null}
-      totalXp={0}
       userLevel={userLevel}
       completedUnits={completedUnits}
       dueCardsCount={dueCardsCount}
       currentUnitData={currentUnitData}
-      initialXpCurrent={0}
       dailyMissions={dailyMissions}
-      dailyXpGoal={0}
       wordOfDay={wordOfDay}
       completedUnitIds={completedUnitIds}
-      streakFreezeCount={0}
-      weeklyData={[]}
-      calendarData={[]}
       allUnits={UNITS.map((unit) => ({
         id: unit.id,
         title: unit.title,


### PR DESCRIPTION
## Cleanup
- removes nine retired gamification compatibility fields from DashboardClientProps
- removes the matching dummy 0/null/[] props from dashboard/page.tsx
- keeps the focused learning dashboard behavior unchanged

This is contract cleanup only: no new product behavior and no DB changes. Exact-head Verify must pass before merge.