### PR TITLE
feat(learn): ship A0 English Life Episode 1 vertical slice

### DIFF
--- a/src/components/learn/sections/SpeakingSection.tsx
+++ b/src/components/learn/sections/SpeakingSection.tsx
@@ -8,7 +8,7 @@ import LessonContinueButton from "../lesson-ui/LessonContinueButton";
 import { lessonSectionMotion } from "../lesson-ui/motion";
 import { toast } from "sonner";
 import { calcSpeechScore } from "@/lib/utils/speech";
-import { SpeechRecognitionFallback } from "@/lib/utils/speech-fallback";
+import { getNativeSpeechRecognitionConstructor } from "@/lib/utils/native-speech-recognition";
 import type { UnitData } from "../UnitTemplate";
 import { trackPilotEventPersistentlyOnce } from "@/lib/pilot/pilot-analytics-client";
 import {
@@ -116,6 +116,7 @@ export default function SpeakingSection({
   const [interactionLearnerTurns, setInteractionLearnerTurns] = useState<string[]>([]);
 
   const [isRecognizing, setIsRecognizing] = useState(false);
+  const [speechRecognitionUnavailable, setSpeechRecognitionUnavailable] = useState(false);
   const recognitionRef = useRef<SpeechRecognitionObj | null>(null);
   const speakingInteraction = getSpeakingInteraction(unit.unitId);
 
@@ -133,12 +134,9 @@ export default function SpeakingSection({
 
   const getSpeechRecognition = () => {
     if (typeof window === "undefined") return null;
-    const windowWithSpeech = window as unknown as Record<string, unknown>;
-    return (
-      windowWithSpeech.SpeechRecognition ??
-      windowWithSpeech.webkitSpeechRecognition ??
-      SpeechRecognitionFallback
-    ) as unknown as new () => SpeechRecognitionObj;
+    return getNativeSpeechRecognitionConstructor<SpeechRecognitionObj>(
+      window as unknown as Record<string, unknown>
+    );
   };
 
   const formattedL1Prompt = unit.speaking.level1Prompt.replace(
@@ -152,12 +150,18 @@ export default function SpeakingSection({
   ) => {
     const SpeechRecognitionAPI = getSpeechRecognition();
     if (!SpeechRecognitionAPI) {
+      setIsLevel1Recording(false);
+      setLevel2Recording(false);
+      setIsRecognizing(false);
+      setSpeechRecognitionUnavailable(true);
       toast.error("Trình duyệt không hỗ trợ nhận diện giọng nói");
       return;
     }
 
+    setSpeechRecognitionUnavailable(false);
+
     // Retain the expected transcript at call sites for scoring/test readability.
-    // The honest fallback no longer fabricates a transcript from it.
+    // It is never used to fabricate learner evidence.
     void expectedTranscript;
 
     const recognition = new SpeechRecognitionAPI();
@@ -231,7 +235,7 @@ export default function SpeakingSection({
         return;
       }
 
-      const taskEvaluation = evaluateSpeakingTask(unit.unitId, combinedTranscript);
+      const taskEvaluation = evaluateSpeakingTask(unit.unitId, combinedTranscript, nextTurns);
       if (!taskEvaluation) return;
 
       setLevel2TaskEvaluation(taskEvaluation);
@@ -249,6 +253,8 @@ export default function SpeakingSection({
 
       if (taskEvaluation.accomplished) {
         toast.success(`Hoàn thành hội thoại: ${taskEvaluation.metCount}/${taskEvaluation.total} tiêu chí`);
+      } else if (taskEvaluation.transfer && !taskEvaluation.transfer.accomplished) {
+        toast.info("Phần có hướng dẫn đã ổn hơn, nhưng lượt chuyển cảnh vẫn cần thử lại.");
       } else {
         toast.info(
           `Đã làm được ${taskEvaluation.metCount}/${taskEvaluation.total} tiêu chí — thử lại cuộc hội thoại.`
@@ -368,7 +374,7 @@ export default function SpeakingSection({
                 <Volume2 size={16} /> Nghe mẫu
               </button>
               <button
-                disabled={isLevel1Recording || isRecognizing}
+                disabled={isLevel1Recording || isRecognizing || speechRecognitionUnavailable}
                 onClick={() => {
                   setIsLevel1Recording(true);
                   startRecognition(formattedL1Prompt, (text) => {
@@ -396,7 +402,7 @@ export default function SpeakingSection({
                   isLevel1Recording
                     ? "bg-red-600 text-white animate-pulse"
                     : "bg-primary hover:bg-primary/90 text-primary-foreground shadow-md active:scale-95"
-                }`}
+                } ${speechRecognitionUnavailable ? "cursor-not-allowed opacity-50" : ""}`}
               >
                 {isLevel1Recording ? (
                   <>
@@ -592,6 +598,34 @@ export default function SpeakingSection({
                     <span className="text-xs text-muted-foreground">{criterion.labelVi}</span>
                   </div>
                 ))}
+
+                {level2TaskEvaluation.transfer && (
+                  <div className="mt-3 space-y-2 rounded-lg border border-violet-500/20 bg-violet-500/5 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-bold text-violet-300">Chuyển cảnh · Thử độc lập</p>
+                      <span
+                        className={`text-xs font-black ${
+                          level2TaskEvaluation.transfer.accomplished
+                            ? "text-emerald-400"
+                            : "text-amber-400"
+                        }`}
+                      >
+                        {level2TaskEvaluation.transfer.metCount}/{level2TaskEvaluation.transfer.total}
+                      </span>
+                    </div>
+                    {level2TaskEvaluation.transfer.criteria.map((criterion) => (
+                      <div key={`transfer-${criterion.id}`} className="flex items-start gap-2">
+                        {criterion.met ? (
+                          <CheckCircle size={14} className="mt-0.5 shrink-0 text-emerald-400" />
+                        ) : (
+                          <XCircle size={14} className="mt-0.5 shrink-0 text-amber-400" />
+                        )}
+                        <span className="text-xs text-muted-foreground">{criterion.labelVi}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
                 <p className="text-[11px] leading-relaxed text-muted-foreground/70">
                   Đây là phản hồi luyện tập theo nhiệm vụ giao tiếp. Lượt chuyển cảnh là transfer practice, không phải chứng nhận CEFR hay mastery.
                 </p>
@@ -657,6 +691,7 @@ export default function SpeakingSection({
 
         <div className="flex gap-3">
           <button
+            disabled={speechRecognitionUnavailable}
             onClick={
               level2Recording
                 ? () => {
@@ -670,7 +705,7 @@ export default function SpeakingSection({
               level2Recording
                 ? "bg-red-600 text-white animate-pulse"
                 : "bg-emerald-600 hover:bg-emerald-500 text-white"
-            }`}
+            } ${speechRecognitionUnavailable ? "cursor-not-allowed opacity-50" : ""}`}
           >
             {level2Recording ? <MicOff size={16} /> : <Mic size={16} />}
             {level2Recording
@@ -695,9 +730,9 @@ export default function SpeakingSection({
           )}
         </div>
 
-        {!getSpeechRecognition() && (
+        {speechRecognitionUnavailable && (
           <p className="text-yellow-400 text-xs mt-3 text-center">
-            ⚠️ Trình duyệt không hỗ trợ ghi âm. Thử Chrome hoặc Edge.
+            ⚠️ Trình duyệt này không có Web Speech API để thu bằng chứng nói. Hãy dùng Chrome hoặc Edge có hỗ trợ nhận diện giọng nói.
           </p>
         )}
         <p className="text-muted-foreground/60 text-xs mt-2 text-center">

--- a/src/components/learn/sections/SpeakingSection.tsx
+++ b/src/components/learn/sections/SpeakingSection.tsx
@@ -156,9 +156,9 @@ export default function SpeakingSection({
       return;
     }
 
-    if (SpeechRecognitionAPI === SpeechRecognitionFallback) {
-      SpeechRecognitionFallback.activeTranscript = expectedTranscript;
-    }
+    // Retain the expected transcript at call sites for scoring/test readability.
+    // The honest fallback no longer fabricates a transcript from it.
+    void expectedTranscript;
 
     const recognition = new SpeechRecognitionAPI();
     recognition.lang = "en-US";
@@ -314,6 +314,7 @@ export default function SpeakingSection({
   };
 
   const currentInteractionTurn = speakingInteraction?.turns[interactionIndex];
+  const canRevealHint = !speakingInteraction || Boolean(currentInteractionTurn?.hint);
 
   return (
     <motion.div
@@ -480,15 +481,17 @@ export default function SpeakingSection({
           <p className="text-foreground text-sm italic">&ldquo;{unit.speaking.level2Situation}&rdquo;</p>
         </div>
 
-        <div className="flex gap-2 mb-4">
-          <button
-            onClick={() => setShowHint((previous) => !previous)}
-            className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
-          >
-            <Lightbulb size={12} />
-            {showHint ? "Ẩn gợi ý" : "Xem gợi ý"}
-          </button>
-        </div>
+        {canRevealHint && (
+          <div className="flex gap-2 mb-4">
+            <button
+              onClick={() => setShowHint((previous) => !previous)}
+              className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
+              <Lightbulb size={12} />
+              {showHint ? "Ẩn gợi ý" : "Xem gợi ý"}
+            </button>
+          </div>
+        )}
 
         <AnimatePresence>
           {showHint && !speakingInteraction && (

--- a/src/components/learn/sections/SpeakingSection.tsx
+++ b/src/components/learn/sections/SpeakingSection.tsx
@@ -15,6 +15,7 @@ import {
   evaluateSpeakingTask,
   type SpeakingTaskEvaluation,
 } from "@/lib/lessons/speaking-task-evaluation";
+import { getSpeakingInteraction } from "@/lib/lessons/speaking-interactions";
 
 interface SpeechRecognitionEvent {
   results: {
@@ -53,29 +54,6 @@ interface SpeakingSectionProps {
   playTTS: (text: string) => void;
   goNext: () => void;
 }
-
-const UNIT1_INTERACTION_TURNS = [
-  {
-    alex: "Hi! I'm Alex. What's your name?",
-    promptVi: "Chào Alex và nói tên của bạn.",
-    fallback: "Hi! My name is Minh.",
-  },
-  {
-    alex: "Nice to meet you. Where are you from?",
-    promptVi: "Trả lời bạn đến từ đâu.",
-    fallback: "I'm from Vietnam.",
-  },
-  {
-    alex: "I'm from Canada. Now ask me how I am.",
-    promptVi: "Hỏi thăm Alex bằng một câu đơn giản.",
-    fallback: "How are you?",
-  },
-  {
-    alex: "I'm good, thank you! It was nice meeting you.",
-    promptVi: "Kết thúc cuộc gặp một cách lịch sự.",
-    fallback: "Nice meeting you too. Goodbye.",
-  },
-] as const;
 
 function detectMissingCodas(expected: string, actual: string): string[] {
   const missingWarnings: string[] = [];
@@ -134,11 +112,12 @@ export default function SpeakingSection({
     useState<SpeakingTaskEvaluation | null>(null);
   const [level2Done, setLevel2Done] = useState(false);
   const [showHint, setShowHint] = useState(false);
-  const [unit1InteractionIndex, setUnit1InteractionIndex] = useState(0);
-  const [unit1LearnerTurns, setUnit1LearnerTurns] = useState<string[]>([]);
+  const [interactionIndex, setInteractionIndex] = useState(0);
+  const [interactionLearnerTurns, setInteractionLearnerTurns] = useState<string[]>([]);
 
   const [isRecognizing, setIsRecognizing] = useState(false);
   const recognitionRef = useRef<SpeechRecognitionObj | null>(null);
+  const speakingInteraction = getSpeakingInteraction(unit.unitId);
 
   useEffect(() => {
     return () => {
@@ -218,32 +197,37 @@ export default function SpeakingSection({
     recognition.start();
   };
 
-  const handleUnit1InteractionRecord = () => {
+  const handleInteractionRecord = () => {
+    if (!speakingInteraction) return;
+
     const restarting = level2TaskEvaluation !== null;
-    const currentIndex = restarting ? 0 : unit1InteractionIndex;
+    const currentIndex = restarting ? 0 : interactionIndex;
 
     if (restarting) {
-      setUnit1LearnerTurns([]);
-      setUnit1InteractionIndex(0);
+      setInteractionLearnerTurns([]);
+      setInteractionIndex(0);
       setLevel2Transcript("");
       setLevel2TaskEvaluation(null);
       setLevel2Done(false);
+      setShowHint(false);
     }
 
-    const turn = UNIT1_INTERACTION_TURNS[currentIndex];
-    setLevel2Recording(true);
+    const turn = speakingInteraction.turns[currentIndex];
+    if (!turn) return;
 
+    setLevel2Recording(true);
     startRecognition(turn.fallback, (text) => {
-      const nextTurns = restarting ? [] : [...unit1LearnerTurns];
+      const nextTurns = restarting ? [] : [...interactionLearnerTurns];
       nextTurns[currentIndex] = text;
-      setUnit1LearnerTurns(nextTurns);
+      setInteractionLearnerTurns(nextTurns);
       setLevel2Recording(false);
+      setShowHint(false);
 
       const combinedTranscript = nextTurns.filter(Boolean).join(" ");
       setLevel2Transcript(combinedTranscript);
 
-      if (currentIndex < UNIT1_INTERACTION_TURNS.length - 1) {
-        setUnit1InteractionIndex(currentIndex + 1);
+      if (currentIndex < speakingInteraction.turns.length - 1) {
+        setInteractionIndex(currentIndex + 1);
         return;
       }
 
@@ -252,6 +236,17 @@ export default function SpeakingSection({
 
       setLevel2TaskEvaluation(taskEvaluation);
       setLevel2Done(taskEvaluation.accomplished);
+
+      if (unit.unitId === "unit-a0-1") {
+        const taskScore = Math.round((taskEvaluation.metCount / taskEvaluation.total) * 100);
+        trackPilotEventPersistentlyOnce("first_speaking_completed", unit.unitId, {
+          source: "lesson",
+          unitId: unit.unitId,
+          score: taskScore,
+          passed: taskEvaluation.accomplished,
+        });
+      }
+
       if (taskEvaluation.accomplished) {
         toast.success(`Hoàn thành hội thoại: ${taskEvaluation.metCount}/${taskEvaluation.total} tiêu chí`);
       } else {
@@ -263,10 +258,11 @@ export default function SpeakingSection({
   };
 
   const handleLevel2Record = () => {
-    if (unit.unitId === "unit-1") {
-      handleUnit1InteractionRecord();
+    if (speakingInteraction) {
+      handleInteractionRecord();
       return;
     }
+
     setLevel2Recording(true);
     setLevel2Transcript("");
     setLevel2Score(null);
@@ -316,6 +312,8 @@ export default function SpeakingSection({
       }
     });
   };
+
+  const currentInteractionTurn = speakingInteraction?.turns[interactionIndex];
 
   return (
     <motion.div
@@ -469,7 +467,9 @@ export default function SpeakingSection({
           <span className="px-2 py-0.5 text-xs font-bold bg-teal-600/20 text-teal-400 rounded-full">
             Cấp độ 2
           </span>
-          <p className="text-foreground font-semibold">Thực hiện nhiệm vụ giao tiếp</p>
+          <p className="text-foreground font-semibold">
+            {speakingInteraction ? speakingInteraction.title : "Thực hiện nhiệm vụ giao tiếp"}
+          </p>
           {level2Done && <CheckCircle size={16} className="text-emerald-400 ml-auto" />}
         </div>
 
@@ -491,7 +491,7 @@ export default function SpeakingSection({
         </div>
 
         <AnimatePresence>
-          {showHint && (
+          {showHint && !speakingInteraction && (
             <motion.div
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
@@ -506,29 +506,43 @@ export default function SpeakingSection({
           )}
         </AnimatePresence>
 
-        {unit.unitId === "unit-1" && (
-          <div className="space-y-3 mb-4" aria-label="Hội thoại với Alex">
-            {UNIT1_INTERACTION_TURNS.map((turn, index) => {
-              const learnerText = unit1LearnerTurns[index];
-              const isCurrent = index === unit1InteractionIndex && !level2TaskEvaluation;
-              if (index > unit1InteractionIndex && !learnerText && !level2TaskEvaluation) return null;
+        {speakingInteraction && (
+          <div className="space-y-3 mb-4" aria-label={speakingInteraction.title}>
+            {speakingInteraction.turns.map((turn, index) => {
+              const learnerText = interactionLearnerTurns[index];
+              const isCurrent = index === interactionIndex && !level2TaskEvaluation;
+              if (index > interactionIndex && !learnerText && !level2TaskEvaluation) return null;
 
               return (
-                <div key={turn.alex} className="space-y-2">
+                <div key={`${turn.speaker}-${index}-${turn.text}`} className="space-y-2">
+                  {turn.phase === "transfer" && (
+                    <div className="rounded-xl border border-violet-500/25 bg-violet-500/10 px-3 py-2">
+                      <p className="text-[10px] font-black uppercase tracking-wider text-violet-300">
+                        Chuyển cảnh · Thử độc lập
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Cùng năng lực, bối cảnh mới. Lượt này không có câu mẫu để đọc theo.
+                      </p>
+                    </div>
+                  )}
+
                   <div className="max-w-[88%] rounded-2xl rounded-tl-md bg-muted/60 border border-border/60 px-4 py-3">
                     <div className="mb-1 flex items-center justify-between gap-3">
-                      <p className="text-[10px] font-black uppercase tracking-wider text-teal-400">Alex</p>
+                      <p className="text-[10px] font-black uppercase tracking-wider text-teal-400">
+                        {turn.speaker}
+                      </p>
                       <button
                         type="button"
-                        onClick={() => playTTS(turn.alex)}
-                        aria-label={`Nghe Alex: ${turn.alex}`}
+                        onClick={() => playTTS(turn.text)}
+                        aria-label={`Nghe ${turn.speaker}: ${turn.text}`}
                         className="inline-flex items-center gap-1 text-[10px] font-bold text-muted-foreground hover:text-foreground"
                       >
-                        <Volume2 size={12} /> Nghe Alex
+                        <Volume2 size={12} /> Nghe {turn.speaker}
                       </button>
                     </div>
-                    <p className="text-sm text-foreground">{turn.alex}</p>
+                    <p className="text-sm text-foreground">{turn.text}</p>
                   </div>
+
                   {learnerText ? (
                     <div className="ml-auto max-w-[88%] rounded-2xl rounded-tr-md bg-primary/10 border border-primary/20 px-4 py-3">
                       <p className="text-[10px] font-black uppercase tracking-wider text-primary mb-1">Bạn</p>
@@ -536,7 +550,12 @@ export default function SpeakingSection({
                     </div>
                   ) : isCurrent ? (
                     <div className="ml-auto max-w-[88%] rounded-2xl rounded-tr-md border border-dashed border-primary/30 bg-primary/5 px-4 py-3">
-                      <p className="text-xs text-muted-foreground">{turn.promptVi}</p>
+                      <p className="text-xs text-muted-foreground">{turn.goalVi}</p>
+                      {showHint && turn.hint && (
+                        <p className="mt-2 border-t border-primary/10 pt-2 text-xs font-semibold text-foreground">
+                          Gợi ý: {turn.hint}
+                        </p>
+                      )}
                     </div>
                   ) : null}
                 </div>
@@ -547,25 +566,38 @@ export default function SpeakingSection({
               <div className="mt-3 space-y-2 rounded-xl border border-border/60 bg-muted/30 p-3">
                 <div className="flex items-center justify-between gap-3">
                   <p className="text-xs font-bold text-foreground">Kết quả nhiệm vụ giao tiếp</p>
-                  <span className={`text-xs font-black px-2.5 py-1 rounded-full ${level2TaskEvaluation.accomplished ? "bg-emerald-500/15 text-emerald-400" : "bg-amber-500/15 text-amber-400"}`}>
+                  <span
+                    className={`text-xs font-black px-2.5 py-1 rounded-full ${
+                      level2TaskEvaluation.accomplished
+                        ? "bg-emerald-500/15 text-emerald-400"
+                        : "bg-amber-500/15 text-amber-400"
+                    }`}
+                  >
                     {level2TaskEvaluation.metCount}/{level2TaskEvaluation.total}
                   </span>
                 </div>
                 {level2TaskEvaluation.criteria.map((criterion) => (
-                  <div key={criterion.id} className="flex items-start gap-2 rounded-lg border border-border/50 bg-background/30 px-3 py-2">
-                    {criterion.met ? <CheckCircle size={14} className="mt-0.5 shrink-0 text-emerald-400" /> : <XCircle size={14} className="mt-0.5 shrink-0 text-amber-400" />}
+                  <div
+                    key={criterion.id}
+                    className="flex items-start gap-2 rounded-lg border border-border/50 bg-background/30 px-3 py-2"
+                  >
+                    {criterion.met ? (
+                      <CheckCircle size={14} className="mt-0.5 shrink-0 text-emerald-400" />
+                    ) : (
+                      <XCircle size={14} className="mt-0.5 shrink-0 text-amber-400" />
+                    )}
                     <span className="text-xs text-muted-foreground">{criterion.labelVi}</span>
                   </div>
                 ))}
                 <p className="text-[11px] leading-relaxed text-muted-foreground/70">
-                  Đây là phản hồi luyện tập theo nhiệm vụ giao tiếp, không phải chứng nhận bạn đã đạt CEFR A1.
+                  Đây là phản hồi luyện tập theo nhiệm vụ giao tiếp. Lượt chuyển cảnh là transfer practice, không phải chứng nhận CEFR hay mastery.
                 </p>
               </div>
             )}
           </div>
         )}
 
-        {unit.unitId !== "unit-1" && level2Transcript && (
+        {!speakingInteraction && level2Transcript && (
           <div className="bg-muted/30 rounded-xl p-3 mb-3">
             <p className="text-xs text-muted-foreground mb-1">Bạn vừa nói:</p>
             <p className="text-foreground text-sm">&ldquo;{level2Transcript}&rdquo;</p>
@@ -640,15 +672,17 @@ export default function SpeakingSection({
             {level2Recording ? <MicOff size={16} /> : <Mic size={16} />}
             {level2Recording
               ? "Dừng"
-              : unit.unitId === "unit-1"
+              : speakingInteraction
                 ? level2TaskEvaluation
                   ? "Thử lại từ đầu"
-                  : `Trả lời Alex (${unit1InteractionIndex + 1}/${UNIT1_INTERACTION_TURNS.length})`
+                  : currentInteractionTurn?.phase === "transfer"
+                    ? "Thử độc lập"
+                    : `Trả lời (${interactionIndex + 1}/${speakingInteraction.turns.length})`
                 : level2Transcript
                   ? "Thử lại"
                   : "Bắt đầu nói"}
           </button>
-          {unit.unitId !== "unit-1" && level2Transcript && (
+          {!speakingInteraction && level2Transcript && (
             <button
               onClick={() => setLevel2Done(true)}
               className="px-4 py-3 rounded-xl bg-muted hover:bg-muted/80 text-foreground font-semibold text-sm transition-colors"
@@ -668,10 +702,10 @@ export default function SpeakingSection({
         </p>
       </div>
 
-      {level1Done && (level2Done || (unit.unitId !== "unit-1" && level2Transcript !== "")) && (
+      {level1Done && (level2Done || (!speakingInteraction && level2Transcript !== "")) && (
         <LessonContinueButton onClick={goNext}>Xem kết quả</LessonContinueButton>
       )}
-      {level1Done && !level2Done && (unit.unitId === "unit-1" || level2Transcript === "") && (
+      {level1Done && !level2Done && (Boolean(speakingInteraction) || level2Transcript === "") && (
         <p className="text-center text-muted-foreground text-sm">
           Thử nói ở Cấp độ 2 trước khi tiếp tục 🎤
         </p>

--- a/src/lib/lessons/speaking-interactions.test.ts
+++ b/src/lib/lessons/speaking-interactions.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from "vitest";
 import { evaluateSpeakingTask } from "@/lib/lessons/speaking-task-evaluation";
 import { getSpeakingInteraction } from "@/lib/lessons/speaking-interactions";
 
+const successfulTurns = [
+  "Hello! My name is Minh.",
+  "M I N H.",
+  "I don't understand. Can you say that again, please?",
+  "I'm from Vietnam.",
+  "Nice to meet you too.",
+  "Good morning. My name is Minh. M I N H.",
+];
+
 describe("A0 English Life speaking interaction", () => {
   it("authors a changed-context transfer turn without a language hint", () => {
     const interaction = getSpeakingInteraction("unit-a0-1");
@@ -15,26 +24,53 @@ describe("A0 English Life speaking interaction", () => {
       phase: "transfer",
     });
     expect(transferTurn).not.toHaveProperty("hint");
+    expect(interaction?.transferCriteria).toHaveLength(3);
   });
 
-  it("passes when the learner communicates every authored target", () => {
+  it("passes when the learner communicates every authored target including transfer", () => {
     const result = evaluateSpeakingTask(
       "unit-a0-1",
-      "Hello, my name is Minh. M I N H. I don't understand. Can you say that again, please? I'm from Vietnam. Nice to meet you too."
+      successfulTurns.join(" "),
+      successfulTurns
     );
 
     expect(result).toMatchObject({
       unitId: "unit-a0-1",
       accomplished: true,
       evidenceKind: "practice-task-feedback",
+      transfer: {
+        accomplished: true,
+        metCount: 3,
+        total: 3,
+      },
     });
     expect(result?.metCount).toBe(result?.total);
   });
 
-  it("does not pass when the repair strategy is missing", () => {
+  it("does not let guided evidence hide a failed transfer turn", () => {
+    const failedTransferTurns = [...successfulTurns];
+    failedTransferTurns[5] = "Banana.";
+
     const result = evaluateSpeakingTask(
       "unit-a0-1",
-      "Hello, my name is Minh. M I N H. I'm from Vietnam. Nice to meet you too."
+      failedTransferTurns.join(" "),
+      failedTransferTurns
+    );
+
+    expect(result?.criteria.every((criterion) => criterion.met)).toBe(true);
+    expect(result?.transfer?.accomplished).toBe(false);
+    expect(result?.transfer?.metCount).toBe(0);
+    expect(result?.accomplished).toBe(false);
+  });
+
+  it("does not pass when the repair strategy is missing", () => {
+    const missingRepairTurns = [...successfulTurns];
+    missingRepairTurns[2] = "I'm a driver.";
+
+    const result = evaluateSpeakingTask(
+      "unit-a0-1",
+      missingRepairTurns.join(" "),
+      missingRepairTurns
     );
 
     expect(result?.accomplished).toBe(false);

--- a/src/lib/lessons/speaking-interactions.test.ts
+++ b/src/lib/lessons/speaking-interactions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateSpeakingTask } from "@/lib/lessons/speaking-task-evaluation";
+import { getSpeakingInteraction } from "@/lib/lessons/speaking-interactions";
+
+describe("A0 English Life speaking interaction", () => {
+  it("authors a changed-context transfer turn without a language hint", () => {
+    const interaction = getSpeakingInteraction("unit-a0-1");
+
+    expect(interaction).toBeDefined();
+    expect(interaction?.title).toBe("Episode 1 · Meet Alex");
+    expect(interaction?.turns.at(-1)).toMatchObject({
+      speaker: "Receptionist",
+      phase: "transfer",
+      hint: undefined,
+    });
+  });
+
+  it("passes when the learner communicates every authored target", () => {
+    const result = evaluateSpeakingTask(
+      "unit-a0-1",
+      "Hello, my name is Minh. M I N H. I don't understand. Can you say that again, please? I'm from Vietnam. Nice to meet you too."
+    );
+
+    expect(result).toMatchObject({
+      unitId: "unit-a0-1",
+      accomplished: true,
+      evidenceKind: "practice-task-feedback",
+    });
+    expect(result?.metCount).toBe(result?.total);
+  });
+
+  it("does not pass when the repair strategy is missing", () => {
+    const result = evaluateSpeakingTask(
+      "unit-a0-1",
+      "Hello, my name is Minh. M I N H. I'm from Vietnam. Nice to meet you too."
+    );
+
+    expect(result?.accomplished).toBe(false);
+    expect(result?.criteria.find((criterion) => criterion.id === "repair")?.met).toBe(false);
+  });
+
+  it("does not invent a rubric for an unauthored unit", () => {
+    expect(evaluateSpeakingTask("unit-a0-99", "Hello")).toBeUndefined();
+  });
+});

--- a/src/lib/lessons/speaking-interactions.test.ts
+++ b/src/lib/lessons/speaking-interactions.test.ts
@@ -6,14 +6,15 @@ import { getSpeakingInteraction } from "@/lib/lessons/speaking-interactions";
 describe("A0 English Life speaking interaction", () => {
   it("authors a changed-context transfer turn without a language hint", () => {
     const interaction = getSpeakingInteraction("unit-a0-1");
+    const transferTurn = interaction?.turns.at(-1);
 
     expect(interaction).toBeDefined();
     expect(interaction?.title).toBe("Episode 1 · Meet Alex");
-    expect(interaction?.turns.at(-1)).toMatchObject({
+    expect(transferTurn).toMatchObject({
       speaker: "Receptionist",
       phase: "transfer",
-      hint: undefined,
     });
+    expect(transferTurn).not.toHaveProperty("hint");
   });
 
   it("passes when the learner communicates every authored target", () => {

--- a/src/lib/lessons/speaking-interactions.ts
+++ b/src/lib/lessons/speaking-interactions.ts
@@ -1,0 +1,204 @@
+export type SpeakingTaskCriterionId =
+  | "greeting"
+  | "identity"
+  | "spelling"
+  | "personal-info"
+  | "repair"
+  | "interaction"
+  | "closing";
+
+export interface SpeakingInteractionTurn {
+  speaker: string;
+  text: string;
+  goalVi: string;
+  /** Optional language scaffold. The learner must explicitly reveal it. */
+  hint?: string;
+  /** Deterministic transcript used only by the local SpeechRecognition fallback. */
+  fallback: string;
+  /** Transfer is practice in a changed context, not a mastery/proficiency claim. */
+  phase?: "guided" | "transfer";
+}
+
+export interface SpeakingInteractionCriterion {
+  id: SpeakingTaskCriterionId;
+  labelVi: string;
+  patterns: RegExp[];
+}
+
+export interface SpeakingInteractionConfig {
+  unitId: string;
+  title: string;
+  turns: SpeakingInteractionTurn[];
+  criteria: SpeakingInteractionCriterion[];
+}
+
+const UNIT_A0_1_INTERACTION: SpeakingInteractionConfig = {
+  unitId: "unit-a0-1",
+  title: "Episode 1 · Meet Alex",
+  turns: [
+    {
+      speaker: "Alex",
+      text: "Hi! I'm Alex. What's your name?",
+      goalVi: "Chào Alex và nói tên của bạn.",
+      hint: "Hello! My name is Minh.",
+      fallback: "Hello! My name is Minh.",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "Nice to meet you. How do you spell your name?",
+      goalVi: "Đánh vần tên của bạn bằng từng chữ cái.",
+      hint: "M-I-N-H.",
+      fallback: "M-I-N-H.",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "Sorry, what do you do?",
+      goalVi: "Giả sử bạn chưa hiểu câu hỏi. Hãy yêu cầu Alex nói lại hoặc nói chậm hơn.",
+      hint: "I don't understand. Can you say that again, please?",
+      fallback: "I don't understand. Can you say that again, please?",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "No problem. Where are you from?",
+      goalVi: "Nói bạn đến từ đâu.",
+      hint: "I'm from Vietnam.",
+      fallback: "I'm from Vietnam.",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "Thanks! Nice to meet you.",
+      goalVi: "Kết thúc cuộc gặp một cách lịch sự.",
+      hint: "Nice to meet you too.",
+      fallback: "Nice to meet you too.",
+      phase: "guided",
+    },
+    {
+      speaker: "Receptionist",
+      text: "Good morning. Can I have your name, please?",
+      goalVi: "Chuyển cảnh: không có câu mẫu. Tự chào, nói tên và đánh vần tên cho lễ tân.",
+      fallback: "Good morning. My name is Minh. M-I-N-H.",
+      phase: "transfer",
+    },
+  ],
+  criteria: [
+    {
+      id: "greeting",
+      labelVi: "Mở đầu bằng lời chào phù hợp.",
+      patterns: [/\b(hi|hello|hey|good morning|good afternoon|good evening)\b/],
+    },
+    {
+      id: "identity",
+      labelVi: "Tự giới thiệu tên.",
+      patterns: [/\bmy name is\b/, /\bi(?:'m| am)\s+(?!from\b)[a-z]+\b/],
+    },
+    {
+      id: "spelling",
+      labelVi: "Đánh vần tên bằng ít nhất ba chữ cái tách rời.",
+      patterns: [/(?:\b[a-z]\b\s*){3,}/],
+    },
+    {
+      id: "repair",
+      labelVi: "Dùng một chiến lược sửa chữa khi chưa hiểu.",
+      patterns: [
+        /\bi don'?t understand\b/,
+        /\b(?:say that again|say it again|repeat(?: that)?|speak more slowly|speak slower)\b/,
+      ],
+    },
+    {
+      id: "personal-info",
+      labelVi: "Nói bạn đến từ đâu.",
+      patterns: [/\bi(?:'m| am) from\b/],
+    },
+    {
+      id: "closing",
+      labelVi: "Kết thúc cuộc gặp lịch sự.",
+      patterns: [/\b(nice to meet you too|nice meeting you|goodbye|bye|see you|see you later)\b/],
+    },
+  ],
+};
+
+const LEGACY_UNIT_1_INTERACTION: SpeakingInteractionConfig = {
+  unitId: "unit-1",
+  title: "Meet Alex",
+  turns: [
+    {
+      speaker: "Alex",
+      text: "Hi! I'm Alex. What's your name?",
+      goalVi: "Chào Alex và nói tên của bạn.",
+      hint: "Hi! My name is Minh.",
+      fallback: "Hi! My name is Minh.",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "Nice to meet you. Where are you from?",
+      goalVi: "Trả lời bạn đến từ đâu.",
+      hint: "I'm from Vietnam.",
+      fallback: "I'm from Vietnam.",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "I'm from Canada. Now ask me how I am.",
+      goalVi: "Hỏi thăm Alex bằng một câu đơn giản.",
+      hint: "How are you?",
+      fallback: "How are you?",
+      phase: "guided",
+    },
+    {
+      speaker: "Alex",
+      text: "I'm good, thank you! It was nice meeting you.",
+      goalVi: "Kết thúc cuộc gặp một cách lịch sự.",
+      hint: "Nice meeting you too. Goodbye.",
+      fallback: "Nice meeting you too. Goodbye.",
+      phase: "guided",
+    },
+  ],
+  criteria: [
+    {
+      id: "greeting",
+      labelVi: "Mở đầu bằng lời chào phù hợp.",
+      patterns: [/\b(hi|hello|hey|good morning|good afternoon|good evening)\b/],
+    },
+    {
+      id: "identity",
+      labelVi: "Tự giới thiệu tên.",
+      patterns: [/\bmy name is\b/, /\bi(?:'m| am)\s+(?!from\b)[a-z]+\b/],
+    },
+    {
+      id: "personal-info",
+      labelVi: "Nói ít nhất một thông tin cá nhân đơn giản.",
+      patterns: [
+        /\bi(?:'m| am) from\b/,
+        /\bi (?:live|work|study) (?:in|at)\b/,
+        /\bi(?:'m| am) (?:a|an)\s+[a-z]+\b/,
+      ],
+    },
+    {
+      id: "interaction",
+      labelVi: "Hỏi người đối thoại ít nhất một câu đơn giản.",
+      patterns: [
+        /\b(where are you from|what(?:'s| is) your name|how are you|and you|how about you|what about you)\b/,
+        /\b(?:where|what|how|do|are|can)\b[^?]{0,50}\b(?:you|your)\b\??/,
+      ],
+    },
+    {
+      id: "closing",
+      labelVi: "Kết thúc cuộc gặp lịch sự.",
+      patterns: [/\b(goodbye|bye|see you|see you later|have a nice day|nice meeting you)\b/],
+    },
+  ],
+};
+
+const INTERACTIONS = new Map<string, SpeakingInteractionConfig>([
+  [UNIT_A0_1_INTERACTION.unitId, UNIT_A0_1_INTERACTION],
+  [LEGACY_UNIT_1_INTERACTION.unitId, LEGACY_UNIT_1_INTERACTION],
+]);
+
+export function getSpeakingInteraction(unitId: string): SpeakingInteractionConfig | undefined {
+  return INTERACTIONS.get(unitId);
+}

--- a/src/lib/lessons/speaking-interactions.ts
+++ b/src/lib/lessons/speaking-interactions.ts
@@ -13,7 +13,7 @@ export interface SpeakingInteractionTurn {
   goalVi: string;
   /** Optional language scaffold. The learner must explicitly reveal it. */
   hint?: string;
-  /** Deterministic transcript used only by the local SpeechRecognition fallback. */
+  /** Deterministic transcript used only by test/dev call sites; never evidence by itself. */
   fallback: string;
   /** Transfer is practice in a changed context, not a mastery/proficiency claim. */
   phase?: "guided" | "transfer";
@@ -30,6 +30,8 @@ export interface SpeakingInteractionConfig {
   title: string;
   turns: SpeakingInteractionTurn[];
   criteria: SpeakingInteractionCriterion[];
+  /** Criteria evaluated only against the authored transfer turn. */
+  transferCriteria?: SpeakingInteractionCriterion[];
 }
 
 const UNIT_A0_1_INTERACTION: SpeakingInteractionConfig = {
@@ -117,6 +119,23 @@ const UNIT_A0_1_INTERACTION: SpeakingInteractionConfig = {
       id: "closing",
       labelVi: "Kết thúc cuộc gặp lịch sự.",
       patterns: [/\b(nice to meet you too|nice meeting you|goodbye|bye|see you|see you later)\b/],
+    },
+  ],
+  transferCriteria: [
+    {
+      id: "greeting",
+      labelVi: "Ở bối cảnh mới, tự mở đầu bằng lời chào phù hợp.",
+      patterns: [/\b(hi|hello|hey|good morning|good afternoon|good evening)\b/],
+    },
+    {
+      id: "identity",
+      labelVi: "Ở bối cảnh mới, tự nói tên của bạn.",
+      patterns: [/\bmy name is\b/, /\bi(?:'m| am)\s+(?!from\b)[a-z]+\b/],
+    },
+    {
+      id: "spelling",
+      labelVi: "Ở bối cảnh mới, tự đánh vần tên bằng ít nhất ba chữ cái tách rời.",
+      patterns: [/(?:\b[a-z]\b\s*){3,}/],
     },
   ],
 };

--- a/src/lib/lessons/speaking-task-evaluation.ts
+++ b/src/lib/lessons/speaking-task-evaluation.ts
@@ -1,5 +1,6 @@
 import {
   getSpeakingInteraction,
+  type SpeakingInteractionCriterion,
   type SpeakingTaskCriterionId,
 } from "@/lib/lessons/speaking-interactions";
 
@@ -9,9 +10,17 @@ export interface SpeakingTaskCriterionResult {
   met: boolean;
 }
 
+export interface SpeakingTransferEvaluation {
+  criteria: SpeakingTaskCriterionResult[];
+  metCount: number;
+  total: number;
+  accomplished: boolean;
+}
+
 export interface SpeakingTaskEvaluation {
   unitId: string;
   criteria: SpeakingTaskCriterionResult[];
+  transfer?: SpeakingTransferEvaluation;
   metCount: number;
   total: number;
   accomplished: boolean;
@@ -27,31 +36,66 @@ const normalize = (transcript: string) =>
     .replace(/\s+/g, " ")
     .trim();
 
-/**
- * Returns task-accomplishment feedback only for units with an explicitly authored interaction contract.
- * Undefined means the unit must continue using its existing practice feedback until a rubric is authored.
- */
-export function evaluateSpeakingTask(
-  unitId: string,
+const evaluateCriteria = (
+  criteria: SpeakingInteractionCriterion[],
   transcript: string
-): SpeakingTaskEvaluation | undefined {
-  const interaction = getSpeakingInteraction(unitId);
-  if (!interaction) return undefined;
-
+): SpeakingTaskCriterionResult[] => {
   const text = normalize(transcript);
-  const criteria: SpeakingTaskCriterionResult[] = interaction.criteria.map((criterion) => ({
+  return criteria.map((criterion) => ({
     id: criterion.id,
     labelVi: criterion.labelVi,
     met: criterion.patterns.some((pattern) => pattern.test(text)),
   }));
-  const metCount = criteria.filter((criterion) => criterion.met).length;
+};
+
+/**
+ * Returns task-accomplishment feedback only for units with an explicitly authored interaction contract.
+ * Undefined means the unit must continue using its existing practice feedback until a rubric is authored.
+ *
+ * `learnerTurns` preserves per-turn evidence. When a contract authors transfer criteria,
+ * the changed-context turn must pass on its own; guided evidence cannot substitute for it.
+ */
+export function evaluateSpeakingTask(
+  unitId: string,
+  transcript: string,
+  learnerTurns?: string[]
+): SpeakingTaskEvaluation | undefined {
+  const interaction = getSpeakingInteraction(unitId);
+  if (!interaction) return undefined;
+
+  const criteria = evaluateCriteria(interaction.criteria, transcript);
+  const baseMetCount = criteria.filter((criterion) => criterion.met).length;
+
+  const transferTurnIndex = interaction.turns.findIndex((turn) => turn.phase === "transfer");
+  const transferCriteria = interaction.transferCriteria;
+
+  let transfer: SpeakingTransferEvaluation | undefined;
+  if (transferCriteria && transferTurnIndex >= 0) {
+    const transferResults = evaluateCriteria(
+      transferCriteria,
+      learnerTurns?.[transferTurnIndex] ?? ""
+    );
+    const transferMetCount = transferResults.filter((criterion) => criterion.met).length;
+    transfer = {
+      criteria: transferResults,
+      metCount: transferMetCount,
+      total: transferResults.length,
+      accomplished: transferMetCount === transferResults.length,
+    };
+  }
+
+  const metCount = baseMetCount + (transfer?.metCount ?? 0);
+  const total = criteria.length + (transfer?.total ?? 0);
+  const accomplished =
+    baseMetCount === criteria.length && (transfer ? transfer.accomplished : true);
 
   return {
     unitId,
     criteria,
+    transfer,
     metCount,
-    total: criteria.length,
-    accomplished: metCount === criteria.length,
+    total,
+    accomplished,
     evidenceKind: "practice-task-feedback",
   };
 }

--- a/src/lib/lessons/speaking-task-evaluation.ts
+++ b/src/lib/lessons/speaking-task-evaluation.ts
@@ -1,5 +1,10 @@
+import {
+  getSpeakingInteraction,
+  type SpeakingTaskCriterionId,
+} from "@/lib/lessons/speaking-interactions";
+
 export interface SpeakingTaskCriterionResult {
-  id: "greeting" | "identity" | "personal-info" | "interaction" | "closing";
+  id: SpeakingTaskCriterionId;
   labelVi: string;
   met: boolean;
 }
@@ -22,62 +27,31 @@ const normalize = (transcript: string) =>
     .replace(/\s+/g, " ")
     .trim();
 
-function evaluateUnit1(transcript: string): SpeakingTaskEvaluation {
-  const text = normalize(transcript);
-
-  const criteria: SpeakingTaskCriterionResult[] = [
-    {
-      id: "greeting",
-      labelVi: "Mở đầu bằng lời chào phù hợp.",
-      met: /\b(hi|hello|hey|good morning|good afternoon|good evening)\b/.test(text),
-    },
-    {
-      id: "identity",
-      labelVi: "Tự giới thiệu tên.",
-      met: /\bmy name is\b/.test(text) || /\bi(?:'m| am)\s+(?!from\b)[a-z]+\b/.test(text),
-    },
-    {
-      id: "personal-info",
-      labelVi: "Nói ít nhất một thông tin cá nhân đơn giản.",
-      met:
-        /\bi(?:'m| am) from\b/.test(text) ||
-        /\bi (?:live|work|study) (?:in|at)\b/.test(text) ||
-        /\bi(?:'m| am) (?:a|an)\s+[a-z]+\b/.test(text),
-    },
-    {
-      id: "interaction",
-      labelVi: "Hỏi người đối thoại ít nhất một câu đơn giản.",
-      met:
-        /\b(where are you from|what(?:'s| is) your name|how are you|and you|how about you|what about you)\b/.test(text) ||
-        /\b(?:where|what|how|do|are|can)\b[^?]{0,50}\b(?:you|your)\b\??/.test(text),
-    },
-    {
-      id: "closing",
-      labelVi: "Kết thúc cuộc gặp lịch sự.",
-      met: /\b(goodbye|bye|see you|see you later|have a nice day|nice meeting you)\b/.test(text),
-    },
-  ];
-
-  const metCount = criteria.filter((criterion) => criterion.met).length;
-
-  return {
-    unitId: "unit-1",
-    criteria,
-    metCount,
-    total: criteria.length,
-    accomplished: metCount === criteria.length,
-    evidenceKind: "practice-task-feedback",
-  };
-}
-
 /**
- * Returns task-accomplishment feedback only for units with an explicitly designed evaluator.
+ * Returns task-accomplishment feedback only for units with an explicitly authored interaction contract.
  * Undefined means the unit must continue using its existing practice feedback until a rubric is authored.
  */
 export function evaluateSpeakingTask(
   unitId: string,
   transcript: string
 ): SpeakingTaskEvaluation | undefined {
-  if (unitId === "unit-1") return evaluateUnit1(transcript);
-  return undefined;
+  const interaction = getSpeakingInteraction(unitId);
+  if (!interaction) return undefined;
+
+  const text = normalize(transcript);
+  const criteria: SpeakingTaskCriterionResult[] = interaction.criteria.map((criterion) => ({
+    id: criterion.id,
+    labelVi: criterion.labelVi,
+    met: criterion.patterns.some((pattern) => pattern.test(text)),
+  }));
+  const metCount = criteria.filter((criterion) => criterion.met).length;
+
+  return {
+    unitId,
+    criteria,
+    metCount,
+    total: criteria.length,
+    accomplished: metCount === criteria.length,
+    evidenceKind: "practice-task-feedback",
+  };
 }

--- a/src/lib/utils/native-speech-recognition.test.ts
+++ b/src/lib/utils/native-speech-recognition.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { getNativeSpeechRecognitionConstructor } from "@/lib/utils/native-speech-recognition";
+
+describe("getNativeSpeechRecognitionConstructor", () => {
+  it("returns null when the browser exposes no native speech recognition API", () => {
+    expect(getNativeSpeechRecognitionConstructor({})).toBeNull();
+    expect(getNativeSpeechRecognitionConstructor(null)).toBeNull();
+  });
+
+  it("uses SpeechRecognition when available", () => {
+    class NativeRecognition {}
+
+    expect(
+      getNativeSpeechRecognitionConstructor({ SpeechRecognition: NativeRecognition })
+    ).toBe(NativeRecognition);
+  });
+
+  it("uses webkitSpeechRecognition when that is the native browser surface", () => {
+    class WebkitRecognition {}
+
+    expect(
+      getNativeSpeechRecognitionConstructor({ webkitSpeechRecognition: WebkitRecognition })
+    ).toBe(WebkitRecognition);
+  });
+});

--- a/src/lib/utils/native-speech-recognition.ts
+++ b/src/lib/utils/native-speech-recognition.ts
@@ -1,0 +1,18 @@
+export type NativeSpeechRecognitionConstructor<T = unknown> = new () => T;
+
+/**
+ * Returns only a browser-provided Web Speech recognition constructor.
+ *
+ * Compatibility adapters must not be reported as native support because that
+ * would hide the unavailable state from the learner.
+ */
+export function getNativeSpeechRecognitionConstructor<T = unknown>(
+  windowLike: Record<string, unknown> | null | undefined
+): NativeSpeechRecognitionConstructor<T> | null {
+  if (!windowLike) return null;
+
+  const candidate = windowLike.SpeechRecognition ?? windowLike.webkitSpeechRecognition;
+  return typeof candidate === "function"
+    ? (candidate as NativeSpeechRecognitionConstructor<T>)
+    : null;
+}


### PR DESCRIPTION
## Summary

Turns the actual A0 entry unit (`unit-a0-1`) into the first bounded **English Life** speaking vertical slice without creating a second product mode or roadmap.

### What changes
- adds one authored speaking-interaction contract shared by runtime and evaluator;
- routes `unit-a0-1` through a six-turn Episode 1 interaction instead of the generic monologue path;
- keeps language hints reveal-only during guided turns;
- ends with a changed-context Receptionist turn with no language hint or reveal button;
- evaluates that transfer turn independently so guided evidence cannot hide a failed changed-context response;
- reports transfer results separately while keeping all evidence at `practice-task-feedback`;
- detects native Web Speech support honestly instead of masking the unavailable state with `SpeechRecognitionFallback`;
- adds focused regression tests for transfer evidence and native speech-support detection;
- preserves the legacy `unit-1` interaction contract for compatibility.

## Interaction
1. Meet Alex: greet + name.
2. Spell the learner's name.
3. Encounter an unfamiliar question and use a repair strategy.
4. Say where the learner is from.
5. Close politely.
6. Transfer practice: answer a receptionist in a changed context without a language hint.

## Evidence boundary
`evaluateSpeakingTask` emits only `practice-task-feedback`. The changed-context turn is independently checked practice; this PR does **not** claim CEFR mastery, proficiency, retention, validated transfer or learning efficacy.

## Independent audit corrections
A merge-readiness audit found two issues on the previous exact head `a3b870377db7f2c7ab691aeba5fc75c10a3aa172`:

1. the final transfer answer was not independently evaluated because all learner turns were scored as one combined transcript;
2. unsupported Web Speech API handling was masked by the compatibility fallback, making the explicit unavailable-browser path unreachable.

Both are corrected on the current head. The audit is recorded in PR conversation comment `5572057828`.

## Scope / non-goals
- no broad curriculum rewrite;
- no new AI provider/tutor architecture;
- no DB migration;
- no production deploy;
- no new roadmap/product identity;
- no merge without owner authorization.

## Verification
Exact PR head: `e66ee6ff1231a3883d67a634149a299863af21b9`

GitHub Verify run #889 passed on that exact head:
- lint: PASS
- TypeScript type-check: PASS
- unit tests: PASS
- content standards: PASS

Relevant regression coverage now proves:
- a bad/irrelevant Receptionist transfer turn cannot pass solely from guided evidence;
- native `SpeechRecognition` / `webkitSpeechRecognition` detection returns null when the browser exposes neither surface.

Earlier CI #883 remains historical evidence for the prior head only; merge readiness must use #889 and the exact current head above.