### PR TITLE
refactor(scope): remove daily mission gamification

### DIFF
--- a/src/__tests__/daily-missions.test.ts
+++ b/src/__tests__/daily-missions.test.ts
@@ -10,7 +10,6 @@ const baseInput = {
     title: "Unit 1: Greetings",
     progress: 40,
     route: "/learn/unit-1",
-    xp: 80,
   },
   dueCardsCount: 5,
   lessonCompletedToday: false,
@@ -20,6 +19,18 @@ const baseInput = {
 };
 
 describe("buildDailyMissions", () => {
+  it("keeps only the four learning-core missions", () => {
+    const missions = buildDailyMissions(baseInput);
+
+    expect(missions.map((mission) => mission.id)).toEqual([
+      "lesson",
+      "srs",
+      "quiz",
+      "speaking",
+    ]);
+    expect(missions.every((mission) => !("xp" in mission))).toBe(true);
+  });
+
   it("marks SRS done when no cards are due", () => {
     const missions = buildDailyMissions({ ...baseInput, dueCardsCount: 0 });
     const srs = missions.find((m) => m.id === "srs");
@@ -42,13 +53,11 @@ describe("buildDailyMissions", () => {
       lessonCompletedToday: true,
       quizDoneToday: true,
       speakingDoneToday: true,
-      challengeDoneToday: true,
     });
 
     expect(missions.find((m) => m.id === "lesson")?.completed).toBe(true);
     expect(missions.find((m) => m.id === "quiz")?.completed).toBe(true);
     expect(missions.find((m) => m.id === "speaking")?.completed).toBe(true);
-    expect(missions.find((m) => m.id === "challenge")?.completed).toBe(true);
-    expect(countCompletedMissions(missions)).toBe(5);
+    expect(countCompletedMissions(missions)).toBe(4);
   });
 });

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -98,7 +98,6 @@ export default async function DashboardPage() {
       title: currentUnitData.title,
       progress: currentUnitData.progress,
       route: currentUnitData.route,
-      xp: currentUnitData.xp,
     },
     dueCardsCount,
     lessonCompletedToday: flags.lessonCompletedOnCurrentUnit,

--- a/src/lib/dashboard/daily-missions.ts
+++ b/src/lib/dashboard/daily-missions.ts
@@ -1,9 +1,8 @@
 export type DailyMission = {
   id: string;
-  kind: "primary" | "task" | "bonus";
+  kind: "primary" | "task";
   label: string;
   detail?: string;
-  xp: number;
   href: string;
   completed: boolean;
 };
@@ -13,14 +12,12 @@ export type DailyMissionInput = {
     title: string;
     progress: number;
     route: string;
-    xp: number;
   };
   dueCardsCount: number;
   lessonCompletedToday: boolean;
   srsReviewedToday: boolean;
   quizDoneToday: boolean;
   speakingDoneToday: boolean;
-  challengeDoneToday?: boolean;
 };
 
 export function buildDailyMissions(input: DailyMissionInput): DailyMission[] {
@@ -32,7 +29,6 @@ export function buildDailyMissions(input: DailyMissionInput): DailyMission[] {
       kind: "primary",
       label: input.currentUnit.title,
       detail: `${input.currentUnit.progress}% tiến độ`,
-      xp: input.currentUnit.xp,
       href: input.currentUnit.route,
       completed: input.lessonCompletedToday,
     },
@@ -43,7 +39,6 @@ export function buildDailyMissions(input: DailyMissionInput): DailyMission[] {
         input.dueCardsCount > 0
           ? `Ôn tập ${input.dueCardsCount} thẻ SRS`
           : "Ôn tập SRS (đã xong hôm nay!)",
-      xp: 15,
       href: "/flashcards",
       completed: srsDone,
     },
@@ -53,7 +48,6 @@ export function buildDailyMissions(input: DailyMissionInput): DailyMission[] {
       label: input.quizDoneToday
         ? "Quiz từ vựng (đã xong!)"
         : "Quiz từ vựng — 5 câu",
-      xp: 15,
       href: "/quiz",
       completed: input.quizDoneToday,
     },
@@ -63,22 +57,12 @@ export function buildDailyMissions(input: DailyMissionInput): DailyMission[] {
       label: input.speakingDoneToday
         ? "Luyện nói (đã xong!)"
         : "Luyện nói — 5 phút",
-      xp: 15,
       href: "/speaking",
       completed: input.speakingDoneToday,
-    },
-    {
-      id: "challenge",
-      kind: "bonus",
-      label: "Thử thách hàng ngày — 5 câu từ vựng",
-      detail: "Hoàn thành daily challenge",
-      xp: 50,
-      href: "/challenge",
-      completed: input.challengeDoneToday ?? false,
     },
   ];
 }
 
 export function countCompletedMissions(missions: DailyMission[]): number {
-  return missions.filter((m) => m.completed).length;
+  return missions.filter((mission) => mission.completed).length;
 }


### PR DESCRIPTION
## Cleanup
- removes XP from the DailyMission data model and builder
- removes the retired bonus/challenge mission that still linked to the already-deleted /challenge route
- stops passing unit XP into daily mission construction
- leaves lesson, SRS, quiz, and speaking missions intact

No new feature behavior and no DB changes. Exact-head Verify must pass before merge.